### PR TITLE
docs: 0.8.3 README highlights + Cargo.lock sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "mnestic"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aho-corasick",
  "approx",

--- a/README.md
+++ b/README.md
@@ -15,6 +15,23 @@
 
 Highlights (full detail in [`CHANGELOG-FORK.md`](CHANGELOG-FORK.md)):
 
+**0.8.3**
+
+- **Native 3-way fused recall** — `hybrid_search` now fuses a graph-proximity leg
+  *in-engine* alongside vector (HNSW) and full-text (FTS). A typed `GraphLeg`
+  generates a recursive bounded shortest-path rule (k-hop, `min(dist)` scoring) and
+  folds it into the same RRF, so one call returns the vector+FTS+graph ranking — a
+  capability no other embedded engine here offers. Measured **41.55 ms p50**, ~4×
+  faster than the hand-decomposed three-query path.
+- **BM25-correct FTS, with O(1) `avgdl`** — the default `::fts` scorer is now Okapi
+  **`bm25`** (term-frequency saturation `k1` + document-length normalization `b`,
+  both tunable; `OR` sums per-term contributions). Average document length is an O(1)
+  read of a durable per-index counter rather than a per-query index scan. Measured:
+  fused recall **0.75 → 0.954** (parity with DuckDB / SQLite) at no net latency cost
+  (decomposed p50 927 → 175 ms, cold p99 2,900 → 258 ms). **Heads-up:** this changes
+  the default FTS score kind (a behaviour change); `tf`/`tf_idf` stay selectable for
+  byte-identical upstream scoring.
+
 **0.8.2**
 
 - **Non-blocking HNSW index builds** — `::hnsw create` no longer holds the base

--- a/cozo-core/README-mnestic.md
+++ b/cozo-core/README-mnestic.md
@@ -20,6 +20,23 @@ of upstream `481af05` (the last upstream commit, 2024-12-04).
 Highlights (full detail in
 [`CHANGELOG-FORK.md`](https://github.com/shuruheel/mnestic/blob/main/CHANGELOG-FORK.md)):
 
+**0.8.3**
+
+- **Native 3-way fused recall** — `hybrid_search` now fuses a graph-proximity leg
+  *in-engine* alongside vector (HNSW) and full-text (FTS). A typed `GraphLeg`
+  generates a recursive bounded shortest-path rule (k-hop, `min(dist)` scoring) and
+  folds it into the same RRF, so one call returns the vector+FTS+graph ranking — a
+  capability no other embedded engine here offers. Measured **41.55 ms p50**, ~4×
+  faster than the hand-decomposed three-query path.
+- **BM25-correct FTS, with O(1) `avgdl`** — the default `::fts` scorer is now Okapi
+  **`bm25`** (term-frequency saturation `k1` + document-length normalization `b`,
+  both tunable; `OR` sums per-term contributions). Average document length is an O(1)
+  read of a durable per-index counter rather than a per-query index scan. Measured:
+  fused recall **0.75 → 0.954** (parity with DuckDB / SQLite) at no net latency cost
+  (decomposed p50 927 → 175 ms, cold p99 2,900 → 258 ms). **Heads-up:** this changes
+  the default FTS score kind (a behaviour change); `tf`/`tf_idf` stay selectable for
+  byte-identical upstream scoring.
+
 **0.8.2**
 
 - **Non-blocking HNSW index builds** — `::hnsw create` no longer holds the base
@@ -70,7 +87,7 @@ so existing CozoDB code works unchanged:
 
 ```toml
 [dependencies]
-mnestic = "0.8.2"
+mnestic = "0.8.3"
 ```
 
 ```rust


### PR DESCRIPTION
Follow-up to the 0.8.3 release (PR #1). That PR updated `CHANGELOG-FORK.md` and `cozo-core/Cargo.toml` but left two things stale:

- **README highlights** — the "What mnestic adds over CozoDB" list in both `README.md` and `cozo-core/README-mnestic.md` stopped at 0.8.2. Adds the **0.8.3** entry:
  - Native 3-way fused recall (`GraphLeg`) — one call returns vector+FTS+graph, ~4× faster than the decomposed path (41.55 ms p50)
  - BM25-correct FTS with O(1) `avgdl` — fused recall 0.75 → 0.954 at no net latency cost, with the **behaviour-change heads-up** (default `::fts` scorer `tf_idf` → `bm25`)
  - Bumps the install snippet to `mnestic = "0.8.3"`
- **`Cargo.lock`** — synced the `mnestic` entry `0.8.2 → 0.8.3` (the release PR bumped `Cargo.toml` but not the lockfile).

Docs/lockfile only — no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)