### PR TITLE
Tier D item 0: adapter **extra pass-through + Mem0 unlock (0.2.0)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -142,6 +142,34 @@ jobs:
           name: dist-${{ matrix.pkg }}
           path: cozo-lib-python/integrations/${{ matrix.pkg }}/dist
 
+  # --- adapter test suites (against the latest published mnestic wheel) ---
+  # Runs each integration package's pytest suite with mnestic installed from
+  # PyPI — the adapters ship independently of the engine wheel, so this is the
+  # environment users actually get. Also guards the vendored-copy invariant.
+  test-integrations:
+    name: test ${{ matrix.pkg }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - pkg: langchain-mnestic
+            deps: langchain-core mem0ai langchain-community
+          - pkg: llama-index-vector-stores-mnestic
+            deps: llama-index-core
+    steps:
+      - uses: actions/checkout@v4
+      - name: vendored _core.py copies must stay byte-identical
+        run: >
+          diff
+          cozo-lib-python/integrations/langchain-mnestic/langchain_mnestic/_core.py
+          cozo-lib-python/integrations/llama-index-vector-stores-mnestic/llama_index/vector_stores/mnestic/_core.py
+      - uses: actions/setup-python@v5
+        with: { python-version: "3.12" }
+      - run: python -m pip install mnestic pytest ${{ matrix.deps }}
+      - run: python -m pip install -e cozo-lib-python/integrations/${{ matrix.pkg }}
+      - run: python -m pytest cozo-lib-python/integrations/${{ matrix.pkg }}/tests -q
+
   # --- wheel smoke test: a wheel whose rocksdb engine doesn't open must not ship ---
   # One natively runnable runner per built wheel. The mac x86_64 cross wheel has
   # no native runner (Intel-mac runners are retired); it was validated locally
@@ -235,7 +263,7 @@ jobs:
 
   publish-langchain-mnestic:
     # The adapters wrap the mnestic wheel — don't ship them off a broken wheel set.
-    needs: [build-adapters, test-wheels]
+    needs: [build-adapters, test-wheels, test-integrations]
     if: github.event_name == 'push' || inputs.publish
     runs-on: ubuntu-latest
     environment: pypi
@@ -250,7 +278,7 @@ jobs:
           skip-existing: true
 
   publish-llama-index-vector-stores-mnestic:
-    needs: [build-adapters, test-wheels]
+    needs: [build-adapters, test-wheels, test-integrations]
     if: github.event_name == 'push' || inputs.publish
     runs-on: ubuntu-latest
     environment: pypi

--- a/cozo-lib-python/integrations/langchain-mnestic/README.md
+++ b/cozo-lib-python/integrations/langchain-mnestic/README.md
@@ -30,6 +30,41 @@ retriever = store.as_retriever(search_kwargs={"k": 4})
 Scores returned by `similarity_search_with_score` are RRF **fused scores — higher
 is better** (a relevance score, not a distance).
 
+## Engine pass-through: graph legs and more
+
+Any extra keyword argument on the search methods goes straight to the engine's
+hybrid query. That includes **`graph_legs`** — fuse graph proximity into the
+ranking alongside the dense and keyword legs, in the same single call:
+
+```python
+db = store._store.db  # or pass your own CozoDbPy via MnesticVectorStore(db=...)
+db.run_script(":create links {src: String, dst: String}", {}, False)
+db.run_script("?[src, dst] <- [['doc-1', 'doc-9']] :put links {src, dst}", {}, False)
+
+docs = store.similarity_search(
+    "feline", k=4,
+    graph_legs=[{
+        "edge_relation": "links", "from_col": "src", "to_col": "dst",
+        "seeds": ["doc-1"], "max_hops": 2, "label": "graph",
+    }],
+)
+```
+
+`extra_lists`, `vector_k`, `fts_k`, `rrf_k`, and future engine keys pass through
+the same way — no adapter release needed when the engine grows new knobs.
+
+## Mem0
+
+The store works as a [Mem0](https://github.com/mem0ai/mem0) vector-store backend
+through Mem0's `provider="langchain"` (it implements the by-vector search, scored
+search, `get_by_ids`, `add_embeddings`, and scalar metadata `filter` calls Mem0's
+wrapper makes — exercised in `tests/test_mem0.py`):
+
+```python
+config = {"vector_store": {"provider": "langchain",
+                           "config": {"client": store, "collection_name": "mem0"}}}
+```
+
 ## License
 
 Mozilla Public License 2.0.

--- a/cozo-lib-python/integrations/langchain-mnestic/langchain_mnestic/__init__.py
+++ b/cozo-lib-python/integrations/langchain-mnestic/langchain_mnestic/__init__.py
@@ -3,4 +3,4 @@
 from langchain_mnestic.vectorstores import MnesticVectorStore
 
 __all__ = ["MnesticVectorStore"]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/cozo-lib-python/integrations/langchain-mnestic/langchain_mnestic/_core.py
+++ b/cozo-lib-python/integrations/langchain-mnestic/langchain_mnestic/_core.py
@@ -7,7 +7,7 @@ Vendored per integration package so each is standalone-installable.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 
 class MnesticStore:
@@ -110,7 +110,16 @@ class MnesticStore:
         *,
         rrf_k: float = 60.0,
         mmr: Optional[Dict[str, Any]] = None,
+        **extra: Any,
     ) -> List[Dict[str, Any]]:
+        """Hybrid (HNSW + FTS -> RRF) search.
+
+        Any extra keyword argument is passed straight through to the engine's
+        ``hybrid_search`` query dict (e.g. ``graph_legs``, ``extra_lists``,
+        ``vector_k``, ``fts_k``), so new engine keys need no adapter change.
+        ``detailed`` is rejected: its long format emits one row per
+        (result, leg) and would surface duplicate ids here.
+        """
         hq: Dict[str, Any] = {
             "relation": self.relation,
             "id_col": self.id_col,
@@ -129,8 +138,60 @@ class MnesticStore:
             mmr = dict(mmr)
             mmr.setdefault("embedding_col", self.emb_col)
             hq["mmr"] = mmr
+        if extra.pop("detailed", None):
+            raise ValueError(
+                "detailed is not supported through the adapter: the long format "
+                "emits one row per (result, leg) and would surface duplicate ids"
+            )
+        hq.update(extra)
         res = self.db.hybrid_search(hq)
         ranked = [(row[0], float(row[1])) for row in res["rows"]][:k]
+        return self._hydrate(ranked)
+
+    def search_by_vector(
+        self,
+        query_vector: Sequence[float],
+        k: int,
+        *,
+        ef: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """Vector-only recall (no FTS leg, no fusion).
+
+        ``score`` is the negated engine distance, so higher = more similar —
+        the same orientation as the hybrid semantic leg. Works on every engine
+        version the adapters support (plain HNSW index search).
+        """
+        vec_call = "vec($qv, 'F64')" if self.dtype == "F64" else "vec($qv)"
+        script = (
+            f"?[id, score] := ~{self.relation}:{self.vector_index}{{ "
+            f"{self.id_col}: id | query: {vec_call}, k: {int(k)}, "
+            f"ef: {int(ef) if ef is not None else max(self.ef_search, k)}, "
+            f"bind_distance: __dist }}, score = -__dist\n"
+            f":order -score\n"
+            f":limit {int(k)}"
+        )
+        res = self.db.run_script(script, {"qv": [float(x) for x in query_vector]}, True)
+        ranked = [(row[0], float(row[1])) for row in res["rows"]]
+        return self._hydrate(ranked)
+
+    def get(self, ids: Sequence[str]) -> List[Dict[str, Any]]:
+        """Keyed lookup by id, preserving input order; missing ids are skipped."""
+        by_id = self._fetch(list(ids))
+        out: List[Dict[str, Any]] = []
+        for rid in ids:
+            row = by_id.get(rid)
+            if row is None:
+                continue
+            out.append(
+                {
+                    "id": rid,
+                    "text": row[1],
+                    "metadata": (row[2] if row[2] is not None else {}),
+                }
+            )
+        return out
+
+    def _hydrate(self, ranked: List[Tuple[str, float]]) -> List[Dict[str, Any]]:
         if not ranked:
             return []
         by_id = self._fetch([rid for rid, _ in ranked])

--- a/cozo-lib-python/integrations/langchain-mnestic/langchain_mnestic/vectorstores.py
+++ b/cozo-lib-python/integrations/langchain-mnestic/langchain_mnestic/vectorstores.py
@@ -9,7 +9,7 @@ creating the HNSW + FTS indices on first use.
 from __future__ import annotations
 
 import uuid
-from typing import Any, Iterable, List, Optional, Tuple
+from typing import Any, Iterable, List, Optional, Sequence, Tuple
 
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
@@ -63,6 +63,28 @@ class MnesticVectorStore(VectorStore):
         embeddings = self._embedding.embed_documents(texts)
         return self._store.add(ids, texts, embeddings, metadatas)
 
+    def add_embeddings(
+        self,
+        embeddings: List[List[float]],
+        metadatas: Optional[List[dict]] = None,
+        *,
+        ids: Optional[List[str]] = None,
+        texts: Optional[Sequence[str]] = None,
+        **kwargs: Any,
+    ) -> List[str]:
+        """Insert precomputed embeddings (no embedding call).
+
+        The indexed text comes from `texts` when given, else from each
+        metadata's `"data"` key (the Mem0 payload convention), else `""`.
+        """
+        if not embeddings:
+            return []
+        metas = list(metadatas) if metadatas is not None else [{} for _ in embeddings]
+        ids = ids or [uuid.uuid4().hex for _ in embeddings]
+        if texts is None:
+            texts = [str((m or {}).get("data", "")) for m in metas]
+        return self._store.add(ids, list(texts), embeddings, metas)
+
     @classmethod
     def from_texts(
         cls,
@@ -89,13 +111,57 @@ class MnesticVectorStore(VectorStore):
     ) -> List[Tuple[Document, float]]:
         query_vector = self._embedding.embed_query(query)
         hits = self._store.search(query_vector, query, k, **kwargs)
-        return [
-            (
-                Document(id=h["id"], page_content=h["text"], metadata={**h["metadata"], "id": h["id"]}),
-                h["score"],
-            )
-            for h in hits
-        ]
+        return [(self._to_document(h), h["score"]) for h in hits]
 
     def similarity_search(self, query: str, k: int = 4, **kwargs: Any) -> List[Document]:
         return [doc for doc, _ in self.similarity_search_with_score(query, k, **kwargs)]
+
+    def similarity_search_with_score_by_vector(
+        self, embedding: List[float], k: int = 4, **kwargs: Any
+    ) -> List[Tuple[Document, float]]:
+        """Vector-only search from a precomputed embedding.
+
+        `score` is the negated engine distance (higher = more similar), unlike
+        the hybrid methods whose score is the RRF fused score. An optional
+        `filter` dict (scalar metadata equality, e.g. `{"user_id": "u1"}` —
+        the shape Mem0 passes) is applied post-search over an over-fetched
+        candidate set; operator filters raise rather than silently match
+        nothing.
+        """
+        metadata_filter = kwargs.pop("filter", None)
+        if metadata_filter:
+            for key, val in metadata_filter.items():
+                if isinstance(val, (dict, list)):
+                    raise ValueError(
+                        f"unsupported filter for {key!r}: only scalar equality "
+                        "filters are supported (got an operator/list form)"
+                    )
+            hits = self._store.search_by_vector(embedding, max(k * 4, 20), **kwargs)
+            hits = [
+                h
+                for h in hits
+                if all(h["metadata"].get(key) == val for key, val in metadata_filter.items())
+            ][:k]
+        else:
+            hits = self._store.search_by_vector(embedding, k, **kwargs)
+        return [(self._to_document(h), h["score"]) for h in hits]
+
+    def similarity_search_by_vector(
+        self, embedding: List[float], k: int = 4, **kwargs: Any
+    ) -> List[Document]:
+        return [
+            doc
+            for doc, _ in self.similarity_search_with_score_by_vector(embedding, k, **kwargs)
+        ]
+
+    def get_by_ids(self, ids: Sequence[str], /) -> List[Document]:
+        """Fetch documents by id, preserving input order; missing ids are skipped."""
+        return [self._to_document(r) for r in self._store.get(list(ids))]
+
+    @staticmethod
+    def _to_document(hit: dict) -> Document:
+        return Document(
+            id=hit["id"],
+            page_content=hit["text"],
+            metadata={**hit["metadata"], "id": hit["id"]},
+        )

--- a/cozo-lib-python/integrations/langchain-mnestic/pyproject.toml
+++ b/cozo-lib-python/integrations/langchain-mnestic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langchain-mnestic"
-version = "0.1.0"
+version = "0.2.0"
 description = "LangChain VectorStore for mnestic — embedded graph + vector + full-text store with one-call hybrid retrieval."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -12,7 +12,7 @@ license = { text = "MPL-2.0" }
 authors = [{ name = "Shan Rizvi" }]
 keywords = ["langchain", "mnestic", "vectorstore", "hybrid-search", "rag", "cozodb"]
 dependencies = [
-    "mnestic>=0.8.2",
+    "mnestic>=0.8.3",
     "langchain-core>=0.3,<2.0",
 ]
 

--- a/cozo-lib-python/integrations/langchain-mnestic/tests/test_mem0.py
+++ b/cozo-lib-python/integrations/langchain-mnestic/tests/test_mem0.py
@@ -1,0 +1,107 @@
+"""Mem0 `provider="langchain"` compatibility, executed — not inferred.
+
+Instantiates Mem0's own Langchain vector-store wrapper around a
+`MnesticVectorStore` and exercises the exact methods the wrapper calls
+(insert -> add_embeddings/add_texts, search -> *_by_vector, get -> get_by_ids,
+delete -> delete). No LLM, no network: skipped unless `mem0ai` (and its
+`langchain-community` import dependency) is installed.
+
+The full `mem0.Memory` pipeline needs an LLM key; an env-gated smoke for that
+lives at the bottom (`MEM0_E2E=1` + `OPENAI_API_KEY`).
+"""
+
+import os
+from typing import List
+
+import pytest
+
+mem0_langchain = pytest.importorskip(
+    "mem0.vector_stores.langchain", reason="mem0ai (+ langchain-community) not installed"
+)
+
+from langchain_core.embeddings import Embeddings
+
+from langchain_mnestic import MnesticVectorStore
+
+
+class TwoDimEmbeddings(Embeddings):
+    """Deterministic 2-D embedder; mem0 supplies vectors itself for search."""
+
+    @staticmethod
+    def _e(t: str) -> List[float]:
+        t = t.lower()
+        return [1.0, 0.0] if "alpha" in t else [0.0, 1.0]
+
+    def embed_documents(self, texts):
+        return [self._e(t) for t in texts]
+
+    def embed_query(self, text):
+        return self._e(text)
+
+
+def _wrapper():
+    store = MnesticVectorStore(TwoDimEmbeddings(), engine="mem", dim=2)
+    return mem0_langchain.Langchain(client=store, collection_name="mem0"), store
+
+
+def test_mem0_wrapper_insert_search_get_delete():
+    wrapper, _store = _wrapper()
+
+    # insert: prefers add_embeddings(embeddings=, metadatas=, ids=) when present.
+    wrapper.insert(
+        vectors=[[1.0, 0.0], [0.0, 1.0]],
+        payloads=[
+            {"data": "alpha memory", "user_id": "u1"},
+            {"data": "omega memory", "user_id": "u2"},
+        ],
+        ids=["m1", "m2"],
+    )
+
+    # search: by-vector with real scores (similarity_search_with_score_by_vector).
+    results = wrapper.search(query="alpha", vectors=[1.0, 0.0], top_k=1)
+    assert results, "mem0 search returned nothing"
+    top = results[0]
+    assert top.id == "m1"
+    assert top.payload.get("data") == "alpha memory"
+    assert top.score is not None
+
+    # search with filters — the shape every real mem0 Memory call uses
+    # (user_id scoping). Must return only u2's memory despite the query
+    # vector pointing at u1's.
+    scoped = wrapper.search(query="alpha", vectors=[1.0, 0.0], top_k=5, filters={"user_id": "u2"})
+    assert [r.id for r in scoped] == ["m2"]
+
+    # get: get_by_ids under the hood.
+    got = wrapper.get("m2")
+    assert got is not None
+    assert got.id == "m2"
+
+    # update: delete + insert under the hood.
+    wrapper.update("m2", vector=[0.0, 1.0], payload={"data": "omega revised", "user_id": "u2"})
+    assert wrapper.get("m2").payload.get("data") == "omega revised"
+
+    # delete
+    wrapper.delete("m1")
+    after = wrapper.search(query="alpha", vectors=[1.0, 0.0], top_k=2)
+    assert all(r.id != "m1" for r in after)
+
+
+@pytest.mark.skipif(
+    not (os.environ.get("MEM0_E2E") and os.environ.get("OPENAI_API_KEY")),
+    reason="full-pipeline e2e is env-gated (MEM0_E2E=1 + OPENAI_API_KEY)",
+)
+def test_mem0_full_memory_pipeline():
+    from mem0 import Memory
+
+    store = MnesticVectorStore(TwoDimEmbeddings(), engine="mem", dim=1536)
+    m = Memory.from_config(
+        {
+            "vector_store": {
+                "provider": "langchain",
+                "config": {"client": store, "collection_name": "mem0"},
+            }
+        }
+    )
+    m.add("I prefer window seats on long flights.", user_id="u1")
+    found = m.search("what seats does the user like?", user_id="u1")
+    assert found.get("results")

--- a/cozo-lib-python/integrations/langchain-mnestic/tests/test_vectorstore.py
+++ b/cozo-lib-python/integrations/langchain-mnestic/tests/test_vectorstore.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 from typing import List
 
+import pytest
 from langchain_core.embeddings import Embeddings
 
 from langchain_mnestic import MnesticVectorStore
@@ -64,3 +65,104 @@ def test_sqlite_persistence_across_reopen():
     reopened = MnesticVectorStore(KeywordEmbeddings(), db=CozoDbPy("sqlite", path, "{}"), dim=2)
     hits = reopened.similarity_search("dog", k=2)
     assert hits[0].page_content == "a dog ran in the park"
+
+
+# --- graph_legs / pass-through (the un-stranded engine surface) ---
+#
+# Corpus with a strict vector gradient for the query "alpha" so the hybrid
+# ranking is deterministic: vector order a > b > c > d, FTS matches only a.
+# An edge a -> d then lets a graph leg boost d above b — the ranking MUST
+# change when graph_legs is supplied, which is exactly what the old adapter
+# (dropping the kwarg) could never do.
+
+GRADIENT = {
+    "alpha": [1.0, 0.0],
+    "beta": [0.95, 0.05],
+    "gamma": [0.85, 0.15],
+    "delta": [0.7, 0.3],
+}
+
+
+class GradientEmbeddings(Embeddings):
+    @staticmethod
+    def _e(t: str) -> List[float]:
+        t = t.lower()
+        for tok, v in GRADIENT.items():
+            if tok in t:
+                return list(v)
+        return [0.5, 0.5]
+
+    def embed_documents(self, texts):
+        return [self._e(t) for t in texts]
+
+    def embed_query(self, text):
+        return self._e(text)
+
+
+GRAPH_IDS = ["a", "b", "c", "d"]
+GRAPH_TEXTS = ["alpha doc", "beta doc", "gamma doc", "delta doc"]
+
+# 0.12.2-safe leg shape: single leg, unique label, explicit cols, client seeds.
+GRAPH_LEG = {
+    "edge_relation": "links",
+    "from_col": "src",
+    "to_col": "dst",
+    "seeds": ["a"],
+    "max_hops": 1,
+    "label": "graph",
+}
+
+
+def _graph_store() -> MnesticVectorStore:
+    s = MnesticVectorStore.from_texts(
+        GRAPH_TEXTS,
+        GradientEmbeddings(),
+        metadatas=[{"i": i} for i in GRAPH_IDS],
+        ids=GRAPH_IDS,
+        engine="mem",
+    )
+    db = s._store.db
+    db.run_script(":create links {src: String, dst: String}", {}, False)
+    db.run_script("?[src, dst] <- [['a', 'd']] :put links {src, dst}", {}, False)
+    return s
+
+
+def test_graph_legs_change_ranking():
+    s = _graph_store()
+    base = [d.id for d in s.similarity_search("alpha", k=4)]
+    assert base == ["a", "b", "c", "d"]
+
+    boosted = [d.id for d in s.similarity_search("alpha", k=4, graph_legs=[GRAPH_LEG])]
+    assert boosted != base
+    assert boosted.index("d") < boosted.index("b")
+
+
+def test_detailed_rejected():
+    s = _graph_store()
+    with pytest.raises(ValueError, match="detailed"):
+        s.similarity_search("alpha", k=2, detailed=True)
+
+
+def test_by_vector_and_get_by_ids():
+    s = _graph_store()
+    hits = s.similarity_search_with_score_by_vector(GRADIENT["alpha"], k=2)
+    assert [d.id for d, _ in hits] == ["a", "b"]
+    assert hits[0][1] >= hits[1][1]
+
+    docs = s.get_by_ids(["b", "missing", "a"])
+    assert [d.id for d in docs] == ["b", "a"]
+    assert docs[0].page_content == "beta doc"
+
+
+def test_add_embeddings_mem0_convention():
+    s = MnesticVectorStore(GradientEmbeddings(), engine="mem", dim=2)
+    ids = s.add_embeddings(
+        embeddings=[[1.0, 0.0], [0.0, 1.0]],
+        metadatas=[{"data": "alpha memory"}, {"data": "omega memory"}],
+        ids=["m1", "m2"],
+    )
+    assert ids == ["m1", "m2"]
+
+    hits = s.similarity_search_with_score_by_vector([1.0, 0.0], k=1)
+    assert hits[0][0].id == "m1"
+    assert hits[0][0].page_content == "alpha memory"

--- a/cozo-lib-python/integrations/llama-index-vector-stores-mnestic/README.md
+++ b/cozo-lib-python/integrations/llama-index-vector-stores-mnestic/README.md
@@ -28,6 +28,26 @@ nodes = index.as_retriever(similarity_top_k=4).retrieve("feline")
 `dim` must match your embedding model's dimension. `query` runs hybrid search when
 the query carries text (the usual index path), otherwise vector-only.
 
+## Engine pass-through: graph legs and more
+
+Extra keyword arguments flow from the retriever to the engine's hybrid query via
+`vector_store_kwargs`. That includes **`graph_legs`** — fuse graph proximity into
+the ranking alongside the dense and keyword legs, in the same single call:
+
+```python
+retriever = index.as_retriever(
+    similarity_top_k=4,
+    vector_store_kwargs={"graph_legs": [{
+        "edge_relation": "links", "from_col": "src", "to_col": "dst",
+        "seeds": ["doc-1"], "max_hops": 2, "label": "graph",
+    }]},
+)
+```
+
+`MnesticRetriever(..., search_kwargs={...})` forwards the same way, and so do
+`extra_lists`, `vector_k`, `fts_k`, `rrf_k`, and future engine keys — no adapter
+release needed when the engine grows new knobs.
+
 ## License
 
 Mozilla Public License 2.0.

--- a/cozo-lib-python/integrations/llama-index-vector-stores-mnestic/llama_index/vector_stores/mnestic/__init__.py
+++ b/cozo-lib-python/integrations/llama-index-vector-stores-mnestic/llama_index/vector_stores/mnestic/__init__.py
@@ -3,4 +3,4 @@
 from llama_index.vector_stores.mnestic.base import MnesticRetriever, MnesticVectorStore
 
 __all__ = ["MnesticVectorStore", "MnesticRetriever"]
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/cozo-lib-python/integrations/llama-index-vector-stores-mnestic/llama_index/vector_stores/mnestic/_core.py
+++ b/cozo-lib-python/integrations/llama-index-vector-stores-mnestic/llama_index/vector_stores/mnestic/_core.py
@@ -7,7 +7,7 @@ Vendored per integration package so each is standalone-installable.
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 
 class MnesticStore:
@@ -110,7 +110,16 @@ class MnesticStore:
         *,
         rrf_k: float = 60.0,
         mmr: Optional[Dict[str, Any]] = None,
+        **extra: Any,
     ) -> List[Dict[str, Any]]:
+        """Hybrid (HNSW + FTS -> RRF) search.
+
+        Any extra keyword argument is passed straight through to the engine's
+        ``hybrid_search`` query dict (e.g. ``graph_legs``, ``extra_lists``,
+        ``vector_k``, ``fts_k``), so new engine keys need no adapter change.
+        ``detailed`` is rejected: its long format emits one row per
+        (result, leg) and would surface duplicate ids here.
+        """
         hq: Dict[str, Any] = {
             "relation": self.relation,
             "id_col": self.id_col,
@@ -129,8 +138,60 @@ class MnesticStore:
             mmr = dict(mmr)
             mmr.setdefault("embedding_col", self.emb_col)
             hq["mmr"] = mmr
+        if extra.pop("detailed", None):
+            raise ValueError(
+                "detailed is not supported through the adapter: the long format "
+                "emits one row per (result, leg) and would surface duplicate ids"
+            )
+        hq.update(extra)
         res = self.db.hybrid_search(hq)
         ranked = [(row[0], float(row[1])) for row in res["rows"]][:k]
+        return self._hydrate(ranked)
+
+    def search_by_vector(
+        self,
+        query_vector: Sequence[float],
+        k: int,
+        *,
+        ef: Optional[int] = None,
+    ) -> List[Dict[str, Any]]:
+        """Vector-only recall (no FTS leg, no fusion).
+
+        ``score`` is the negated engine distance, so higher = more similar —
+        the same orientation as the hybrid semantic leg. Works on every engine
+        version the adapters support (plain HNSW index search).
+        """
+        vec_call = "vec($qv, 'F64')" if self.dtype == "F64" else "vec($qv)"
+        script = (
+            f"?[id, score] := ~{self.relation}:{self.vector_index}{{ "
+            f"{self.id_col}: id | query: {vec_call}, k: {int(k)}, "
+            f"ef: {int(ef) if ef is not None else max(self.ef_search, k)}, "
+            f"bind_distance: __dist }}, score = -__dist\n"
+            f":order -score\n"
+            f":limit {int(k)}"
+        )
+        res = self.db.run_script(script, {"qv": [float(x) for x in query_vector]}, True)
+        ranked = [(row[0], float(row[1])) for row in res["rows"]]
+        return self._hydrate(ranked)
+
+    def get(self, ids: Sequence[str]) -> List[Dict[str, Any]]:
+        """Keyed lookup by id, preserving input order; missing ids are skipped."""
+        by_id = self._fetch(list(ids))
+        out: List[Dict[str, Any]] = []
+        for rid in ids:
+            row = by_id.get(rid)
+            if row is None:
+                continue
+            out.append(
+                {
+                    "id": rid,
+                    "text": row[1],
+                    "metadata": (row[2] if row[2] is not None else {}),
+                }
+            )
+        return out
+
+    def _hydrate(self, ranked: List[Tuple[str, float]]) -> List[Dict[str, Any]]:
         if not ranked:
             return []
         by_id = self._fetch([rid for rid, _ in ranked])

--- a/cozo-lib-python/integrations/llama-index-vector-stores-mnestic/llama_index/vector_stores/mnestic/base.py
+++ b/cozo-lib-python/integrations/llama-index-vector-stores-mnestic/llama_index/vector_stores/mnestic/base.py
@@ -67,9 +67,18 @@ class MnesticVectorStore(BasePydanticVectorStore):
         self._store.delete([ref_doc_id])
 
     def query(self, query: VectorStoreQuery, **kwargs: Any) -> VectorStoreQueryResult:
+        """Hybrid search; vector-only when the query carries no `query_str`.
+
+        Extra keyword arguments (e.g. from the retriever's
+        `vector_store_kwargs`) are forwarded to the engine's hybrid query —
+        `graph_legs`, `extra_lists`, `vector_k`, `fts_k`, ...
+        """
         k = query.similarity_top_k or 4
         query_str = query.query_str or ""
-        hits = self._store.search(query.query_embedding, query_str, k)
+        if not query_str and not kwargs:
+            hits = self._store.search_by_vector(query.query_embedding, k)
+        else:
+            hits = self._store.search(query.query_embedding, query_str, k, **kwargs)
         nodes: List[TextNode] = []
         similarities: List[float] = []
         ids: List[str] = []
@@ -81,7 +90,12 @@ class MnesticVectorStore(BasePydanticVectorStore):
 
 
 class MnesticRetriever(BaseRetriever):
-    """Direct hybrid retriever over a `MnesticVectorStore` + an embed model."""
+    """Direct hybrid retriever over a `MnesticVectorStore` + an embed model.
+
+    `search_kwargs` are forwarded to every query — e.g.
+    `search_kwargs={"graph_legs": [...]}` adds a graph-proximity leg to the
+    hybrid fusion.
+    """
 
     def __init__(
         self,
@@ -89,10 +103,12 @@ class MnesticRetriever(BaseRetriever):
         embed_model: Any,
         similarity_top_k: int = 4,
         callback_manager: Optional[Any] = None,
+        search_kwargs: Optional[dict] = None,
     ) -> None:
         self._vector_store = vector_store
         self._embed_model = embed_model
         self._similarity_top_k = similarity_top_k
+        self._search_kwargs = dict(search_kwargs or {})
         super().__init__(callback_manager=callback_manager)
 
     def _retrieve(self, query_bundle: QueryBundle) -> List[NodeWithScore]:
@@ -104,7 +120,8 @@ class MnesticRetriever(BaseRetriever):
                 query_embedding=embedding,
                 query_str=query_bundle.query_str,
                 similarity_top_k=self._similarity_top_k,
-            )
+            ),
+            **self._search_kwargs,
         )
         nodes: List[NodeWithScore] = []
         for i, node in enumerate(result.nodes or []):

--- a/cozo-lib-python/integrations/llama-index-vector-stores-mnestic/pyproject.toml
+++ b/cozo-lib-python/integrations/llama-index-vector-stores-mnestic/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "llama-index-vector-stores-mnestic"
-version = "0.1.0"
+version = "0.2.0"
 description = "LlamaIndex vector store for mnestic — embedded graph + vector + full-text store with one-call hybrid retrieval."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -12,7 +12,7 @@ license = { text = "MPL-2.0" }
 authors = [{ name = "Shan Rizvi" }]
 keywords = ["llamaindex", "llama-index", "mnestic", "vector-store", "hybrid-search", "rag", "cozodb"]
 dependencies = [
-    "mnestic>=0.8.2",
+    "mnestic>=0.8.3",
     "llama-index-core>=0.12,<0.15",
 ]
 

--- a/cozo-lib-python/integrations/llama-index-vector-stores-mnestic/tests/test_vectorstore.py
+++ b/cozo-lib-python/integrations/llama-index-vector-stores-mnestic/tests/test_vectorstore.py
@@ -57,3 +57,106 @@ def test_mnestic_retriever_hybrid():
     vs, _index_ = _index()
     nodes = MnesticRetriever(vs, KeywordEmbedding(), similarity_top_k=2).retrieve("dog")
     assert nodes[0].node.get_content() == "a dog ran in the park"
+
+
+# --- graph_legs / pass-through (the previously-dropped **kwargs) ---
+#
+# Strict vector gradient for the query "alpha" (a > b > c > d), FTS matches
+# only a, and an edge a -> d lets a graph leg boost d above b. The old
+# `query()` dropped **kwargs on the floor and silently returned graph-blind
+# results — these tests fail against that behavior.
+
+from llama_index.core.schema import TextNode  # noqa: E402
+from llama_index.core.vector_stores.types import VectorStoreQuery  # noqa: E402
+
+GRADIENT = {
+    "alpha": [1.0, 0.0],
+    "beta": [0.95, 0.05],
+    "gamma": [0.85, 0.15],
+    "delta": [0.7, 0.3],
+}
+
+GRAPH_LEG = {
+    "edge_relation": "links",
+    "from_col": "src",
+    "to_col": "dst",
+    "seeds": ["a"],
+    "max_hops": 1,
+    "label": "graph",
+}
+
+
+def _gvec(t: str) -> List[float]:
+    t = t.lower()
+    for tok, v in GRADIENT.items():
+        if tok in t:
+            return list(v)
+    return [0.5, 0.5]
+
+
+class GradientEmbedding(BaseEmbedding):
+    def _get_query_embedding(self, query: str) -> List[float]:
+        return _gvec(query)
+
+    def _get_text_embedding(self, text: str) -> List[float]:
+        return _gvec(text)
+
+    async def _aget_query_embedding(self, query: str) -> List[float]:
+        return _gvec(query)
+
+    async def _aget_text_embedding(self, text: str) -> List[float]:
+        return _gvec(text)
+
+
+def _graph_vs() -> MnesticVectorStore:
+    vs = MnesticVectorStore(dim=2, engine="mem")
+    nodes = [
+        TextNode(id_=i, text=f"{tok} doc", embedding=_gvec(tok))
+        for i, tok in zip("abcd", ["alpha", "beta", "gamma", "delta"])
+    ]
+    vs.add(nodes)
+    db = vs.client
+    db.run_script(":create links {src: String, dst: String}", {}, False)
+    db.run_script("?[src, dst] <- [['a', 'd']] :put links {src, dst}", {}, False)
+    return vs
+
+
+def test_graph_legs_change_ranking_direct_query():
+    vs = _graph_vs()
+    q = VectorStoreQuery(query_embedding=GRADIENT["alpha"], query_str="alpha", similarity_top_k=4)
+    base = list(vs.query(q).ids)
+    assert base == ["a", "b", "c", "d"]
+
+    boosted = list(vs.query(q, graph_legs=[GRAPH_LEG]).ids)
+    assert boosted != base
+    assert boosted.index("d") < boosted.index("b")
+
+
+def test_graph_legs_through_index_retriever():
+    vs = _graph_vs()
+    index = VectorStoreIndex.from_vector_store(vs, embed_model=GradientEmbedding())
+    base = [n.node.node_id for n in index.as_retriever(similarity_top_k=4).retrieve("alpha")]
+    boosted = [
+        n.node.node_id
+        for n in index.as_retriever(
+            similarity_top_k=4, vector_store_kwargs={"graph_legs": [GRAPH_LEG]}
+        ).retrieve("alpha")
+    ]
+    assert boosted != base
+    assert boosted.index("d") < boosted.index("b")
+
+
+def test_mnestic_retriever_search_kwargs():
+    vs = _graph_vs()
+    r = MnesticRetriever(
+        vs, GradientEmbedding(), similarity_top_k=4, search_kwargs={"graph_legs": [GRAPH_LEG]}
+    )
+    ids = [n.node.node_id for n in r.retrieve("alpha")]
+    assert ids.index("d") < ids.index("b")
+
+
+def test_vector_only_when_no_query_str():
+    vs = _graph_vs()
+    res = vs.query(VectorStoreQuery(query_embedding=GRADIENT["alpha"], similarity_top_k=2))
+    assert list(res.ids) == ["a", "b"]
+    assert all(s is not None for s in res.similarities)


### PR DESCRIPTION
## What

Un-strands the three engine fields (`graph_legs`, `extra_lists`, `detailed`) that shipped in PyPI `mnestic` 0.8.3 and have been unreachable from both framework adapters for 14 consecutive releases (MNESTIC-ROADMAP Tier D item 0, decisions 18e/22).

- **`_core.py`** (both vendored copies, byte-identical — now CI-guarded): `search(**extra)` forwards unknown keys into the engine's `hybrid_search` dict, so 0.13.0+ keys reach both frameworks with zero adapter work. `detailed` is rejected loudly. New `search_by_vector()` (plain HNSW leg, works back to the 0.8.3 floor) + `get()`.
- **LlamaIndex `base.py`**: `query()` no longer drops `**kwargs` on the floor — the silent graph-blind-results bug. Vector-only fallback when the query has no `query_str` (matches its own docstring). `MnesticRetriever(search_kwargs=...)`.
- **LangChain `vectorstores.py`**: `similarity_search_by_vector`, `similarity_search_with_score_by_vector` (incl. the scalar metadata `filter` Mem0 always passes), `get_by_ids`, `add_embeddings` — exactly the surface `mem0`'s `provider="langchain"` wrapper calls.
- **Versions**: both `0.1.0 → 0.2.0` (both publish jobs use `skip-existing: true`, so an unbumped publish is a silent no-op); `mnestic` floor `>=0.8.2 → >=0.8.3`.
- **CI**: new `test-integrations` job running both pytest suites against the published mnestic wheel + a `_core.py` byte-parity diff; adapter publish jobs gate on it.

## Tests (discriminating — the pre-existing 5 could not see this fix)

- Ranking provably **changes** when `graph_legs` is supplied (strict vector gradient a>b>c>d + edge a→d ⇒ `[a,b,c,d] → [a,d,b,c]`), on both adapters, through both the direct query and retriever (`vector_store_kwargs`) paths. 0.12.2-safe leg shape (single leg, unique label, client-side seeds).
- Mem0 unlock **executed, not inferred**: `mem0ai` 2.0.12's own `Langchain` wrapper driven end-to-end (insert via `add_embeddings`, scored by-vector search, `user_id` filter scoping, get, update, delete). Full `Memory` pipeline e2e is env-gated (`MEM0_E2E=1`).
- Local run: langchain 8 passed + 1 skipped; llama-index 6 passed (Python 3.13, mnestic 0.12.2, langchain-core 1.4.9, llama-index-core 0.14.23).

## Publish gate

Built and tested against the published 0.12.2 wheel, but **must not publish before mnestic ≥0.13.0 ships** — `graph_legs`'s duplicate-label + seed-rescoring fixes are only on `main`. Publishing is a separate `workflow_dispatch publish=true` after the engine release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)