### PR TITLE
0.8.3 — native 3-way fused recall + BM25-correct FTS (O(1) avgdl)

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -3,18 +3,30 @@
 Divergences from upstream CozoDB `481af05` (2024-12-04). See `FORK.md` for
 provenance and licensing.
 
-## Unreleased — native 3-way fused recall (DEVELOPMENT.md Bet 1a)
+## 0.8.3 — 2026-05-31
 
-Extends the one-call `hybrid_search` so a **graph-proximity signal is fused
-in-engine** alongside the vector (HNSW) and keyword (FTS) legs — the capability
-no other embedded engine in the hybrid-recall bench offers (graphless engines
-crater at ~0.51 recall vs 0.75+ for graph-capable ones), and which previously
-required a *second* `run_script` the caller had to RRF by hand (~8× slower:
-325 ms vs 41 ms p50, because each script re-parses and opens its own
-transaction). All 169 inherited lib tests + feature suites pass;
-`cargo clippy -p mnestic -- -D warnings` is clean.
+Fourth fork release. Two agentic-memory wedge features land together and are
+**validated end-to-end** on the `mnestic-benchmarks` hybrid suite (2026-05-31,
+SQLite-backed wheel, vs SQLite/DuckDB/LanceDB/Kuzu): **native 3-way fused recall**
+(Bet 1a) and **BM25-correct FTS with O(1) `avgdl`** (Bet 1b). All 169 inherited
+lib tests + feature suites pass; `cargo clippy -p mnestic -- -D warnings` is clean.
 
-### New — typed `GraphLeg` on `HybridSearch`
+> **Heads-up — the FTS default scorer changed.** The default `::fts` score kind
+> moves from `tf_idf` to Okapi `bm25` (a behaviour change). `tf` and `tf_idf`
+> stay selectable for byte-identical upstream scoring.
+
+**Measured (2026-05-31):**
+- **BM25 + O(1) `avgdl`:** fused recall **0.75 → 0.954** (parity with DuckDB
+  0.957 / SQLite 1.0); decomposed-path p50 **927 → 175 ms** and the cold p99 tail
+  **2,900 → 258 ms**. (The tail was the per-query `avgdl` scan, *not* cold HNSW as
+  first assumed — the vector leg even got faster cold→warm, 117 → 23 ms, unchanged.)
+- **Native 3-way:** the one fused call runs vector+FTS+graph at **41.55 ms p50**
+  (recall 0.873) — **~4× faster** than the 175 ms hand-decomposed path, fusing a
+  signal (graph) no other engine here has (LanceDB native is 2-way only: recall
+  0.456). The one-call advantage reappeared exactly as predicted once the `avgdl`
+  fix removed the FTS scan that had masked it.
+
+### New — native 3-way fused recall: typed `GraphLeg` on `HybridSearch`
 - `HybridSearch::graph_legs: Vec<GraphLeg>` (new `GraphLeg` type, re-exported from
   the crate root). Each leg expands from a set of `seeds` over a stored edge
   relation up to `max_hops`, scores every reached node by its **minimum hop
@@ -50,18 +62,12 @@ transaction). All 169 inherited lib tests + feature suites pass;
   fix that matters**, not the plan cache. See the "Item 9" note in `DEVELOPMENT.md`
   for the two structural blockers a real cache must also clear (parse-time param
   inlining; no reusable-plan execute entry point).
-## Unreleased — BM25-correct FTS (DEVELOPMENT.md Bet 1b)
 
-Makes full-text scoring **Okapi BM25** — the recall lever the hybrid-retrieval
-benchmark localized the entire fused-recall gap to (FTS recall-agreement 0.72 vs
-vector 0.99 / graph 1.00). All 169 inherited lib tests + the
-integration/feature suites pass; `cargo clippy -p mnestic -- -D warnings` is clean.
+### FTS — Okapi BM25 scoring + summed disjunction + O(1) `avgdl`
 
-This is a **behavior change** (the default FTS score kind changes), so it warrants
-a **minor** version bump (→ `0.9.0`) when released; `tf` and `tf_idf` remain
-selectable for byte-identical upstream behavior.
+The recall lever the hybrid-retrieval benchmark localized the entire fused-recall
+gap to (FTS recall-agreement 0.72 vs vector 0.99 / graph 1.00).
 
-### FTS — Okapi BM25 scoring + summed disjunction
 - **New default score kind `bm25`** for `::fts`/`~rel:idx{… | score_kind: 'bm25'}`.
   Implements `idf · tf·(k1+1) / (tf + k1·(1 − b + b·|D|/avgdl))`: term-frequency
   **saturation** (`k1`, default 1.2) and **document-length normalization** (`b`,
@@ -100,10 +106,15 @@ selectable for byte-identical upstream behavior.
   (delete-equals-fresh-build, survives reopen, `avgdl` feeds the BM25 denominator).
   Well-behaved workloads (insert, delete, del-then-put update) are exact; an FTS-only
   relation with no secondary index can drift on in-place update, mirroring upstream's
-  existing posting leak there (an index rebuild resets it).
-- **Still pending:** re-running the `mnestic-benchmarks` hybrid suite to confirm the
-  FTS latency drops back to ~71 ms and the recall gain holds (target: 0.72 → parity
-  with the BM25-native SQL engines).
+  existing posting leak there (an index rebuild resets it). **Bench-confirmed:** the
+  FTS leg returned to ~71 ms and decomposed p99 fell 2,900 → 258 ms with recall held
+  at 0.954.
+
+### Python
+- `cozo-lib-python`'s `hybrid_search` now accepts a `graph_legs` list (mapped to
+  `Vec<GraphLeg>`), so the embedded `mnestic` wheel can drive the native 3-way
+  fused recall from Python. `cozo-lib-python` stays workspace-excluded (built only
+  when the wheel is built).
 
 ## 0.8.2 — 2026-05-30
 

--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -3,6 +3,45 @@
 Divergences from upstream CozoDB `481af05` (2024-12-04). See `FORK.md` for
 provenance and licensing.
 
+## Unreleased — BM25-correct FTS (DEVELOPMENT.md Bet 1b)
+
+Makes full-text scoring **Okapi BM25** — the recall lever the hybrid-retrieval
+benchmark localized the entire fused-recall gap to (FTS recall-agreement 0.72 vs
+vector 0.99 / graph 1.00). All 169 inherited lib tests + the
+integration/feature suites pass; `cargo clippy -p mnestic -- -D warnings` is clean.
+
+This is a **behavior change** (the default FTS score kind changes), so it warrants
+a **minor** version bump (→ `0.9.0`) when released; `tf` and `tf_idf` remain
+selectable for byte-identical upstream behavior.
+
+### FTS — Okapi BM25 scoring + summed disjunction
+- **New default score kind `bm25`** for `::fts`/`~rel:idx{… | score_kind: 'bm25'}`.
+  Implements `idf · tf·(k1+1) / (tf + k1·(1 − b + b·|D|/avgdl))`: term-frequency
+  **saturation** (`k1`, default 1.2) and **document-length normalization** (`b`,
+  default 0.75, range `[0,1]`), both tunable as query params. Replaces upstream's
+  raw `tf · idf`, which had neither — long documents and high raw term counts
+  dominated unfairly. Two upstream defects fixed:
+  - *No length normalization.* The per-document token length was **already stored**
+    on every posting (`vals[3]`) but **discarded** at search time; it is now read
+    (`LiteralStats::doc_len`) and used. Average document length (`avgdl`) is computed
+    by a deduplicated scan of the FTS index, cached per index alongside `N`.
+  - *Disjunction did not sum.* An `a OR b` query took the **max** of per-term scores,
+    so a document matching both terms could tie one matching a single term — forcing
+    callers into app-side per-term aggregation with wide over-fetch. Under `bm25`,
+    `OR` now **sums** per-term contributions (a document matching more query terms
+    ranks higher). `tf`/`tf_idf` keep upstream's max-combine.
+- **Backward compatible:** `score_kind: 'tf_idf'` and `'tf'` are unchanged
+  (byte-identical scoring and the original `OR`=max semantics). Only the *default*
+  moved to `bm25`.
+- Guarded by `tests/bm25.rs` (sqlite backend, stored path): OR-sum beats
+  repeated-single-term, length normalization favors the shorter doc, and `b: 0.0`
+  provably disables length normalization (proving `b` is wired through).
+- **Deferred follow-up** (noted in DEVELOPMENT.md): `avgdl` is currently a full
+  index scan with an O(#docs) dedup set; a future optimization maintains a running
+  token total in the index manifest incrementally on `put`/`del`. Also pending:
+  re-running the `mnestic-benchmarks` hybrid suite to measure the FTS
+  recall-agreement gain (target: 0.72 → parity with the BM25-native SQL engines).
+
 ## 0.8.2 — 2026-05-30
 
 Third fork release. Makes HNSW index builds **non-blocking for readers**: an

--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -3,6 +3,54 @@
 Divergences from upstream CozoDB `481af05` (2024-12-04). See `FORK.md` for
 provenance and licensing.
 
+## Unreleased — native 3-way fused recall (DEVELOPMENT.md Bet 1a)
+
+Extends the one-call `hybrid_search` so a **graph-proximity signal is fused
+in-engine** alongside the vector (HNSW) and keyword (FTS) legs — the capability
+no other embedded engine in the hybrid-recall bench offers (graphless engines
+crater at ~0.51 recall vs 0.75+ for graph-capable ones), and which previously
+required a *second* `run_script` the caller had to RRF by hand (~8× slower:
+325 ms vs 41 ms p50, because each script re-parses and opens its own
+transaction). All 169 inherited lib tests + feature suites pass;
+`cargo clippy -p mnestic -- -D warnings` is clean.
+
+### New — typed `GraphLeg` on `HybridSearch`
+- `HybridSearch::graph_legs: Vec<GraphLeg>` (new `GraphLeg` type, re-exported from
+  the crate root). Each leg expands from a set of `seeds` over a stored edge
+  relation up to `max_hops`, scores every reached node by its **minimum hop
+  distance** (closer ⇒ higher rank), and contributes that ranked list to the
+  *same* Reciprocal Rank Fusion as the vector/keyword legs — one call, one
+  transaction, no hand-written recursion.
+- Why a new type rather than the existing `extra_lists`: an `extra_lists` entry is
+  a *single* spliced rule body, which cannot express the recursive shortest-path
+  rule that bounded-hop proximity needs. `GraphLeg` generates that rule — a seed
+  relation, a hop-1 base rule, and a `min(dist)` recursive rule gated at
+  `max_hops` — for you. Supports `undirected` traversal (also follows edges in
+  reverse) and multiple seeds (unioned).
+- **Injection-safe.** Seed values are passed as query **params** (`$hg{i}_seed{j}`),
+  never string-interpolated; the label, edge relation, and column names are
+  validated as bare identifiers, and empty seeds / `max_hops == 0` are rejected.
+  The generated script remains inspectable via `hybrid_search_script`.
+- `runtime/hybrid.rs`; guarded by `tests/hybrid_graph_leg.rs` (recall a neighbour
+  the fixed legs miss, closer-outranks-farther via `min(dist)`, hop bound,
+  undirected reverse edges, multi-seed union, script-is-recursive-and-parametrised,
+  input validation). Backward compatible: an empty `graph_legs` generates the exact
+  prior script.
+
+### Added — read-path latency baseline (groundwork for Item 9)
+- `benches/read_path.rs` (criterion) times `parse_only` (parse + compile-to-AST)
+  vs `full_run` (end-to-end `run_script`) for a point read and a multi-rule
+  retrieval query on SQLite, to size the parse/compile fraction a compiled-plan
+  cache could eliminate before any cache is built (the fork's baseline-first
+  rule). **Finding:** parse/compile is a roughly *fixed* ~20–85 µs cost — ≈39% of
+  a 55.7 µs point read but only ≈1.1% of a 7.68 ms multi-rule retrieval query — so
+  a plan cache helps cheap point reads but is noise for the retrieval workload,
+  where execution (and, on RocksDB, the pessimistic txn) dominates. That makes
+  **Bet 1a (one fused call instead of three `run_script`s) the read-path latency
+  fix that matters**, not the plan cache. See the "Item 9" note in `DEVELOPMENT.md`
+  for the two structural blockers a real cache must also clear (parse-time param
+  inlining; no reusable-plan execute entry point).
+
 ## 0.8.2 — 2026-05-30
 
 Third fork release. Makes HNSW index builds **non-blocking for readers**: an

--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -70,8 +70,8 @@ selectable for byte-identical upstream behavior.
   dominated unfairly. Two upstream defects fixed:
   - *No length normalization.* The per-document token length was **already stored**
     on every posting (`vals[3]`) but **discarded** at search time; it is now read
-    (`LiteralStats::doc_len`) and used. Average document length (`avgdl`) is computed
-    by a deduplicated scan of the FTS index, cached per index alongside `N`.
+    (`LiteralStats::doc_len`) and used. Average document length (`avgdl`) is an
+    **O(1) read** of a durable per-index doc-stats counter (see below).
   - *Disjunction did not sum.* An `a OR b` query took the **max** of per-term scores,
     so a document matching both terms could tie one matching a single term — forcing
     callers into app-side per-term aggregation with wide over-fetch. Under `bm25`,
@@ -83,11 +83,27 @@ selectable for byte-identical upstream behavior.
 - Guarded by `tests/bm25.rs` (sqlite backend, stored path): OR-sum beats
   repeated-single-term, length normalization favors the shorter doc, and `b: 0.0`
   provably disables length normalization (proving `b` is wired through).
-- **Deferred follow-up** (noted in DEVELOPMENT.md): `avgdl` is currently a full
-  index scan with an O(#docs) dedup set; a future optimization maintains a running
-  token total in the index manifest incrementally on `put`/`del`. Also pending:
-  re-running the `mnestic-benchmarks` hybrid suite to measure the FTS
-  recall-agreement gain (target: 0.72 → parity with the BM25-native SQL engines).
+- **`avgdl` is now O(1) (durable doc-stats counter).** The bench validated BM25's
+  recall (0.75 → 0.96) but exposed a **~10× FTS latency regression** (71 → 755 ms
+  p50): the initial `avgdl` was a full deduplicated index scan (O(#docs),
+  ~680 ms/query at 40k chunks) recomputed on *every* query, because the cache lived
+  on the per-operator `FtsCache`. Fixed: each FTS index maintains a durable
+  `(total_tokens, n_docs)` counter at a reserved `[Bot]` key (sorts above all
+  `[term, …doc_key]` postings, so it is invisible to term scans). `put_fts_index_item`
+  adds a document's tokens, `del_fts_index_item` subtracts them (guarded by a posting
+  existence probe), and `create_fts_index` publishes the authoritative count via one
+  final scan — so `avgdl` is a single keyed `get`. A legacy index that predates the
+  counter migrates itself on its first write (seed-by-scan) and, until then, reads
+  fall back to a `Db`-scoped cross-query cache (one scan per process, not per query —
+  correct because an un-migrated index is immutable). Identical scores to the prior
+  scan (the counter value equals the scan); guarded by `tests/fts_avgdl.rs`
+  (delete-equals-fresh-build, survives reopen, `avgdl` feeds the BM25 denominator).
+  Well-behaved workloads (insert, delete, del-then-put update) are exact; an FTS-only
+  relation with no secondary index can drift on in-place update, mirroring upstream's
+  existing posting leak there (an index rebuild resets it).
+- **Still pending:** re-running the `mnestic-benchmarks` hybrid suite to confirm the
+  FTS latency drops back to ~71 ms and the recall gain holds (target: 0.72 → parity
+  with the BM25-native SQL engines).
 
 ## 0.8.2 — 2026-05-30
 

--- a/cozo-core/Cargo.toml
+++ b/cozo-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mnestic"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 description = "A transactional relational-graph-vector database using Datalog — a maintained fork of CozoDB, tuned as a substrate for agentic memory"
 authors = ["Shan Rizvi", "Ziyang Hu (original CozoDB author)"]

--- a/cozo-core/Cargo.toml
+++ b/cozo-core/Cargo.toml
@@ -161,3 +161,7 @@ criterion = { version = "0.5", features = ["html_reports"] }
 [[bench]]
 name = "point_lookup"
 harness = false
+
+[[bench]]
+name = "read_path"
+harness = false

--- a/cozo-core/benches/read_path.rs
+++ b/cozo-core/benches/read_path.rs
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026, Shan Rizvi (mnestic fork).
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Read-path latency baseline for DEVELOPMENT.md **Item 9** (compiled-plan cache
+//! + read-only snapshot path). Grounds *where* a read query's per-call cost goes
+//! before any caching work — per the fork's "baseline-first" rule.
+//!
+//! For each query shape it times two things on the SQLite backend:
+//!   - `parse_only`: `parse::parse_script(...)` alone — parse + compile-to-AST.
+//!     This is the work a compiled-plan cache would eliminate on a cache hit.
+//!   - `full_run`:   `run_script(...)` end-to-end — parse + compile + open the
+//!     (pessimistic) transaction + execute.
+//!
+//! `full_run − parse_only` ≈ transaction-open + execution. The split tells us
+//! how much a plan cache could save (the `parse_only` fraction) versus what only
+//! a read-snapshot execution path can touch (the remainder). Run:
+//!   cargo bench -p mnestic --bench read_path
+//!
+//! Caveat (the reason this is a *baseline*, not a fix): the public API offers no
+//! way to execute a pre-compiled plan twice — `CozoScript` is not `Clone` and
+//! `run_script_ast` consumes it — and parameters are inlined as constants at
+//! parse time (`parse/expr.rs`), so a real plan cache additionally needs
+//! late-bound params. This bench measures the *ceiling* such work could reach.
+
+use std::collections::BTreeMap;
+
+use cozo::data::functions::current_validity;
+use cozo::{parse::parse_script, DataValue, DbInstance, ScriptMutability};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+const N: usize = 5000;
+
+fn make_db() -> (tempfile::TempDir, DbInstance) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = DbInstance::new(
+        "sqlite",
+        dir.path().join("read_path.db").to_str().unwrap(),
+        Default::default(),
+    )
+    .unwrap();
+    db.run_script(
+        ":create docs { id: String => n: Int, text: String }",
+        BTreeMap::new(),
+        ScriptMutability::Mutable,
+    )
+    .unwrap();
+    let mut i = 0;
+    while i < N {
+        let end = (i + 500).min(N);
+        let rows: Vec<String> = (i..end)
+            .map(|k| format!(r#"["k{k}",{k},"doc number {k} alpha beta"]"#))
+            .collect();
+        let script = format!(
+            "?[id, n, text] <- [{}] :put docs {{ id => n, text }}",
+            rows.join(",")
+        );
+        db.run_script(&script, BTreeMap::new(), ScriptMutability::Mutable)
+            .unwrap();
+        i = end;
+    }
+    (dir, db)
+}
+
+fn bench_read_path(c: &mut Criterion) {
+    let (_dir, db) = make_db();
+    let fixed_rules = db.get_fixed_rules();
+
+    let mut params = BTreeMap::new();
+    params.insert("u".to_string(), DataValue::Str(format!("k{}", N / 2).into()));
+    params.insert("t".to_string(), DataValue::from(100i64));
+
+    // Two shapes: a single-rule point read, and a multi-rule "retrieval-like"
+    // query (filter → derived rule → order/limit) closer to the agent read path.
+    let queries = [
+        ("point", "?[id, n] := id = $u, *docs{ id, n }"),
+        (
+            "retrieval",
+            "cand[id, n] := *docs{ id, n }, n > $t \
+             top[id, n] := cand[id, n] \
+             ?[id, n] := top[id, n] :order -n :limit 10",
+        ),
+    ];
+
+    let mut group = c.benchmark_group("read_path");
+    for (name, query) in queries {
+        group.bench_with_input(
+            BenchmarkId::new("parse_only", name),
+            &query,
+            |b, q| {
+                b.iter(|| {
+                    let ast = parse_script(q, &params, &fixed_rules, current_validity()).unwrap();
+                    criterion::black_box(&ast);
+                })
+            },
+        );
+        group.bench_with_input(BenchmarkId::new("full_run", name), &query, |b, q| {
+            b.iter(|| {
+                let res = db
+                    .run_script(q, params.clone(), ScriptMutability::Immutable)
+                    .unwrap();
+                criterion::black_box(res.rows.len());
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_read_path);
+criterion_main!(benches);

--- a/cozo-core/src/data/program.rs
+++ b/cozo-core/src/data/program.rs
@@ -992,7 +992,12 @@ pub(crate) struct HnswSearch {
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub(crate) enum FtsScoreKind {
+    /// Okapi BM25 (mnestic fork default): `tf` saturation via `k1` + document-length
+    /// normalization via `b`, and `OR` sums per-term contributions. See `fts/indexing.rs`.
+    Bm25,
+    /// Upstream `tf * idf` (no length normalization; `OR` takes max). Kept for compatibility.
     TfIdf,
+    /// Raw term frequency (× booster).
     Tf,
 }
 
@@ -1003,8 +1008,10 @@ pub(crate) struct FtsSearch {
     pub(crate) manifest: FtsIndexManifest,
     pub(crate) bindings: Vec<Symbol>,
     pub(crate) k: usize,
-    // pub(crate) k1: f64,
-    // pub(crate) b: f64,
+    /// BM25 term-frequency saturation parameter (only used when `score_kind == Bm25`).
+    pub(crate) k1: f64,
+    /// BM25 document-length normalization parameter, 0..=1 (only used when `score_kind == Bm25`).
+    pub(crate) b: f64,
     pub(crate) query: Symbol,
     pub(crate) score_kind: FtsScoreKind,
     pub(crate) bind_score: Option<Symbol>,
@@ -1289,12 +1296,33 @@ impl SearchInput {
                     .ok_or_else(|| miette!("Score kind for FTS must be a string"))?;
 
                 match r {
+                    "bm25" => FtsScoreKind::Bm25,
                     "tf_idf" => FtsScoreKind::TfIdf,
                     "tf" => FtsScoreKind::Tf,
                     s => bail!("Unknown score kind for FTS: {}", s),
                 }
             }
-            None => FtsScoreKind::TfIdf,
+            None => FtsScoreKind::Bm25,
+        };
+
+        // BM25 parameters (standard defaults k1=1.2, b=0.75); ignored for tf/tf_idf.
+        let k1 = match self.parameters.remove("k1") {
+            None => 1.2,
+            Some(expr) => expr
+                .eval_to_const()?
+                .get_float()
+                .ok_or_else(|| miette!("`k1` for FTS must be a number"))?,
+        };
+        let b = match self.parameters.remove("b") {
+            None => 0.75,
+            Some(expr) => {
+                let b = expr
+                    .eval_to_const()?
+                    .get_float()
+                    .ok_or_else(|| miette!("`b` for FTS must be a number"))?;
+                ensure!((0.0..=1.0).contains(&b), "`b` for FTS must be in [0, 1], got {b}");
+                b
+            }
         };
 
         let filter = self.parameters.remove("filter");
@@ -1326,12 +1354,12 @@ impl SearchInput {
             manifest,
             bindings,
             k: k as usize,
+            k1,
+            b,
             query,
             score_kind,
             bind_score,
             // lax_mode,
-            // k1,
-            // b,
             filter,
             span: self.span,
         }));

--- a/cozo-core/src/fts/indexing.rs
+++ b/cozo-core/src/fts/indexing.rs
@@ -29,7 +29,6 @@ use thiserror::Error;
 #[derive(Default)]
 pub(crate) struct FtsCache {
     total_n_cache: FxHashMap<SmartString<LazyCompact>, usize>,
-    avgdl_cache: FxHashMap<SmartString<LazyCompact>, f64>,
 }
 
 impl FtsCache {
@@ -46,38 +45,33 @@ impl FtsCache {
         })
     }
     /// Average document length (in tokens) over the indexed corpus — the BM25
-    /// length-normalization denominator. Computed once per index by a deduplicated
-    /// scan of the FTS index relation (each document's length is stored redundantly
-    /// on every posting, so we count each document key once) and cached for the
-    /// lifetime of this cache, like `N`.
+    /// length-normalization denominator (mnestic fork, DEVELOPMENT.md Bet 1b).
     ///
-    /// NOTE (deferred, see DEVELOPMENT.md Bet 1b): this is a full index scan with an
-    /// O(#docs) dedup set. A future optimization maintains a running token total in
-    /// the index manifest incrementally (on `put`/`del`) to avoid the scan entirely.
+    /// **O(1)** when the index carries the durable doc-stats counter (every index
+    /// built or written under this code): a single keyed `get`. For a *legacy*
+    /// index that predates the counter and has not been written since (its corpus
+    /// is therefore immutable), it falls back to one deduplicated full scan,
+    /// cached on the `Db` so it is paid once per process rather than per query.
     fn get_avgdl_for_index(&mut self, idx: &RelationHandle, tx: &SessionTx<'_>) -> Result<f64> {
-        if let Some(v) = self.avgdl_cache.get(&idx.name) {
-            return Ok(*v);
+        let avgdl = |total: u64, n: u64| if n > 0 { total as f64 / n as f64 } else { 0.0 };
+        if let Some((total, n)) = tx.read_fts_doc_stats(idx)? {
+            return Ok(avgdl(total, n));
         }
-        let start = idx.encode_partial_key_for_store(&[]);
-        let end = idx.encode_partial_key_for_store(&[DataValue::Bot]);
-        let mut seen: FxHashSet<Tuple> = FxHashSet::default();
-        let mut total_len: u64 = 0;
-        for item in tx.store_tx.range_scan(&start, &end) {
-            let (kvec, vvec) = item?;
-            let key_tuple = decode_tuple_from_key(&kvec, idx.metadata.keys.len());
-            // key[0] is the term; key[1..] is the document key. Count each doc once.
-            if seen.insert(key_tuple[1..].to_vec()) {
-                let vals: Vec<DataValue> = rmp_serde::from_slice(&vvec[ENCODED_KEY_MIN_LEN..]).unwrap();
-                total_len += vals[3].get_int().unwrap() as u64;
-            }
+        if let Some((total, n)) = tx
+            .fts_doc_stats_cache
+            .lock()
+            .unwrap()
+            .get(&idx.name)
+            .copied()
+        {
+            return Ok(avgdl(total, n));
         }
-        let avgdl = if seen.is_empty() {
-            0.0
-        } else {
-            total_len as f64 / seen.len() as f64
-        };
-        self.avgdl_cache.insert(idx.name.clone(), avgdl);
-        Ok(avgdl)
+        let (total, n) = tx.scan_fts_doc_stats(idx)?;
+        tx.fts_doc_stats_cache
+            .lock()
+            .unwrap()
+            .insert(idx.name.clone(), (total, n));
+        Ok(avgdl(total, n))
     }
 }
 
@@ -96,6 +90,82 @@ struct LiteralStats {
 }
 
 impl<'a> SessionTx<'a> {
+    /// Reserved key under which an FTS index stores its durable corpus doc-stats
+    /// counter `[total_tokens, n_docs]` (mnestic fork, Bet 1b). `DataValue::Bot`
+    /// is the top key sentinel, so this sits *above* every `[term, …doc_key]`
+    /// posting — it is never returned by a term range scan nor by the full-index
+    /// doc scan (whose exclusive upper bound is exactly this key).
+    fn fts_stats_key(idx: &RelationHandle) -> Vec<u8> {
+        idx.encode_partial_key_for_store(&[DataValue::Bot])
+    }
+
+    /// Read the durable doc-stats counter, or `None` if the index predates it
+    /// (legacy / not yet migrated).
+    pub(crate) fn read_fts_doc_stats(&self, idx: &RelationHandle) -> Result<Option<(u64, u64)>> {
+        let key = Self::fts_stats_key(idx);
+        match self.store_tx.get(&key, false)? {
+            None => Ok(None),
+            Some(v) => {
+                let vals: Vec<DataValue> = rmp_serde::from_slice(&v[ENCODED_KEY_MIN_LEN..])
+                    .map_err(|e| miette!("corrupt FTS doc-stats counter: {e}"))?;
+                let total = vals.first().and_then(|d| d.get_int()).unwrap_or(0).max(0) as u64;
+                let n = vals.get(1).and_then(|d| d.get_int()).unwrap_or(0).max(0) as u64;
+                Ok(Some((total, n)))
+            }
+        }
+    }
+
+    pub(crate) fn write_fts_doc_stats(
+        &mut self,
+        idx: &RelationHandle,
+        total: u64,
+        n: u64,
+    ) -> Result<()> {
+        let key = Self::fts_stats_key(idx);
+        let val = vec![DataValue::from(total as i64), DataValue::from(n as i64)];
+        let val_bytes = idx.encode_val_only_for_store(&val, Default::default())?;
+        self.store_tx.put(&key, &val_bytes)
+    }
+
+    /// Deduplicated full scan of the FTS index → `(total_tokens, n_docs)` over
+    /// the documents that have at least one posting. Each document's length is
+    /// stored redundantly on every posting (`vals[3]`), so we count each document
+    /// key once. This is the legacy/seed path; the steady state reads the counter.
+    pub(crate) fn scan_fts_doc_stats(&self, idx: &RelationHandle) -> Result<(u64, u64)> {
+        let start = idx.encode_partial_key_for_store(&[]);
+        let end = idx.encode_partial_key_for_store(&[DataValue::Bot]);
+        let mut seen: FxHashSet<Tuple> = FxHashSet::default();
+        let mut total: u64 = 0;
+        for item in self.store_tx.range_scan(&start, &end) {
+            let (kvec, vvec) = item?;
+            let key_tuple = decode_tuple_from_key(&kvec, idx.metadata.keys.len());
+            if seen.insert(key_tuple[1..].to_vec()) {
+                let vals: Vec<DataValue> = rmp_serde::from_slice(&vvec[ENCODED_KEY_MIN_LEN..])
+                    .map_err(|e| miette!("corrupt FTS posting value: {e}"))?;
+                total += vals[3].get_int().unwrap_or(0).max(0) as u64;
+            }
+        }
+        Ok((total, seen.len() as u64))
+    }
+
+    /// Read the counter, seeding it from a one-time scan if absent — so a legacy
+    /// index migrates itself to O(1) on its first write.
+    fn ensure_fts_doc_stats(&mut self, idx: &RelationHandle) -> Result<(u64, u64)> {
+        if let Some(s) = self.read_fts_doc_stats(idx)? {
+            return Ok(s);
+        }
+        let (total, n) = self.scan_fts_doc_stats(idx)?;
+        self.write_fts_doc_stats(idx, total, n)?;
+        Ok((total, n))
+    }
+
+    /// Recompute and overwrite the durable counter from a full scan. Called at the
+    /// end of an index (re)build to publish the authoritative corpus stats.
+    pub(crate) fn rebuild_fts_doc_stats(&mut self, idx: &RelationHandle) -> Result<()> {
+        let (total, n) = self.scan_fts_doc_stats(idx)?;
+        self.write_fts_doc_stats(idx, total, n)
+    }
+
     fn fts_search_literal(
         &self,
         literal: &FtsLiteral,
@@ -410,6 +480,18 @@ impl<'a> SessionTx<'a> {
         for k in &tuple[..rel_handle.metadata.keys.len()] {
             key.push(k.clone());
         }
+        // Maintain the durable doc-stats counter (mnestic fork, Bet 1b) so `avgdl`
+        // is an O(1) read. Done *before* writing this document's postings so a
+        // seed-on-absent scan sees the pre-insert corpus and we add the new
+        // document exactly once. `count == 0` (no tokens ⇒ no postings) is skipped,
+        // matching the scan, which only counts documents that have postings.
+        // (The normal update path is del-then-put, so the old document is already
+        // subtracted; an FTS-only relation with no secondary index does not call
+        // `del` on update and can drift, mirroring upstream's posting leak there.)
+        if count > 0 {
+            let (total, n) = self.ensure_fts_doc_stats(idx_handle)?;
+            self.write_fts_doc_stats(idx_handle, total + count as u64, n + 1)?;
+        }
         let mut val = vec![
             DataValue::Bot,
             DataValue::Bot,
@@ -450,14 +532,36 @@ impl<'a> SessionTx<'a> {
         };
         let mut token_stream = tokenizer.token_stream(&to_index);
         let mut collector = FxHashSet::default();
+        let mut count = 0i64;
         while let Some(token) = token_stream.next() {
             let text = SmartString::<LazyCompact>::from(&token.text);
             collector.insert(text);
+            count += 1;
         }
         let mut key = Vec::with_capacity(1 + rel_handle.metadata.keys.len());
         key.push(DataValue::Bot);
         for k in &tuple[..rel_handle.metadata.keys.len()] {
             key.push(k.clone());
+        }
+        // Maintain the durable doc-stats counter (mnestic fork, Bet 1b) — but only
+        // if this document is actually indexed (probe one of its postings). That
+        // guards against a delete of an unindexed row and the del-then-put refresh
+        // in `create_fts_index`, where `del` runs over a not-yet-indexed row. Done
+        // before the postings are removed so a seed-on-absent scan still sees them.
+        if count > 0 {
+            if let Some(term) = collector.iter().next() {
+                let mut probe = key.clone();
+                probe[0] = DataValue::Str(term.clone());
+                let probe_bytes = idx_handle.encode_key_for_store(&probe, Default::default())?;
+                if self.store_tx.exists(&probe_bytes, false)? {
+                    let (total, n) = self.ensure_fts_doc_stats(idx_handle)?;
+                    self.write_fts_doc_stats(
+                        idx_handle,
+                        total.saturating_sub(count as u64),
+                        n.saturating_sub(1),
+                    )?;
+                }
+            }
         }
         for text in collector {
             key[0] = DataValue::Str(text);

--- a/cozo-core/src/fts/indexing.rs
+++ b/cozo-core/src/fts/indexing.rs
@@ -29,6 +29,7 @@ use thiserror::Error;
 #[derive(Default)]
 pub(crate) struct FtsCache {
     total_n_cache: FxHashMap<SmartString<LazyCompact>, usize>,
+    avgdl_cache: FxHashMap<SmartString<LazyCompact>, f64>,
 }
 
 impl FtsCache {
@@ -44,6 +45,40 @@ impl FtsCache {
             Entry::Occupied(o) => *o.get(),
         })
     }
+    /// Average document length (in tokens) over the indexed corpus — the BM25
+    /// length-normalization denominator. Computed once per index by a deduplicated
+    /// scan of the FTS index relation (each document's length is stored redundantly
+    /// on every posting, so we count each document key once) and cached for the
+    /// lifetime of this cache, like `N`.
+    ///
+    /// NOTE (deferred, see DEVELOPMENT.md Bet 1b): this is a full index scan with an
+    /// O(#docs) dedup set. A future optimization maintains a running token total in
+    /// the index manifest incrementally (on `put`/`del`) to avoid the scan entirely.
+    fn get_avgdl_for_index(&mut self, idx: &RelationHandle, tx: &SessionTx<'_>) -> Result<f64> {
+        if let Some(v) = self.avgdl_cache.get(&idx.name) {
+            return Ok(*v);
+        }
+        let start = idx.encode_partial_key_for_store(&[]);
+        let end = idx.encode_partial_key_for_store(&[DataValue::Bot]);
+        let mut seen: FxHashSet<Tuple> = FxHashSet::default();
+        let mut total_len: u64 = 0;
+        for item in tx.store_tx.range_scan(&start, &end) {
+            let (kvec, vvec) = item?;
+            let key_tuple = decode_tuple_from_key(&kvec, idx.metadata.keys.len());
+            // key[0] is the term; key[1..] is the document key. Count each doc once.
+            if seen.insert(key_tuple[1..].to_vec()) {
+                let vals: Vec<DataValue> = rmp_serde::from_slice(&vvec[ENCODED_KEY_MIN_LEN..]).unwrap();
+                total_len += vals[3].get_int().unwrap() as u64;
+            }
+        }
+        let avgdl = if seen.is_empty() {
+            0.0
+        } else {
+            total_len as f64 / seen.len() as f64
+        };
+        self.avgdl_cache.insert(idx.name.clone(), avgdl);
+        Ok(avgdl)
+    }
 }
 
 struct PositionInfo {
@@ -55,7 +90,9 @@ struct PositionInfo {
 struct LiteralStats {
     key: Tuple,
     position_info: Vec<PositionInfo>,
-    // doc_len: u32,
+    /// Total token count of the document this posting belongs to (stored per posting
+    /// at index time as `vals[3]`); used for BM25 length normalization.
+    doc_len: u32,
 }
 
 impl<'a> SessionTx<'a> {
@@ -88,7 +125,7 @@ impl<'a> SessionTx<'a> {
             let froms = vals[0].get_slice().unwrap();
             let tos = vals[1].get_slice().unwrap();
             let positions = vals[2].get_slice().unwrap();
-            // let total_length = vals[3].get_int().unwrap();
+            let total_length = vals[3].get_int().unwrap();
             let position_info = froms
                 .iter()
                 .zip(tos.iter())
@@ -102,7 +139,7 @@ impl<'a> SessionTx<'a> {
             results.push(LiteralStats {
                 key: key_tuple[1..].to_vec(),
                 position_info,
-                // doc_len: total_length as u32,
+                doc_len: total_length as u32,
             });
         }
         Ok(results)
@@ -112,6 +149,7 @@ impl<'a> SessionTx<'a> {
         ast: &FtsExpr,
         config: &FtsSearch,
         n: usize,
+        avgdl: f64,
     ) -> Result<FxHashMap<Tuple, f64>> {
         Ok(match ast {
             FtsExpr::Literal(l) => {
@@ -123,6 +161,8 @@ impl<'a> SessionTx<'a> {
                         el.position_info.len(),
                         found_docs_len,
                         n,
+                        el.doc_len,
+                        avgdl,
                         l.booster.0,
                         config,
                     );
@@ -136,9 +176,10 @@ impl<'a> SessionTx<'a> {
                     l_iter.next().unwrap(),
                     config,
                     n,
+                    avgdl,
                 )?;
                 for nxt in l_iter {
-                    let nxt_res = self.fts_search_impl(nxt, config, n)?;
+                    let nxt_res = self.fts_search_impl(nxt, config, n, avgdl)?;
                     res = res
                         .into_iter()
                         .filter_map(|(k, v)| nxt_res.get(&k).map(|nxt_v| (k, v + nxt_v)))
@@ -147,12 +188,15 @@ impl<'a> SessionTx<'a> {
                 res
             }
             FtsExpr::Or(ls) => {
+                // BM25 sums each query term's contribution (a doc matching more terms
+                // ranks higher); tf/tf_idf keep upstream's max-combine for compatibility.
+                let sum_terms = config.score_kind == FtsScoreKind::Bm25;
                 let mut res: FxHashMap<Tuple, f64> = FxHashMap::default();
                 for nxt in ls {
-                    let nxt_res = self.fts_search_impl(nxt, config, n)?;
+                    let nxt_res = self.fts_search_impl(nxt, config, n, avgdl)?;
                     for (k, v) in nxt_res {
                         if let Some(old_v) = res.get_mut(&k) {
-                            *old_v = (*old_v).max(v);
+                            *old_v = if sum_terms { *old_v + v } else { (*old_v).max(v) };
                         } else {
                             res.insert(k, v);
                         }
@@ -163,7 +207,11 @@ impl<'a> SessionTx<'a> {
             FtsExpr::Near(FtsNear { literals, distance }) => {
                 let mut l_it = literals.iter();
                 let mut coll: FxHashMap<_, _> = FxHashMap::default();
+                // The document length is identical across a doc's postings, so capture
+                // it from the first literal's scan for BM25 length normalization.
+                let mut doc_lens: FxHashMap<Tuple, u32> = FxHashMap::default();
                 for first_el in self.fts_search_literal(l_it.next().unwrap(), &config.idx_handle)? {
+                    doc_lens.insert(first_el.key.clone(), first_el.doc_len);
                     coll.insert(
                         first_el.key,
                         first_el
@@ -209,17 +257,24 @@ impl<'a> SessionTx<'a> {
                 let coll_len = coll.len();
                 coll.into_iter()
                     .map(|(k, cands)| {
-                        (
-                            k,
-                            Self::fts_compute_score(cands.len(), coll_len, n, booster, config),
-                        )
+                        let doc_len = doc_lens.get(&k).copied().unwrap_or(0);
+                        let score = Self::fts_compute_score(
+                            cands.len(),
+                            coll_len,
+                            n,
+                            doc_len,
+                            avgdl,
+                            booster,
+                            config,
+                        );
+                        (k, score)
                     })
                     .collect()
             }
             FtsExpr::Not(fst, snd) => {
-                let mut res = self.fts_search_impl(fst, config, n)?;
+                let mut res = self.fts_search_impl(fst, config, n, avgdl)?;
                 for el in self
-                    .fts_search_impl(snd, config, n)?
+                    .fts_search_impl(snd, config, n, avgdl)?
                     .keys()
                 {
                     res.remove(el);
@@ -232,6 +287,8 @@ impl<'a> SessionTx<'a> {
         tf: usize,
         n_found_docs: usize,
         n_total: usize,
+        doc_len: u32,
+        avgdl: f64,
         booster: f64,
         config: &FtsSearch,
     ) -> f64 {
@@ -242,6 +299,20 @@ impl<'a> SessionTx<'a> {
                 let n_found_docs = n_found_docs as f64;
                 let idf = (1.0 + (n_total as f64 - n_found_docs + 0.5) / (n_found_docs + 0.5)).ln();
                 tf * idf * booster
+            }
+            FtsScoreKind::Bm25 => {
+                // Okapi BM25: idf · tf·(k1+1) / (tf + k1·(1 − b + b·|D|/avgdl)) · booster
+                let df = n_found_docs as f64;
+                let idf = (1.0 + (n_total as f64 - df + 0.5) / (df + 0.5)).ln();
+                let avgdl = if avgdl > 0.0 { avgdl } else { 1.0 };
+                let norm = 1.0 - config.b + config.b * (doc_len as f64) / avgdl;
+                let denom = tf + config.k1 * norm;
+                let saturated = if denom > 0.0 {
+                    tf * (config.k1 + 1.0) / denom
+                } else {
+                    0.0
+                };
+                idf * saturated * booster
             }
         }
     }
@@ -258,13 +329,19 @@ impl<'a> SessionTx<'a> {
         if ast.is_empty() {
             return Ok(vec![]);
         }
-        let n = if config.score_kind == FtsScoreKind::TfIdf {
-            cache.get_n_for_relation(&config.base_handle, self)?
+        let n = match config.score_kind {
+            FtsScoreKind::TfIdf | FtsScoreKind::Bm25 => {
+                cache.get_n_for_relation(&config.base_handle, self)?
+            }
+            FtsScoreKind::Tf => 0,
+        };
+        let avgdl = if config.score_kind == FtsScoreKind::Bm25 {
+            cache.get_avgdl_for_index(&config.idx_handle, self)?
         } else {
-            0
+            0.0
         };
         let mut result: Vec<_> = self
-            .fts_search_impl(&ast, config, n)?
+            .fts_search_impl(&ast, config, n, avgdl)?
             .into_iter()
             .collect();
         result.sort_by_key(|(_, score)| Reverse(OrderedFloat(*score)));

--- a/cozo-core/src/lib.rs
+++ b/cozo-core/src/lib.rs
@@ -66,7 +66,7 @@ pub use data::value::{DataValue, Num, RegexWrapper, UuidWrapper, Validity, Valid
 pub use fixed_rule::{FixedRule, FixedRuleInputRelation, FixedRulePayload};
 pub use runtime::db::Db;
 pub use runtime::db::NamedRows;
-pub use runtime::hybrid::{build_hybrid_query, HybridList, HybridSearch, MmrParams};
+pub use runtime::hybrid::{build_hybrid_query, GraphLeg, HybridList, HybridSearch, MmrParams};
 pub use runtime::relation::decode_tuple_from_kv;
 pub use runtime::temp_store::RegularTempStore;
 pub use storage::mem::{new_cozo_mem, MemStorage};

--- a/cozo-core/src/runtime/db.rs
+++ b/cozo-core/src/runtime/db.rs
@@ -113,6 +113,14 @@ pub struct Db<S> {
     /// (whose publication only becomes visible at the end) without re-blocking
     /// readers. Keyed by the index relation's full `base:idx` name.
     index_builds_in_progress: Arc<Mutex<BTreeSet<SmartString<LazyCompact>>>>,
+    /// Cross-query cache of FTS corpus stats `(total_tokens, n_docs)` keyed by
+    /// index relation name (mnestic fork, DEVELOPMENT.md Bet 1b avgdl). Only
+    /// consulted for *legacy* FTS indexes that predate the durable doc-stats
+    /// counter (no aggregate stored) and have not been written since — for those
+    /// the corpus is immutable, so a single deduplicated scan per process is
+    /// correct and needs no invalidation. Indexes built/migrated under the
+    /// counter read it directly (O(1)) and never touch this cache.
+    fts_doc_stats_cache: Arc<Mutex<BTreeMap<SmartString<LazyCompact>, (u64, u64)>>>,
 }
 
 impl<S> Debug for Db<S> {
@@ -299,6 +307,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             event_callbacks: Default::default(),
             relation_locks: Default::default(),
             index_builds_in_progress: Default::default(),
+            fts_doc_stats_cache: Default::default(),
         };
         Ok(ret)
     }
@@ -915,6 +924,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             relation_store_id: self.relation_store_id.clone(),
             temp_store_id: Default::default(),
             tokenizers: self.tokenizers.clone(),
+            fts_doc_stats_cache: self.fts_doc_stats_cache.clone(),
         };
         Ok(ret)
     }
@@ -925,6 +935,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             relation_store_id: self.relation_store_id.clone(),
             temp_store_id: Default::default(),
             tokenizers: self.tokenizers.clone(),
+            fts_doc_stats_cache: self.fts_doc_stats_cache.clone(),
         };
         Ok(ret)
     }

--- a/cozo-core/src/runtime/hybrid.rs
+++ b/cozo-core/src/runtime/hybrid.rs
@@ -77,12 +77,66 @@ impl Default for MmrParams {
 ///
 /// The body is your own Datalog and is spliced verbatim — it is *not* sanitized.
 /// Only `label` is validated (it becomes a fusion list tag).
+///
+/// For the common case of *bounded-hop graph proximity from a seed set*, prefer
+/// the typed [`GraphLeg`] (`HybridSearch::graph_legs`): a single inline body
+/// cannot express the recursive shortest-path rule that proximity needs, and
+/// [`GraphLeg`] generates it for you (with min-distance semantics, a hop bound,
+/// and params for the seeds) so it folds into the *same* fused call.
 #[derive(Clone, Debug)]
 pub struct HybridList {
     /// Fusion list tag (validated identifier).
     pub label: String,
     /// Rule body binding `id` and `score`.
     pub rule_body: String,
+}
+
+/// A typed **k-hop graph-proximity** leg folded into the fusion (the mnestic
+/// fork's native 3-way fused recall — DEVELOPMENT.md Bet 1a).
+///
+/// Unlike [`HybridList`], whose body is a single spliced rule, this generates a
+/// **recursive bounded shortest-path rule** over a stored edge relation: it
+/// expands from `seeds` up to `max_hops` hops, scores each reached node by its
+/// *minimum* hop distance (closer = higher rank), and contributes that ranked
+/// list to the Reciprocal Rank Fusion alongside the vector and keyword legs —
+/// all in the one optimized call (no second `run_script`, no hand-written
+/// recursion). The reached node id binds to the fused output id, so seeds and
+/// item ids must live in the same id space as the base relation's key.
+///
+/// The seed values are passed as query **params** (never string-interpolated);
+/// every identifier (`label`, relation, columns) is validated.
+#[derive(Clone, Debug)]
+pub struct GraphLeg {
+    /// Fusion list tag (validated identifier). Default `"graph"`.
+    pub label: String,
+    /// The stored edge relation to traverse, e.g. `"edges"`.
+    pub edge_relation: String,
+    /// Edge column holding the source node id. Default `"from"`.
+    pub from_col: String,
+    /// Edge column holding the destination node id. Default `"to"`.
+    pub to_col: String,
+    /// Seed node ids to expand from (the query anchors). The seeds themselves
+    /// are *not* scored — proximity starts at hop 1.
+    pub seeds: Vec<DataValue>,
+    /// Maximum number of hops to expand (`k`). Must be `>= 1`.
+    pub max_hops: usize,
+    /// Treat edges as undirected — also traverse `to_col -> from_col`. Default
+    /// `false` (follow edges in their stored direction only).
+    pub undirected: bool,
+}
+
+impl Default for GraphLeg {
+    fn default() -> Self {
+        GraphLeg {
+            label: "graph".into(),
+            edge_relation: String::new(),
+            from_col: "from".into(),
+            to_col: "to".into(),
+            seeds: Vec::new(),
+            max_hops: 2,
+            undirected: false,
+        }
+    }
 }
 
 /// Parameters for a one-call hybrid retrieval. See the module docs.
@@ -113,6 +167,9 @@ pub struct HybridSearch {
     pub fts_k: usize,
     /// Extra ranked lists folded into the fusion (e.g. graph traversal).
     pub extra_lists: Vec<HybridList>,
+    /// Typed k-hop graph-proximity legs folded into the fusion (native 3-way
+    /// fused recall). See [`GraphLeg`].
+    pub graph_legs: Vec<GraphLeg>,
     /// RRF `k` constant (rank-bias damping). Default `60.0`.
     pub rrf_k: f64,
     /// Optional MMR diversity rerank. `None` returns the fused ranking directly.
@@ -135,6 +192,7 @@ impl Default for HybridSearch {
             query_text: String::new(),
             fts_k: 10,
             extra_lists: Vec::new(),
+            graph_legs: Vec::new(),
             rrf_k: 60.0,
             mmr: None,
             limit: 10,
@@ -186,6 +244,14 @@ pub fn build_hybrid_query(q: &HybridSearch) -> Result<(String, BTreeMap<String, 
     for l in &q.extra_lists {
         validate_ident(&l.label, "extra_lists.label")?;
     }
+    for g in &q.graph_legs {
+        validate_ident(&g.label, "graph_legs.label")?;
+        validate_ident(&g.edge_relation, "graph_legs.edge_relation")?;
+        validate_ident(&g.from_col, "graph_legs.from_col")?;
+        validate_ident(&g.to_col, "graph_legs.to_col")?;
+        ensure!(g.max_hops >= 1, "hybrid_search: graph_legs.max_hops must be >= 1");
+        ensure!(!g.seeds.is_empty(), "hybrid_search: graph_legs.seeds is empty");
+    }
     if let Some(m) = &q.mmr {
         validate_ident(&m.embedding_col, "mmr.embedding_col")?;
         ensure!(m.lambda.is_finite(), "hybrid_search: mmr.lambda must be finite");
@@ -218,6 +284,59 @@ pub fn build_hybrid_query(q: &HybridSearch) -> Result<(String, BTreeMap<String, 
         fk = q.fts_k,
     )
     .unwrap();
+
+    // Typed graph-proximity legs (Bet 1a). For each leg we emit a recursive
+    // bounded shortest-path rule: a seed relation (seeds as params, unioned),
+    // a base rule (hop 1) and a recursive rule (hop n+1, gated at `max_hops`)
+    // that uses `min(dist)` so a node reached by several paths scores by its
+    // *shortest* distance. Internal rule/var names are prefixed `hg{i}_` to
+    // avoid colliding with the fixed legs or a user's `extra_lists` bodies.
+    let mut params = BTreeMap::new();
+    params.insert(
+        "qv".to_string(),
+        DataValue::List(q.query_vector.iter().map(|f| DataValue::from(*f as f64)).collect()),
+    );
+    params.insert("qt".to_string(), DataValue::from(q.query_text.as_str()));
+    for (i, g) in q.graph_legs.iter().enumerate() {
+        let er = &g.edge_relation;
+        let fc = &g.from_col;
+        let tc = &g.to_col;
+        // Seed relation: one union rule per seed, value carried as a param.
+        for (j, seed) in g.seeds.iter().enumerate() {
+            let pname = format!("hg{i}_seed{j}");
+            writeln!(s, "hg{i}_seed[__s] := __s = ${pname}").unwrap();
+            params.insert(pname, seed.clone());
+        }
+        // Hop 1: direct neighbours of the seeds.
+        writeln!(
+            s,
+            "hg{i}_reach[__to, min(__d)] := hg{i}_seed[__s], *{er}{{ {fc}: __s, {tc}: __to }}, __d = 1.0"
+        )
+        .unwrap();
+        if g.undirected {
+            writeln!(
+                s,
+                "hg{i}_reach[__to, min(__d)] := hg{i}_seed[__s], *{er}{{ {fc}: __to, {tc}: __s }}, __d = 1.0"
+            )
+            .unwrap();
+        }
+        // Hop n+1: expand only from nodes whose shortest distance is below the
+        // hop bound, so the recursion is capped at `max_hops`.
+        let bound = fmt_f64(g.max_hops as f64);
+        writeln!(
+            s,
+            "hg{i}_reach[__to, min(__d)] := hg{i}_reach[__mid, __pd], __pd < {bound}, *{er}{{ {fc}: __mid, {tc}: __to }}, __d = __pd + 1.0"
+        )
+        .unwrap();
+        if g.undirected {
+            writeln!(
+                s,
+                "hg{i}_reach[__to, min(__d)] := hg{i}_reach[__mid, __pd], __pd < {bound}, *{er}{{ {fc}: __to, {tc}: __mid }}, __d = __pd + 1.0"
+            )
+            .unwrap();
+        }
+    }
+
     // Union all legs into one [list_id, item, score] relation.
     writeln!(s, "combined[__lid, id, score] := sem[id, score], __lid = 'semantic'").unwrap();
     writeln!(s, "combined[__lid, id, score] := txt[id, score], __lid = 'text'").unwrap();
@@ -227,6 +346,16 @@ pub fn build_hybrid_query(q: &HybridSearch) -> Result<(String, BTreeMap<String, 
             "combined[__lid, id, score] := {body}, __lid = '{label}'",
             body = l.rule_body,
             label = l.label,
+        )
+        .unwrap();
+    }
+    for (i, g) in q.graph_legs.iter().enumerate() {
+        // Closer (smaller distance) ⇒ higher score, matching the other legs'
+        // higher-is-better orientation; RRF only uses the within-list rank.
+        writeln!(
+            s,
+            "combined[__lid, id, score] := hg{i}_reach[id, __gd], score = -__gd, __lid = '{label}'",
+            label = g.label,
         )
         .unwrap();
     }
@@ -264,13 +393,6 @@ pub fn build_hybrid_query(q: &HybridSearch) -> Result<(String, BTreeMap<String, 
             writeln!(s, ":order rank").unwrap();
         }
     }
-
-    let mut params = BTreeMap::new();
-    params.insert(
-        "qv".to_string(),
-        DataValue::List(q.query_vector.iter().map(|f| DataValue::from(*f as f64)).collect()),
-    );
-    params.insert("qt".to_string(), DataValue::from(q.query_text.as_str()));
 
     Ok((s, params))
 }

--- a/cozo-core/src/runtime/relation.rs
+++ b/cozo-core/src/runtime/relation.rs
@@ -992,6 +992,12 @@ impl<'a> SessionTx<'a> {
             )?;
         }
 
+        // Publish the authoritative corpus doc-stats counter for this freshly
+        // built index (mnestic fork, Bet 1b) so `avgdl` is an O(1) read rather
+        // than a per-query scan. Overwrites any incremental value accumulated by
+        // the del/put loop above.
+        self.rebuild_fts_doc_stats(&idx_handle)?;
+
         rel_handle
             .fts_indices
             .insert(manifest.index_name.clone(), (idx_handle, manifest));

--- a/cozo-core/src/runtime/transact.rs
+++ b/cozo-core/src/runtime/transact.rs
@@ -6,10 +6,12 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicU32, AtomicU64};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use miette::{bail, Result};
+use smartstring::{LazyCompact, SmartString};
 use crate::data::program::ReturnMutation;
 
 use crate::data::tuple::TupleT;
@@ -27,6 +29,9 @@ pub struct SessionTx<'a> {
     pub(crate) relation_store_id: Arc<AtomicU64>,
     pub(crate) temp_store_id: AtomicU32,
     pub(crate) tokenizers: Arc<TokenizerCache>,
+    /// Cross-query cache of FTS corpus stats for legacy indexes (mnestic fork);
+    /// see `Db::fts_doc_stats_cache`. Shared `Arc` cloned per transaction.
+    pub(crate) fts_doc_stats_cache: Arc<Mutex<BTreeMap<SmartString<LazyCompact>, (u64, u64)>>>,
 }
 
 pub const CURRENT_STORAGE_VERSION: [u8; 1] = [0x00];

--- a/cozo-core/tests/bm25.rs
+++ b/cozo-core/tests/bm25.rs
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026, Shan Rizvi (mnestic fork).
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Tests for the mnestic fork's BM25-correct FTS scoring (DEVELOPMENT.md Bet 1b).
+//!
+//! Two defects in upstream's `tf_idf` scoring that drag fused recall (bench: FTS
+//! agreement 0.72 vs vector 0.99 / graph 1.00):
+//!   A. scoring is raw `tf * idf` — no Okapi `k1` saturation, no `b` length
+//!      normalization (the per-doc length is *stored* in the index but discarded).
+//!   B. a disjunctive `a OR b` query takes `max` of per-term scores, not the sum,
+//!      so a doc matching *both* terms can tie a doc matching one term strongly.
+//!
+//! Uses the **sqlite** backend (stored path) per CLAUDE.md's test-backend rule.
+
+use cozo::{DbInstance, NamedRows, ScriptMutability};
+use std::collections::{BTreeMap, HashMap};
+
+fn db() -> DbInstance {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("bm25.db");
+    // Leak the tempdir so the sqlite file outlives this fn for the test's duration.
+    std::mem::forget(dir);
+    DbInstance::new("sqlite", path.to_str().unwrap(), Default::default()).unwrap()
+}
+
+fn run(db: &DbInstance, s: &str) -> NamedRows {
+    db.run_script(s, BTreeMap::new(), ScriptMutability::Mutable)
+        .unwrap_or_else(|e| panic!("script failed: {e:?}\n--- script ---\n{s}"))
+}
+
+/// Build a doc relation + FTS index with the given rows, no stemming/stopwords so
+/// our synthetic tokens survive verbatim.
+fn setup(db: &DbInstance, rows: &str) {
+    run(db, r":create doc {k: String => body: String}");
+    run(
+        db,
+        r"::fts create doc:fts { extractor: body, tokenizer: Simple, filters: [Lowercase] }",
+    );
+    run(db, &format!(r"?[k, body] <- [{rows}] :put doc {{k => body}}"));
+}
+
+/// query -> {doc_key: score}, using the given fts param tail (after `|`).
+fn scores(db: &DbInstance, params: &str) -> HashMap<String, f64> {
+    let res = run(
+        db,
+        &format!(r"?[k, s] := ~doc:fts{{k, body | {params}, bind_score: s}}"),
+    );
+    res.rows
+        .iter()
+        .map(|r| (r[0].get_str().unwrap().to_string(), r[1].get_float().unwrap()))
+        .collect()
+}
+
+/// Defect B: an `OR` of two terms must SUM per-term contributions, so a doc
+/// matching both terms outranks one matching a single term many times (whose tf
+/// saturates under BM25's k1). Under upstream `tf_idf` + max-OR, `single` wins.
+#[test]
+fn bm25_or_sums_per_term_contributions() {
+    let db = db();
+    setup(
+        &db,
+        r"
+        ['multi', 'alpha beta'],
+        ['single', 'alpha alpha alpha alpha alpha alpha']
+    ",
+    );
+    let s = scores(&db, "query: 'alpha OR beta', k: 10");
+    let multi = s["multi"];
+    let single = s["single"];
+    assert!(
+        multi > single,
+        "doc matching both OR terms ({multi}) must outrank doc matching one term \
+         repeatedly ({single}) — OR should sum, and repeated tf should saturate"
+    );
+}
+
+/// Defect A: BM25 length-normalizes. Two docs with identical term frequency (1)
+/// for the query term but different lengths must NOT tie — the shorter doc scores
+/// higher. Upstream `tf_idf` ignores doc length, so they tie.
+#[test]
+fn bm25_length_normalization_favors_shorter_doc() {
+    let db = db();
+    let filler = vec!["pad"; 60].join(" ");
+    setup(
+        &db,
+        &format!(
+            r"
+        ['short', 'gamma'],
+        ['long', 'gamma {filler}']
+    "
+        ),
+    );
+    let s = scores(&db, "query: 'gamma', k: 10");
+    let short = s["short"];
+    let long = s["long"];
+    assert!(
+        short > long,
+        "with equal tf, the shorter doc ({short}) must outrank the longer, \
+         length-diluted doc ({long}) under BM25 length normalization"
+    );
+}
+
+/// `k1`/`b` parameters must parse and influence scoring. With `b: 0.0` (length
+/// normalization disabled), the length-difference docs tie again — proving `b`
+/// is actually wired through, not ignored.
+#[test]
+fn bm25_b_zero_disables_length_normalization() {
+    let db = db();
+    let filler = vec!["pad"; 60].join(" ");
+    setup(
+        &db,
+        &format!(
+            r"
+        ['short', 'gamma'],
+        ['long', 'gamma {filler}']
+    "
+        ),
+    );
+    let s = scores(&db, "query: 'gamma', k: 10, b: 0.0");
+    assert!(
+        (s["short"] - s["long"]).abs() < 1e-9,
+        "with b=0 (no length norm) equal-tf docs must tie: short={}, long={}",
+        s["short"],
+        s["long"]
+    );
+}

--- a/cozo-core/tests/fts_avgdl.rs
+++ b/cozo-core/tests/fts_avgdl.rs
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026, Shan Rizvi (mnestic fork).
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Tests for the mnestic fork's **durable FTS doc-stats counter** (DEVELOPMENT.md
+//! Bet 1b, avgdl step). BM25 length normalization needs the average document
+//! length (`avgdl`); upstream's only option was a full deduplicated scan of the
+//! FTS index on every query (O(#docs), ~680 ms at 40k chunks in the bench). The
+//! fork maintains `(total_tokens, n_docs)` incrementally on `put`/`del` and at
+//! index build, so `avgdl` is an O(1) read.
+//!
+//! These tests pin the *behaviour* that proves the counter is maintained
+//! correctly (not just fast): scores are identical whether a corpus is reached by
+//! deletes or built fresh, the counter survives a reopen, and `avgdl` actually
+//! feeds the BM25 denominator. Uses the **sqlite** backend (real stored path).
+
+use cozo::{DbInstance, NamedRows, ScriptMutability};
+use std::collections::{BTreeMap, HashMap};
+
+fn run(db: &DbInstance, s: &str) -> NamedRows {
+    db.run_script(s, BTreeMap::new(), ScriptMutability::Mutable)
+        .unwrap_or_else(|e| panic!("script failed: {e:?}\n--- script ---\n{s}"))
+}
+
+fn setup(db: &DbInstance) {
+    run(db, r":create doc {k: String => body: String}");
+    run(
+        db,
+        r"::fts create doc:fts { extractor: body, tokenizer: Simple, filters: [Lowercase] }",
+    );
+}
+
+fn put(db: &DbInstance, rows: &str) {
+    run(db, &format!(r"?[k, body] <- [{rows}] :put doc {{k => body}}"));
+}
+
+fn rm(db: &DbInstance, keys: &str) {
+    run(db, &format!(r"?[k] <- [{keys}] :rm doc {{k}}"));
+}
+
+/// `{doc_key: bm25_score}` for a single-term query (bm25 is the default scorer).
+fn scores(db: &DbInstance, query: &str) -> HashMap<String, f64> {
+    let res = run(
+        db,
+        &format!(r"?[k, s] := ~doc:fts{{k, body | query: '{query}', k: 50, bind_score: s}}"),
+    );
+    res.rows
+        .iter()
+        .map(|r| (r[0].get_str().unwrap().to_string(), r[1].get_float().unwrap()))
+        .collect()
+}
+
+fn new_db(path: &std::path::Path) -> DbInstance {
+    DbInstance::new("sqlite", path.to_str().unwrap(), Default::default()).unwrap()
+}
+
+const FILLER: &str = "pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad pad";
+
+/// The counter must net correctly through deletes: a corpus reached by inserting
+/// extra long documents and then deleting them must score *identically* to the
+/// same corpus built fresh. `gamma` lives only in the short doc, so `df`/`N` match
+/// across the two databases — any score difference would be a stale `avgdl`, i.e.
+/// a delete that failed to subtract from the counter.
+#[test]
+fn delete_maintains_avgdl_like_fresh_build() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // A: insert short + long docs, then delete the long ones.
+    let a = new_db(&dir.path().join("a.db"));
+    setup(&a);
+    put(
+        &a,
+        &format!(
+            r"['short', 'gamma'], ['l1', 'delta {FILLER}'], ['l2', 'delta {FILLER}'], ['l3', 'delta {FILLER}']"
+        ),
+    );
+    rm(&a, r"['l1'], ['l2'], ['l3']");
+    let sa = scores(&a, "gamma");
+
+    // B: build the end state (just the short doc) directly.
+    let b = new_db(&dir.path().join("b.db"));
+    setup(&b);
+    put(&b, r"['short', 'gamma']");
+    let sb = scores(&b, "gamma");
+
+    assert!(
+        (sa["short"] - sb["short"]).abs() < 1e-9,
+        "score after deletes ({}) must equal fresh-built score ({}) — a difference \
+         means the delete did not maintain the avgdl counter",
+        sa["short"],
+        sb["short"]
+    );
+}
+
+/// The counter is durable: scores are identical after closing and reopening the
+/// database (the counter is read back from the store, not recomputed differently).
+#[test]
+fn avgdl_counter_survives_reopen() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("reopen.db");
+
+    let before = {
+        let db = new_db(&path);
+        setup(&db);
+        put(
+            &db,
+            &format!(r"['short', 'gamma'], ['long', 'gamma {FILLER}']"),
+        );
+        scores(&db, "gamma")
+    }; // db dropped here → sqlite file flushed
+
+    let db = new_db(&path);
+    let after = scores(&db, "gamma");
+
+    for k in ["short", "long"] {
+        assert!(
+            (before[k] - after[k]).abs() < 1e-9,
+            "score for {k} changed across reopen: {} -> {}",
+            before[k],
+            after[k]
+        );
+    }
+}
+
+/// `avgdl` must actually feed the BM25 length normalization: a document of fixed
+/// length scores *higher* in a corpus with a larger average document length
+/// (its `|D|/avgdl` ratio shrinks, so the length penalty relaxes). `gamma` has
+/// `df = 1` and `N = 2` in both corpora, so only `avgdl` differs.
+#[test]
+fn avgdl_value_feeds_bm25_denominator() {
+    let dir = tempfile::tempdir().unwrap();
+
+    // Small avgdl: the other document is short.
+    let small = new_db(&dir.path().join("small.db"));
+    setup(&small);
+    put(&small, r"['target', 'gamma'], ['other', 'delta']");
+    let s_small = scores(&small, "gamma")["target"];
+
+    // Large avgdl: the other document is long (same N, same df for 'gamma').
+    let large = new_db(&dir.path().join("large.db"));
+    setup(&large);
+    put(&large, &format!(r"['target', 'gamma'], ['other', 'delta {FILLER}']"));
+    let s_large = scores(&large, "gamma")["target"];
+
+    assert!(
+        s_large > s_small,
+        "the fixed-length 'target' doc must score higher when avgdl is larger \
+         (small avgdl: {s_small}, large avgdl: {s_large}) — proving avgdl is used"
+    );
+}

--- a/cozo-core/tests/hybrid_graph_leg.rs
+++ b/cozo-core/tests/hybrid_graph_leg.rs
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2026, Shan Rizvi (mnestic fork).
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Tests for the mnestic fork's **native 3-way fused recall** — a typed
+//! [`GraphLeg`] folded into `hybrid_search` alongside the vector (HNSW) and
+//! keyword (FTS) legs (DEVELOPMENT.md Bet 1a).
+//!
+//! The graph leg generates a *recursive bounded shortest-path* rule that a
+//! single spliced [`cozo::HybridList`] body cannot express, scores reached
+//! nodes by their minimum hop distance, and contributes that ranked list to the
+//! same Reciprocal Rank Fusion — in one call, no second `run_script`.
+//!
+//! Uses the **sqlite** backend (real stored-relation / index path) per the
+//! fork's testing convention.
+
+use cozo::{build_hybrid_query, DbInstance, GraphLeg, HybridSearch, NamedRows, ScriptMutability};
+use std::collections::BTreeMap;
+
+fn run(db: &DbInstance, s: &str) -> NamedRows {
+    db.run_script(s, BTreeMap::new(), ScriptMutability::Mutable)
+        .unwrap_or_else(|e| panic!("script failed: {e:?}\n--- script ---\n{s}"))
+}
+
+/// A tiny corpus + a directed edge relation:
+///
+/// ```text
+///   d1 ──▶ d2 ──▶ d3 ──▶ d4
+///   d1 ─────────▶ d3
+///   d5 ─────────────────▶ d4
+/// ```
+///
+/// Only `d1` matches the query (`'alpha'` / `[1,0]`); `d2..d5` are far on both
+/// the vector and keyword legs, so anything else surfacing is the graph leg.
+fn make_db() -> (DbInstance, tempfile::TempDir) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("hybrid_graph.db");
+    let db = DbInstance::new("sqlite", path.to_str().unwrap(), "").unwrap();
+    run(
+        &db,
+        r#"
+        ?[id, text, emb] <- [
+            ['d1', 'alpha',   [1.0, 0.0]],
+            ['d2', 'beta',    [0.0, 1.0]],
+            ['d3', 'gamma',   [0.0, 1.0]],
+            ['d4', 'delta',   [0.0, 1.0]],
+            ['d5', 'epsilon', [-1.0, 0.0]]
+        ]
+        :create docs { id: String => text: String, emb: <F32; 2> }
+    "#,
+    );
+    run(
+        &db,
+        r#"::hnsw create docs:vec {
+            dim: 2, m: 50, dtype: F32, fields: [emb],
+            distance: L2, ef_construction: 20
+        }"#,
+    );
+    run(
+        &db,
+        r#"::fts create docs:fts {
+            extractor: text, tokenizer: Simple, filters: [Lowercase]
+        }"#,
+    );
+    run(
+        &db,
+        r#"
+        ?[from, to] <- [
+            ['d1', 'd2'], ['d1', 'd3'], ['d2', 'd3'], ['d3', 'd4'], ['d5', 'd4']
+        ]
+        :create edges { from: String, to: String }
+    "#,
+    );
+    (db, dir)
+}
+
+fn ids(res: &NamedRows) -> Vec<String> {
+    res.rows
+        .iter()
+        .map(|r| r[0].get_str().unwrap().to_string())
+        .collect()
+}
+
+fn pos(order: &[String], id: &str) -> Option<usize> {
+    order.iter().position(|x| x == id)
+}
+
+/// A baseline query that only `d1` can satisfy on the vector + keyword legs
+/// (`vector_k`/`fts_k` = 1 ⇒ each fixed leg returns just `d1`), so the fused
+/// output beyond `d1` is entirely the graph leg's doing.
+fn graph_dominated(seeds: &[&str], max_hops: usize, undirected: bool) -> HybridSearch {
+    HybridSearch {
+        relation: "docs".into(),
+        vector_index: "vec".into(),
+        query_vector: vec![1.0, 0.0],
+        vector_k: 1,
+        fts_index: "fts".into(),
+        query_text: "alpha".into(),
+        fts_k: 1,
+        graph_legs: vec![GraphLeg {
+            edge_relation: "edges".into(),
+            seeds: seeds.iter().map(|s| (*s).into()).collect(),
+            max_hops,
+            undirected,
+            ..GraphLeg::default()
+        }],
+        limit: 10,
+        ..HybridSearch::default()
+    }
+}
+
+/// The graph leg must surface a neighbour (`d4`, 2 hops from `d1`) that is poor
+/// on *both* the vector and keyword legs — i.e. recall the fixed legs miss.
+#[test]
+fn graph_leg_surfaces_unmatched_neighbor() {
+    let (db, _dir) = make_db();
+
+    // Baseline: vector + FTS only. d4 should be nowhere near (it is far on both).
+    let mut baseline = graph_dominated(&["d1"], 2, false);
+    baseline.graph_legs.clear();
+    let base_ids = ids(&db.hybrid_search(&baseline).unwrap());
+    assert!(
+        pos(&base_ids, "d4").is_none(),
+        "precondition: d4 should not surface without the graph leg; got {base_ids:?}"
+    );
+
+    // With a 2-hop graph leg from d1, d4 (d1→d3→d4) is recalled.
+    let q = graph_dominated(&["d1"], 2, false);
+    let order = ids(&db.hybrid_search(&q).unwrap());
+    assert!(
+        pos(&order, "d4").is_some(),
+        "graph leg should recall d4 within 2 hops; got {order:?}"
+    );
+    // The seed itself is the query anchor and is not scored by the graph leg,
+    // but it still wins via the vector + keyword legs.
+    assert_eq!(order.first().map(String::as_str), Some("d1"), "order = {order:?}");
+}
+
+/// Closer nodes outrank farther ones: with the graph leg dominating, a 1-hop
+/// neighbour (`d2`) must rank above a 2-hop one (`d4`). Exercises the
+/// `min(dist)` distance scoring end-to-end.
+#[test]
+fn graph_leg_closer_outranks_farther() {
+    let (db, _dir) = make_db();
+    let order = ids(&db.hybrid_search(&graph_dominated(&["d1"], 2, false)).unwrap());
+    let p2 = pos(&order, "d2").expect("d2 (1 hop) should be present");
+    let p4 = pos(&order, "d4").expect("d4 (2 hops) should be present");
+    assert!(
+        p2 < p4,
+        "1-hop d2 (pos {p2}) must outrank 2-hop d4 (pos {p4}); order = {order:?}"
+    );
+}
+
+/// `max_hops` bounds the recursion: at 1 hop, the 2-hop node `d4` must NOT be
+/// recalled (and nothing else pulls it in, by construction).
+#[test]
+fn graph_leg_respects_hop_bound() {
+    let (db, _dir) = make_db();
+    let order = ids(&db.hybrid_search(&graph_dominated(&["d1"], 1, false)).unwrap());
+    assert!(
+        pos(&order, "d2").is_some() && pos(&order, "d3").is_some(),
+        "1-hop neighbours d2, d3 should be present; got {order:?}"
+    );
+    assert!(
+        pos(&order, "d4").is_none(),
+        "d4 is 2 hops away and must be excluded at max_hops=1; got {order:?}"
+    );
+}
+
+/// Undirected traversal also follows edges in reverse: from `d3`, a 1-hop
+/// undirected expansion reaches `d4` (forward `d3→d4`) *and* `d2` (reverse of
+/// `d2→d3`); directed reaches only `d4`. (We probe `d2` rather than `d1`: `d1`
+/// is the query anchor and is always returned by the fixed legs, so it can't
+/// distinguish the two directions.)
+#[test]
+fn graph_leg_undirected_follows_reverse_edges() {
+    let (db, _dir) = make_db();
+
+    let directed = ids(&db.hybrid_search(&graph_dominated(&["d3"], 1, false)).unwrap());
+    assert!(
+        pos(&directed, "d2").is_none(),
+        "directed 1-hop from d3 must not reach d2 (edge is d2→d3); got {directed:?}"
+    );
+
+    let undirected = ids(&db.hybrid_search(&graph_dominated(&["d3"], 1, true)).unwrap());
+    assert!(
+        pos(&undirected, "d2").is_some(),
+        "undirected 1-hop from d3 should reach d2 via the reverse edge; got {undirected:?}"
+    );
+}
+
+/// Multiple seeds union their reachable sets: from `{d1, d5}` at 1 hop we get
+/// `d2`/`d3` (from d1) and `d4` (from d5).
+#[test]
+fn graph_leg_multiple_seeds_union() {
+    let (db, _dir) = make_db();
+    let order = ids(&db.hybrid_search(&graph_dominated(&["d1", "d5"], 1, false)).unwrap());
+    for id in ["d2", "d3", "d4"] {
+        assert!(
+            pos(&order, id).is_some(),
+            "multi-seed 1-hop should recall {id}; got {order:?}"
+        );
+    }
+}
+
+/// The generated script must contain the recursive shortest-path rule (with
+/// `min(...)` aggregation and the hop-bound guard), carry seeds as params (not
+/// interpolated), and tag the fusion list with the leg label.
+#[test]
+fn graph_leg_script_is_recursive_and_parametrised() {
+    let q = HybridSearch {
+        relation: "docs".into(),
+        vector_index: "vec".into(),
+        query_vector: vec![1.0, 0.0],
+        fts_index: "fts".into(),
+        query_text: "alpha".into(),
+        graph_legs: vec![GraphLeg {
+            label: "graph".into(),
+            edge_relation: "edges".into(),
+            seeds: vec!["d1".into(), "d2".into()],
+            max_hops: 3,
+            ..GraphLeg::default()
+        }],
+        ..HybridSearch::default()
+    };
+    let (script, params) = build_hybrid_query(&q).unwrap();
+
+    assert!(script.contains("hg0_reach[__to, min(__d)]"), "no recursive min-rule:\n{script}");
+    assert!(script.contains("__pd < 3.0"), "no hop-bound guard:\n{script}");
+    assert!(script.contains("__lid = 'graph'"), "graph leg not fused:\n{script}");
+    // Seeds are params, never string-interpolated into the script body.
+    assert!(script.contains("$hg0_seed0") && script.contains("$hg0_seed1"), "seeds not params:\n{script}");
+    assert!(!script.contains("'d1'"), "seed value leaked into script text:\n{script}");
+    assert_eq!(params.get("hg0_seed0").and_then(|v| v.get_str()), Some("d1"));
+    assert_eq!(params.get("hg0_seed1").and_then(|v| v.get_str()), Some("d2"));
+}
+
+/// Validation rejects an empty seed set and a zero hop bound.
+#[test]
+fn graph_leg_validates_inputs() {
+    let base = HybridSearch {
+        relation: "docs".into(),
+        vector_index: "vec".into(),
+        query_vector: vec![1.0, 0.0],
+        fts_index: "fts".into(),
+        query_text: "alpha".into(),
+        ..HybridSearch::default()
+    };
+
+    let mut empty_seeds = base.clone();
+    empty_seeds.graph_legs = vec![GraphLeg {
+        edge_relation: "edges".into(),
+        seeds: vec![],
+        ..GraphLeg::default()
+    }];
+    assert!(build_hybrid_query(&empty_seeds).is_err(), "empty seeds must be rejected");
+
+    let mut zero_hops = base;
+    zero_hops.graph_legs = vec![GraphLeg {
+        edge_relation: "edges".into(),
+        seeds: vec!["d1".into()],
+        max_hops: 0,
+        ..GraphLeg::default()
+    }];
+    assert!(build_hybrid_query(&zero_hops).is_err(), "max_hops=0 must be rejected");
+}

--- a/cozo-lib-python/src/lib.rs
+++ b/cozo-lib-python/src/lib.rs
@@ -157,6 +157,55 @@ fn py_to_hybrid_search(d: &PyDict) -> PyResult<HybridSearch> {
         }
         q.extra_lists = lists;
     }
+    if let Some(v) = d.get_item("graph_legs")? {
+        let items = v.downcast::<PyList>()?;
+        let mut legs = Vec::with_capacity(items.len());
+        for it in items {
+            let gd = it.downcast::<PyDict>()?;
+            let edge_relation = gd
+                .get_item("edge_relation")?
+                .ok_or_else(|| PyException::new_err("graph_legs entry needs 'edge_relation'"))?
+                .extract()?;
+            let seeds_list = gd
+                .get_item("seeds")?
+                .ok_or_else(|| PyException::new_err("graph_legs entry needs 'seeds'"))?
+                .downcast::<PyList>()?;
+            let mut seeds = Vec::with_capacity(seeds_list.len());
+            for s in seeds_list {
+                seeds.push(py_to_value(s)?);
+            }
+            let max_hops = gd
+                .get_item("max_hops")?
+                .ok_or_else(|| PyException::new_err("graph_legs entry needs 'max_hops'"))?
+                .extract()?;
+            let label = match gd.get_item("label")? {
+                Some(x) => x.extract()?,
+                None => "graph".to_string(),
+            };
+            let from_col = match gd.get_item("from_col")? {
+                Some(x) => x.extract()?,
+                None => "from".to_string(),
+            };
+            let to_col = match gd.get_item("to_col")? {
+                Some(x) => x.extract()?,
+                None => "to".to_string(),
+            };
+            let undirected = match gd.get_item("undirected")? {
+                Some(x) => x.extract()?,
+                None => false,
+            };
+            legs.push(GraphLeg {
+                label,
+                edge_relation,
+                from_col,
+                to_col,
+                seeds,
+                max_hops,
+                undirected,
+            });
+        }
+        q.graph_legs = legs;
+    }
     if let Some(v) = d.get_item("mmr")? {
         if !v.is_none() {
             let md = v.downcast::<PyDict>()?;


### PR DESCRIPTION
Two agentic-memory wedge features, validated end-to-end on the `mnestic-benchmarks` hybrid suite (2026-05-31, SQLite-backed wheel, vs SQLite/DuckDB/LanceDB/Kuzu).

## Bet 1a — native 3-way fused recall (`GraphLeg`)
`hybrid_search` now fuses a **graph-proximity leg in-engine** alongside vector (HNSW) and FTS. A new typed `HybridSearch::graph_legs: Vec<GraphLeg>` generates a recursive bounded shortest-path rule (seed relation → hop-1 base → `min(dist)` recursive rule gated at `max_hops`), scores reached nodes by minimum hop distance, and folds that ranked list into the same RRF as the other legs. Supports `undirected` and multiple seeds; seeds pass as params (injection-safe); empty `graph_legs` → byte-identical prior script.

- **Measured:** the one fused call runs vector+FTS+graph at **41.55 ms p50** (recall 0.873) — **~4× faster** than the 175 ms hand-decomposed path, fusing a signal (graph) no other engine here has (LanceDB native is 2-way only: recall 0.456).
- `runtime/hybrid.rs`; tests in `tests/hybrid_graph_leg.rs` (7). Python `graph_legs` binding for the embedded wheel.

## Bet 1b — BM25-correct FTS + O(1) `avgdl`
Default `::fts` scorer moves from `tf_idf` to **Okapi `bm25`** (`idf · tf(k1+1)/(tf + k1(1−b+b·|D|/avgdl))`), with `k1`/`b` tunable and `OR` summing per-term contributions. **`tf`/`tf_idf` remain selectable for byte-identical upstream scoring.**

`avgdl` is an **O(1) read** of a durable per-index `(total_tokens, n_docs)` counter (reserved `[Bot]` key, maintained on put/del, published authoritatively at `::fts create`); legacy indexes self-migrate on first write, with a `Db`-scoped cross-query cache covering pure-read legacy indexes.

- **Measured:** fused recall **0.75 → 0.954** (parity with DuckDB 0.957 / SQLite 1.0); decomposed-path p50 **927 → 175 ms**, cold p99 tail **2,900 → 258 ms**. (The tail was the per-query `avgdl` scan, not cold HNSW.)
- `fts/indexing.rs`, `runtime/{db,transact,relation}.rs`; tests in `tests/bm25.rs` (3) + `tests/fts_avgdl.rs` (3).

## Also
- `benches/read_path.rs` — read-path latency baseline (Item 9 groundwork): parse/compile is a fixed ~20–85 µs, negligible for non-trivial queries — confirming Bet 1a (one call vs three), not a plan cache, is the read-path lever.

## ⚠️ Behaviour change
The default FTS score kind changes (`tf_idf` → `bm25`). Documented in `CHANGELOG-FORK.md`; `tf`/`tf_idf` stay available.

## Verification
169 inherited lib tests + bm25 / fts_avgdl / hybrid_graph_leg / hybrid_helper / hybrid_retrieval_e2e / rrf / mmr / fork_regressions / matjoin_regression suites green; `cargo clippy -p mnestic -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)