### PR TITLE
Tier D item 3: mnestic-mcp 0.1.0 (local memory MCP server)

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pkg: [langchain-mnestic, llama-index-vector-stores-mnestic, langgraph-store-mnestic]
+        pkg: [langchain-mnestic, llama-index-vector-stores-mnestic, langgraph-store-mnestic, mnestic-mcp]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -159,6 +159,8 @@ jobs:
             deps: llama-index-core
           - pkg: langgraph-store-mnestic
             deps: '"langgraph-checkpoint>=4.1,<5" "langgraph>=1.0"'
+          - pkg: mnestic-mcp
+            deps: '"mcp>=1.27,<2" "fastembed>=0.8"'
     steps:
       - uses: actions/checkout@v4
       - name: vendored _core.py copies must stay byte-identical
@@ -304,6 +306,21 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with: { name: dist-langgraph-store-mnestic, path: dist }
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          skip-existing: true
+
+  publish-mnestic-mcp:
+    needs: [build-adapters, test-wheels, test-integrations]
+    if: github.event_name == 'push' || inputs.publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with: { name: dist-mnestic-mcp, path: dist }
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -130,7 +130,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pkg: [langchain-mnestic, llama-index-vector-stores-mnestic]
+        pkg: [langchain-mnestic, llama-index-vector-stores-mnestic, langgraph-store-mnestic]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -157,6 +157,8 @@ jobs:
             deps: langchain-core mem0ai langchain-community
           - pkg: llama-index-vector-stores-mnestic
             deps: llama-index-core
+          - pkg: langgraph-store-mnestic
+            deps: '"langgraph-checkpoint>=4.1,<5" "langgraph>=1.0"'
     steps:
       - uses: actions/checkout@v4
       - name: vendored _core.py copies must stay byte-identical
@@ -287,6 +289,21 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with: { name: dist-llama-index-vector-stores-mnestic, path: dist }
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+          skip-existing: true
+
+  publish-langgraph-store-mnestic:
+    needs: [build-adapters, test-wheels, test-integrations]
+    if: github.event_name == 'push' || inputs.publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with: { name: dist-langgraph-store-mnestic, path: dist }
       - uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: dist

--- a/cozo-lib-python/integrations/langgraph-store-mnestic/README.md
+++ b/cozo-lib-python/integrations/langgraph-store-mnestic/README.md
@@ -1,0 +1,90 @@
+# langgraph-store-mnestic
+
+A [LangGraph](https://github.com/langchain-ai/langgraph) `BaseStore` backed by
+[mnestic](https://github.com/shuruheel/mnestic) — an embedded graph + vector +
+full-text database (a maintained fork of CozoDB). One process, one file, no
+server: agent long-term memory with **atomic batches** and **in-engine hybrid
+retrieval** (BM25 + vector fused with Reciprocal Rank Fusion — a fusion that
+Postgres + pgvector, LangGraph's default production store, cannot do in one
+system).
+
+> mnestic is a maintained fork of [CozoDB](https://github.com/cozodb/cozo); it is not the official CozoDB. Original design credit belongs to Ziyang Hu and the Cozo Project Authors.
+
+```bash
+pip install langgraph-store-mnestic
+```
+
+```python
+from langgraph_store_mnestic import MnesticStore
+
+store = MnesticStore(
+    engine="sqlite", path="memory.db",          # or engine="mem" for ephemeral
+    index={"dims": 1536, "embed": my_embed_fn}, # any LangGraph IndexConfig embed
+    ttl={"default_ttl": 60 * 24, "refresh_on_read": True},  # optional
+)
+
+store.put(("users", "u1"), "pref", {"text": "prefers window seats"})
+hits = store.search(("users", "u1"), query="seating preference")
+```
+
+Use it in a graph like any store:
+
+```python
+graph = builder.compile(store=store)
+```
+
+## What you get
+
+- **Atomic `batch()`** — every write in a batch lands in one engine
+  transaction. Under LangGraph's parallel fan-out this is the difference
+  between correct recall and silently losing reads (a non-atomic prototype
+  lost 36% of concurrent semantic reads; this store's concurrency suite
+  gates on zero).
+- **Hybrid `search(query=...)`** — BM25 keyword + HNSW vector legs, namespace
+  filter pushed into both index searches, RRF-fused and hydrated in a single
+  engine snapshot. Without an `index` config the store is BM25-only (keyword
+  search still works, no embeddings needed).
+- **Collision-safe namespaces** — any label content stays distinct
+  (`('a.b',)` can never collide with `('a', 'b')`).
+- **TTL** — per-item or `default_ttl` (minutes), lazy expiry on every read
+  path, optional refresh-on-read, and a `start_ttl_sweeper()` background
+  reclaimer.
+- **Sync + async** — full `BaseStore` surface; `a*` methods run the sync
+  engine calls on the default executor.
+
+## LangGraph Platform (`langgraph.json`)
+
+Custom stores are loadable by import path (alpha upstream feature):
+
+```python
+# src/agent/store.py
+from contextlib import asynccontextmanager
+from langgraph_store_mnestic import MnesticStore
+
+@asynccontextmanager
+async def generate_store():
+    store = MnesticStore(engine="sqlite", path="memory.db", index={...})
+    try:
+        yield store
+    finally:
+        store.close()
+```
+
+```json
+{ "store": { "path": "./src/agent/store.py:generate_store" } }
+```
+
+## Notes
+
+- Requires Python ≥ 3.10 and `langgraph-checkpoint >= 4.1`.
+- The wheel build of `mnestic` ships `mem`, `sqlite`, and `rocksdb` engines
+  (the sdist has no rocksdb).
+- The text index applies English stemming + stopwords: queries made only of
+  very common words match nothing on the keyword leg (the vector leg still
+  answers when an `index` config is present).
+- Filter operators supported in `search(filter=...)`: `$eq`, `$ne`, `$gt`,
+  `$gte`, `$lt`, `$lte`, with `InMemoryStore`-parity semantics.
+
+## License
+
+Mozilla Public License 2.0.

--- a/cozo-lib-python/integrations/langgraph-store-mnestic/langgraph_store_mnestic/__init__.py
+++ b/cozo-lib-python/integrations/langgraph-store-mnestic/langgraph_store_mnestic/__init__.py
@@ -1,0 +1,7 @@
+"""LangGraph BaseStore backed by mnestic (embedded graph + vector + full-text
+store with in-engine hybrid retrieval)."""
+
+from langgraph_store_mnestic.store import MnesticStore
+
+__all__ = ["MnesticStore"]
+__version__ = "0.1.0"

--- a/cozo-lib-python/integrations/langgraph-store-mnestic/langgraph_store_mnestic/_filters.py
+++ b/cozo-lib-python/integrations/langgraph-store-mnestic/langgraph_store_mnestic/_filters.py
@@ -1,0 +1,55 @@
+"""SearchOp filter semantics — a faithful port of the reference behavior in
+`langgraph.store.memory` (`_compare_values` / `_apply_operator`), so filters
+behave identically to `InMemoryStore` / the Postgres store: top-level keys into
+the value dict, nested matching via nested dicts, `$eq/$ne/$gt/$gte/$lt/$lte`
+operators, JSONB-style list equality.
+
+Reimplemented (not imported) because upstream keeps these private.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+
+def item_matches(value: Dict[str, Any], filter_: Optional[Dict[str, Any]]) -> bool:
+    if not filter_:
+        return True
+    return all(compare_values(value.get(key), fv) for key, fv in filter_.items())
+
+
+def compare_values(item_value: Any, filter_value: Any) -> bool:
+    if isinstance(filter_value, dict):
+        if any(k.startswith("$") for k in filter_value):
+            return all(
+                _apply_operator(item_value, op_key, op_value)
+                for op_key, op_value in filter_value.items()
+            )
+        if not isinstance(item_value, dict):
+            return False
+        return all(compare_values(item_value.get(k), v) for k, v in filter_value.items())
+    elif isinstance(filter_value, (list, tuple)):
+        return (
+            isinstance(item_value, (list, tuple))
+            and len(item_value) == len(filter_value)
+            and all(compare_values(iv, fv) for iv, fv in zip(item_value, filter_value))
+        )
+    else:
+        return item_value == filter_value
+
+
+def _apply_operator(value: Any, operator: str, op_value: Any) -> bool:
+    if operator == "$eq":
+        return value == op_value
+    elif operator == "$gt":
+        return float(value) > float(op_value)
+    elif operator == "$gte":
+        return float(value) >= float(op_value)
+    elif operator == "$lt":
+        return float(value) < float(op_value)
+    elif operator == "$lte":
+        return float(value) <= float(op_value)
+    elif operator == "$ne":
+        return value != op_value
+    else:
+        raise ValueError(f"Unsupported operator: {operator}")

--- a/cozo-lib-python/integrations/langgraph-store-mnestic/langgraph_store_mnestic/_ns.py
+++ b/cozo-lib-python/integrations/langgraph-store-mnestic/langgraph_store_mnestic/_ns.py
@@ -1,0 +1,95 @@
+"""Collision-safe namespace tuple <-> storage key encoding.
+
+Every label is escaped and terminated with a separator, so:
+
+- the encoding is injective for *any* label content (labels containing the
+  separator, the escape, or dots all stay distinct — ``('a.b',)`` can never
+  collide with ``('a', 'b')``);
+- ``enc(p)`` is a string prefix of ``enc(ns)`` iff ``p`` is a tuple prefix of
+  ``ns`` (the trailing separator stops ``('a',)`` from matching ``('ab',)``),
+  which lets ``starts_with(ns, $prefix)`` implement ``namespace_prefix`` as a
+  pushed-down key range scan in the engine.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Sequence, Tuple
+
+SEP = "\x1f"
+ESC = "\x1e"
+
+
+def _esc(label: str) -> str:
+    return label.replace(ESC, ESC + ESC).replace(SEP, ESC + "S")
+
+
+def encode_ns(namespace: Sequence[str]) -> str:
+    """Encode a namespace tuple as a sortable, prefix-searchable string key."""
+    return "".join(_esc(label) + SEP for label in namespace)
+
+
+def encode_prefix(prefix: Sequence[str]) -> str:
+    """Encode a namespace-prefix tuple; `()` encodes to `""` (matches all)."""
+    return encode_ns(prefix)
+
+
+def decode_ns(encoded: str) -> Tuple[str, ...]:
+    """Inverse of `encode_ns` (used for debugging/tests; reads use ns_parts)."""
+    labels: List[str] = []
+    cur: List[str] = []
+    i = 0
+    while i < len(encoded):
+        ch = encoded[i]
+        if ch == ESC:
+            nxt = encoded[i + 1]
+            cur.append(ESC if nxt == ESC else SEP)
+            i += 2
+        elif ch == SEP:
+            labels.append("".join(cur))
+            cur = []
+            i += 1
+        else:
+            cur.append(ch)
+            i += 1
+    if cur:
+        raise ValueError(f"truncated namespace encoding: {encoded!r}")
+    return tuple(labels)
+
+
+def matches_condition(condition: Any, namespace: Tuple[str, ...]) -> bool:
+    """`ListNamespacesOp` match-condition semantics — a faithful port of the
+    reference `_does_match` in `langgraph.store.memory` (prefix/suffix with
+    `"*"` wildcards)."""
+    match_type = condition.match_type
+    path = condition.path
+    if len(namespace) < len(path):
+        return False
+    if match_type == "prefix":
+        pairs = zip(namespace, path)
+    elif match_type == "suffix":
+        pairs = zip(reversed(namespace), reversed(path))
+    else:
+        raise ValueError(f"Unsupported match type: {match_type}")
+    for label, p_elem in pairs:
+        if p_elem == "*":
+            continue
+        if label != p_elem:
+            return False
+    return True
+
+
+def validate_namespace(namespace: Sequence[str]) -> Tuple[str, ...]:
+    """Structural validation for ops arriving via `batch()` directly.
+
+    Deliberately weaker than upstream's `put()`-level `_validate_namespace`
+    (which also rejects periods): the encoding above makes any label content
+    collision-safe, so `batch()` only enforces shape. The user-facing `put()`
+    wrapper still applies upstream's stricter rules before we ever see the op.
+    """
+    ns = tuple(namespace)
+    if not ns:
+        raise ValueError("Namespace cannot be empty")
+    for label in ns:
+        if not isinstance(label, str) or not label:
+            raise ValueError(f"Namespace labels must be non-empty strings, got {ns!r}")
+    return ns

--- a/cozo-lib-python/integrations/langgraph-store-mnestic/langgraph_store_mnestic/_schema.py
+++ b/cozo-lib-python/integrations/langgraph-store-mnestic/langgraph_store_mnestic/_schema.py
@@ -1,0 +1,107 @@
+"""Idempotent schema management for the two store relations + their indexes.
+
+Layout (`{prefix}` defaults to `lg_store`):
+
+- `{prefix}_items {ns, key => value, ns_parts, created_at, updated_at,
+  expires_at, ttl_minutes}` — the item payloads. `ns` is the collision-safe
+  encoded namespace (see `_ns.py`), `ns_parts` the original tuple so reads
+  never decode. Timestamps are epoch seconds (Float); `expires_at` /
+  `ttl_minutes` are nullable.
+- `{prefix}_vecs {ns, key, field, seq => text[, emb]}` — one row per
+  (item, indexed-field-path, text-instance). `text` feeds the BM25 index;
+  `emb` exists only when the store is built with an IndexConfig. Both search
+  legs run over this relation, so BM25 and vector search index identical text.
+
+Indexes (created before any data — safe for continuous writes):
+`{prefix}_vecs:sem` (HNSW, only with an IndexConfig) and `{prefix}_vecs:txt`
+(FTS with Lowercase/Stemmer/Stopwords — note aggressive stopwording: queries
+made only of common words like "hello" match nothing on the text leg).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+_IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+
+ITEM_VALUE_COLS = "value, ns_parts, created_at, updated_at, expires_at, ttl_minutes"
+
+
+def ensure_schema(
+    db: Any,
+    prefix: str,
+    dims: Optional[int],
+    distance: str,
+    m: int,
+    ef_construction: int,
+) -> None:
+    for name, val in (("relation_prefix", prefix), ("distance", distance)):
+        if not _IDENT.match(val):
+            raise ValueError(f"{name} must be a bare identifier, got {val!r}")
+
+    items, vecs = f"{prefix}_items", f"{prefix}_vecs"
+    rels = {r[0] for r in db.run_script("::relations", {}, True)["rows"]}
+
+    if items not in rels:
+        db.run_script(
+            f":create {items} {{ns: String, key: String => value: Json, "
+            f"ns_parts: [String], created_at: Float, updated_at: Float, "
+            f"expires_at: Float?, ttl_minutes: Float?}}",
+            {},
+            False,
+        )
+    if vecs not in rels:
+        emb = f", emb: <F32; {int(dims)}>" if dims else ""
+        db.run_script(
+            f":create {vecs} {{ns: String, key: String, field: String, seq: Int => "
+            f"text: String{emb}}}",
+            {},
+            False,
+        )
+    else:
+        _validate_vecs_columns(db, vecs, dims)
+
+    idx = {r[0] for r in db.run_script(f"::indices {vecs}", {}, True)["rows"]}
+    if dims and "sem" not in idx:
+        db.run_script(
+            f"::hnsw create {vecs}:sem {{dim: {int(dims)}, m: {int(m)}, dtype: F32, "
+            f"fields: [emb], distance: {distance}, ef_construction: {int(ef_construction)}}}",
+            {},
+            False,
+        )
+    if "txt" not in idx:
+        db.run_script(
+            f"::fts create {vecs}:txt {{extractor: text, tokenizer: Simple, "
+            f"filters: [Lowercase, Stemmer('English'), Stopwords('en')]}}",
+            {},
+            False,
+        )
+
+
+def _validate_vecs_columns(db: Any, vecs: str, dims: Optional[int]) -> None:
+    """Loud error when a database is reopened with a mismatched IndexConfig —
+    a dim mismatch must never surface as a runtime engine error mid-search."""
+    rows = db.run_script(f"::columns {vecs}", {}, True)["rows"]
+    emb_row = next((r for r in rows if r and r[0] == "emb"), None)
+    if dims and emb_row is None:
+        raise ValueError(
+            f"relation {vecs} exists without an embedding column, but the store "
+            "was configured with an IndexConfig. Use the same configuration the "
+            "database was created with (or a fresh database/prefix)."
+        )
+    if not dims and emb_row is not None:
+        raise ValueError(
+            f"relation {vecs} has an embedding column, but the store was "
+            "configured without an IndexConfig. Pass the original index "
+            "configuration (dims + embed)."
+        )
+    if dims and emb_row is not None:
+        type_str = " ".join(str(c) for c in emb_row)
+        match = re.search(r"<F32\s*;\s*(\d+)\s*>", type_str)
+        if match is None or int(match.group(1)) != int(dims):
+            raise ValueError(
+                f"relation {vecs} embedding column is {type_str!r}, which does "
+                f"not match the configured IndexConfig dims={dims}. Embeddings "
+                "from different models/dims cannot share one store."
+            )

--- a/cozo-lib-python/integrations/langgraph-store-mnestic/langgraph_store_mnestic/store.py
+++ b/cozo-lib-python/integrations/langgraph-store-mnestic/langgraph_store_mnestic/store.py
@@ -1,0 +1,513 @@
+"""`MnesticStore` — a LangGraph `BaseStore` backed by mnestic.
+
+Semantics mirror the reference `InMemoryStore`: within one `batch()`, reads
+(get/search/list_namespaces) observe the **pre-batch** state, and all puts are
+deduplicated last-write-wins and applied at the end — here in **one engine
+transaction** (`multi_transact`), so a batch's writes become visible atomically
+or not at all. That atomicity is load-bearing: a non-atomic prototype lost 36%
+of concurrent semantic reads under LangGraph's parallel fan-out.
+
+`search(query=...)` runs an in-engine hybrid query: an HNSW vector leg (when
+the store has an IndexConfig) and a BM25 text leg, both with the namespace
+prefix pushed down into the index search, fused with Reciprocal Rank Fusion and
+hydrated in the same script (single snapshot).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from langgraph.store.base import (
+    BaseStore,
+    GetOp,
+    IndexConfig,
+    Item,
+    ListNamespacesOp,
+    Op,
+    PutOp,
+    Result,
+    SearchItem,
+    SearchOp,
+    TTLConfig,
+    ensure_embeddings,
+    get_text_at_path,
+)
+
+from ._filters import item_matches
+from ._ns import encode_ns, encode_prefix, matches_condition, validate_namespace
+from ._schema import ensure_schema
+
+_WORD = re.compile(r"\w+", re.UNICODE)
+
+
+def _dt(epoch: float) -> datetime:
+    return datetime.fromtimestamp(epoch, tz=timezone.utc)
+
+
+class MnesticStore(BaseStore):
+    """LangGraph store over an embedded mnestic database.
+
+    Args:
+        db: an existing ``mnestic.CozoDbPy`` handle; if omitted, one is opened
+            from ``engine``/``path``/``options``.
+        index: LangGraph ``IndexConfig`` (``dims`` + ``embed`` + optional
+            ``fields``) enabling the vector leg of ``search``. Without it the
+            store is BM25-only (keyword search still works).
+        ttl: LangGraph ``TTLConfig``. TTL is always supported; the config
+            supplies ``default_ttl`` / ``refresh_on_read`` /
+            ``sweep_interval_minutes`` defaults.
+    """
+
+    supports_ttl = True
+
+    def __init__(
+        self,
+        db: Optional[Any] = None,
+        *,
+        engine: str = "mem",
+        path: str = "",
+        options: str = "{}",
+        index: Optional[IndexConfig] = None,
+        ttl: Optional[TTLConfig] = None,
+        relation_prefix: str = "lg_store",
+        distance: str = "Cosine",
+        m: int = 16,
+        ef_construction: int = 50,
+        ef_search: int = 50,
+        rrf_k: float = 60.0,
+        overfetch: int = 4,
+        create: bool = True,
+    ) -> None:
+        self._owns_db = db is None
+        if db is None:
+            from mnestic import CozoDbPy
+
+            db = CozoDbPy(engine, path, options)
+        self.db = db
+        self.index_config = index
+        self.ttl_config = ttl
+        self.ef_search = int(ef_search)
+        self.rrf_k = float(rrf_k)
+        self.overfetch = max(1, int(overfetch))
+
+        self._embeddings = None
+        self._dims: Optional[int] = None
+        self._fields: List[str] = ["$"]
+        if index is not None:
+            self._dims = int(index["dims"])
+            if self._dims <= 0:
+                raise ValueError(f"index['dims'] must be positive, got {self._dims}")
+            self._embeddings = ensure_embeddings(index["embed"])
+            self._fields = list(index.get("fields") or ["$"])
+
+        self._items = f"{relation_prefix}_items"
+        self._vecs = f"{relation_prefix}_vecs"
+        if create:
+            ensure_schema(db, relation_prefix, self._dims, distance, m, ef_construction)
+
+        self._now = time.time  # injectable clock (tests)
+        self._sweeper_stop: Optional[threading.Event] = None
+        self._sweeper_thread: Optional[threading.Thread] = None
+
+    # --- BaseStore contract ---
+
+    def batch(self, ops: Iterable[Op]) -> List[Result]:
+        ops = list(ops)
+        results: List[Result] = []
+        put_ops: Dict[Tuple[Tuple[str, ...], str], PutOp] = {}
+        refresh: List[List[str]] = []
+
+        for op in ops:
+            if isinstance(op, GetOp):
+                results.append(self._get_op(op, refresh))
+            elif isinstance(op, SearchOp):
+                results.append(self._search_op(op, refresh))
+            elif isinstance(op, ListNamespacesOp):
+                results.append(self._list_namespaces_op(op))
+            elif isinstance(op, PutOp):
+                ns = validate_namespace(op.namespace)
+                if op.value is not None and not isinstance(op.value, dict):
+                    raise TypeError(f"Item values must be dicts, got {type(op.value)}")
+                if op.ttl is not None and self.ttl_config is None and not self.supports_ttl:
+                    raise NotImplementedError("TTL is not supported by this store")
+                put_ops[(ns, op.key)] = op
+                results.append(None)
+            else:
+                raise ValueError(f"Unknown operation type: {type(op)}")
+
+        if put_ops:
+            self._apply_puts(put_ops)
+        if refresh:
+            self._apply_refresh(refresh)
+        return results
+
+    async def abatch(self, ops: Iterable[Op]) -> List[Result]:
+        ops = list(ops)
+        return await asyncio.get_running_loop().run_in_executor(None, self.batch, ops)
+
+    # --- write path ---
+
+    def _apply_puts(self, put_ops: Dict[Tuple[Tuple[str, ...], str], PutOp]) -> None:
+        now = self._now()
+        upserts: List[Tuple[str, str, PutOp]] = []  # (ns_enc, key, op)
+        deletes: List[List[str]] = []
+        pending_texts: List[Tuple[int, str, int, str]] = []  # (upsert_idx, field, seq, text)
+
+        for (ns, key), op in put_ops.items():
+            ns_enc = encode_ns(ns)
+            if op.value is None:
+                deletes.append([ns_enc, key])
+                continue
+            idx = len(upserts)
+            upserts.append((ns_enc, key, op))
+            fields = self._op_fields(op)
+            if fields is not None:
+                for field in fields:
+                    for seq, text in enumerate(get_text_at_path(op.value, field)):
+                        pending_texts.append((idx, field, seq, text))
+
+        # Embed the whole batch in one call, BEFORE any transaction is open —
+        # never hold the write locks across a (possibly remote) embedding call.
+        embeddings: List[List[float]] = []
+        if pending_texts and self._embeddings is not None:
+            embeddings = self._embeddings.embed_documents([t[3] for t in pending_texts])
+            for vec in embeddings:
+                if len(vec) != self._dims:
+                    raise ValueError(
+                        f"embedding dimension {len(vec)} != configured dims {self._dims}"
+                    )
+
+        affected_keys = [[e, k] for e, k, _ in upserts] + deletes
+        vec_cols = "text, emb" if self._dims else "text"
+        vec_rows: List[list] = []
+        for i, (pidx, field, seq, text) in enumerate(pending_texts):
+            ns_enc, key, _op = upserts[pidx]
+            row: list = [ns_enc, key, field, seq, text]
+            if self._dims:
+                row.append([float(x) for x in embeddings[i]])
+            vec_rows.append(row)
+
+        tx = self.db.multi_transact(True)
+        try:
+            if upserts:
+                res = tx.run_script(
+                    f"keyset[ns, key] <- $keys\n"
+                    f"?[ns, key, created_at] := keyset[ns, key], "
+                    f"*{self._items}{{ns, key, created_at}}",
+                    {"keys": [[e, k] for e, k, _ in upserts]},
+                )
+                existing = {(r[0], r[1]): float(r[2]) for r in res["rows"]}
+                item_rows = []
+                for ns_enc, key, op in upserts:
+                    ttl_minutes = float(op.ttl) if op.ttl is not None else None
+                    expires_at = (now + ttl_minutes * 60.0) if ttl_minutes is not None else None
+                    item_rows.append(
+                        [
+                            ns_enc,
+                            key,
+                            op.value,
+                            list(op.namespace),
+                            existing.get((ns_enc, key), now),
+                            now,
+                            expires_at,
+                            ttl_minutes,
+                        ]
+                    )
+                tx.run_script(
+                    f"?[ns, key, value, ns_parts, created_at, updated_at, expires_at, ttl_minutes] <- $rows\n"
+                    f":put {self._items} {{ns, key => value, ns_parts, created_at, "
+                    f"updated_at, expires_at, ttl_minutes}}",
+                    {"rows": item_rows},
+                )
+            if deletes:
+                # Items before vecs everywhere, so concurrent transactions
+                # acquire the two relation locks in one global order.
+                tx.run_script(
+                    f"?[ns, key] <- $keys :rm {self._items} {{ns, key}}",
+                    {"keys": deletes},
+                )
+            if affected_keys:
+                tx.run_script(
+                    f"keyset[ns, key] <- $keys\n"
+                    f"?[ns, key, field, seq] := keyset[ns, key], "
+                    f"*{self._vecs}{{ns, key, field, seq}}\n"
+                    f":rm {self._vecs} {{ns, key, field, seq}}",
+                    {"keys": affected_keys},
+                )
+            if vec_rows:
+                tx.run_script(
+                    f"?[ns, key, field, seq, {vec_cols}] <- $rows\n"
+                    f":put {self._vecs} {{ns, key, field, seq => {vec_cols}}}",
+                    {"rows": vec_rows},
+                )
+            tx.commit()
+        except BaseException:
+            try:
+                tx.abort()
+            except Exception:
+                pass
+            raise
+
+    def _op_fields(self, op: PutOp) -> Optional[List[str]]:
+        """Which field paths to index for this op; None = don't index at all."""
+        if op.index is False:
+            return None
+        if op.index is not None:
+            return list(op.index)
+        return self._fields
+
+    # --- read path ---
+
+    def _get_op(self, op: GetOp, refresh: List[List[str]]) -> Optional[Item]:
+        ns = tuple(op.namespace)
+        ns_enc = encode_ns(ns)
+        rows = self.db.run_script(
+            f"?[value, ns_parts, created_at, updated_at, expires_at, ttl_minutes] := "
+            f"ns = $ns, key = $key, "
+            f"*{self._items}{{ns, key, value, ns_parts, created_at, updated_at, "
+            f"expires_at, ttl_minutes}}",
+            {"ns": ns_enc, "key": op.key},
+            True,
+        )["rows"]
+        if not rows:
+            return None
+        value, ns_parts, ca, ua, ea, tm = rows[0]
+        if ea is not None and ea <= self._now():
+            return None
+        if op.refresh_ttl and tm is not None:
+            refresh.append([ns_enc, op.key])
+        return Item(
+            value=value,
+            key=op.key,
+            namespace=tuple(ns_parts),
+            created_at=_dt(ca),
+            updated_at=_dt(ua),
+        )
+
+    def _search_op(self, op: SearchOp, refresh: List[List[str]]) -> List[SearchItem]:
+        nsp = encode_prefix(tuple(op.namespace_prefix or ()))
+        now = self._now()
+        if op.query:
+            candidates = self._query_candidates(op, nsp, now)
+        else:
+            candidates = self._scan_candidates(op, nsp, now)
+
+        picked = candidates[op.offset : op.offset + op.limit]
+        out: List[SearchItem] = []
+        for ns_enc, key, score, value, ns_parts, ca, ua, tm in picked:
+            if op.refresh_ttl and tm is not None:
+                refresh.append([ns_enc, key])
+            out.append(
+                SearchItem(
+                    namespace=tuple(ns_parts),
+                    key=key,
+                    value=value,
+                    created_at=_dt(ca),
+                    updated_at=_dt(ua),
+                    score=score,
+                )
+            )
+        return out
+
+    def _query_candidates(self, op: SearchOp, nsp: str, now: float) -> List[tuple]:
+        # Lowercased word tokens only: bare uppercase AND/OR/NOT/NEAR are FTS
+        # operators, and raw punctuation can fail the FTS query grammar.
+        # Comma-join = OR-of-terms (whitespace would be AND): docs matching
+        # more query terms rank higher under BM25 summing, and a single rare
+        # term still recalls.
+        qt = ", ".join(t.lower() for t in _WORD.findall(op.query or ""))
+        have_sem = self._embeddings is not None
+        have_txt = bool(qt)
+        if not have_sem and not have_txt:
+            return []
+
+        fetch = min(max((op.offset + op.limit) * self.overfetch, 10), 1000)
+        params: Dict[str, Any] = {"nsp": nsp}
+        if have_sem:
+            qv = self._embeddings.embed_query(op.query)
+            if len(qv) != self._dims:
+                raise ValueError(
+                    f"query embedding dimension {len(qv)} != configured dims {self._dims}"
+                )
+            params["qv"] = [float(x) for x in qv]
+        if have_txt:
+            params["qt"] = qt
+
+        rows = self.db.run_script(self._fused_script(have_sem, have_txt, fetch), params, True)[
+            "rows"
+        ]
+        out = []
+        for ns_enc, key, score, value, ns_parts, ca, ua, ea, tm in rows:
+            if ea is not None and ea <= now:
+                continue
+            if not item_matches(value, op.filter):
+                continue
+            out.append((ns_enc, key, float(score), value, ns_parts, ca, ua, tm))
+        return out
+
+    def _fused_script(self, have_sem: bool, have_txt: bool, fetch: int) -> str:
+        parts: List[str] = []
+        if have_sem:
+            parts.append(
+                f"sem[id, score] := ~{self._vecs}:sem{{ns: n, key: k | query: vec($qv), "
+                f"k: {fetch}, ef: {max(self.ef_search, fetch)}, bind_distance: d, "
+                f"filter: starts_with(n, $nsp)}}, id = [n, k], score = -d"
+            )
+            parts.append("combined[lid, id, score] := sem[id, score], lid = 'semantic'")
+        if have_txt:
+            parts.append(
+                f"txt[id, score] := ~{self._vecs}:txt{{ns: n, key: k | query: $qt, "
+                f"k: {fetch}, bind_score: s, filter: starts_with(n, $nsp)}}, "
+                f"id = [n, k], score = s"
+            )
+            parts.append("combined[lid, id, score] := txt[id, score], lid = 'text'")
+        parts.append(
+            f"fused[id, score] <~ ReciprocalRankFusion(combined[lid, id, score], k: {self.rrf_k})"
+        )
+        # Hydrate in the same script: one snapshot for legs, fusion, and items.
+        parts.append(
+            f"?[ns, key, score, value, ns_parts, created_at, updated_at, expires_at, ttl_minutes] := "
+            f"fused[id, score], ns = get(id, 0), key = get(id, 1), "
+            f"*{self._items}{{ns, key, value, ns_parts, created_at, updated_at, "
+            f"expires_at, ttl_minutes}}"
+        )
+        parts.append(":order -score")
+        parts.append(f":limit {fetch}")
+        return "\n".join(parts)
+
+    def _scan_candidates(self, op: SearchOp, nsp: str, now: float) -> List[tuple]:
+        script = (
+            f"?[ns, key, value, ns_parts, created_at, updated_at, expires_at, ttl_minutes] := "
+            f"*{self._items}{{ns, key, value, ns_parts, created_at, updated_at, "
+            f"expires_at, ttl_minutes}}, "
+            f"starts_with(ns, $nsp), "
+            f"if(is_null(expires_at), true, expires_at > $now)\n"
+            f":order ns, key"
+        )
+        if not op.filter:
+            script += f"\n:limit {op.offset + op.limit}"
+        rows = self.db.run_script(script, {"nsp": nsp, "now": now}, True)["rows"]
+        out = []
+        for ns_enc, key, value, ns_parts, ca, ua, _ea, tm in rows:
+            if not item_matches(value, op.filter):
+                continue
+            out.append((ns_enc, key, None, value, ns_parts, ca, ua, tm))
+        return out
+
+    def _list_namespaces_op(self, op: ListNamespacesOp) -> List[Tuple[str, ...]]:
+        rows = self.db.run_script(
+            f"?[ns, ns_parts] := *{self._items}{{ns, ns_parts, expires_at}}, "
+            f"if(is_null(expires_at), true, expires_at > $now)",
+            {"now": self._now()},
+            True,
+        )["rows"]
+        namespaces = {tuple(parts) for _, parts in rows}
+        result: List[Tuple[str, ...]] = list(namespaces)
+        if op.match_conditions:
+            result = [
+                ns
+                for ns in result
+                if all(matches_condition(cond, ns) for cond in op.match_conditions)
+            ]
+        if op.max_depth is not None:
+            result = sorted({ns[: op.max_depth] for ns in result})
+        else:
+            result = sorted(result)
+        return result[op.offset : op.offset + op.limit]
+
+    # --- TTL ---
+
+    def _apply_refresh(self, keys: List[List[str]]) -> None:
+        """Extend expiry for read items — post-batch, in one atomic script that
+        re-reads each row in-engine (never clobbers a concurrent value update)."""
+        if self.ttl_config is not None and not self.ttl_config.get("refresh_on_read", True):
+            return
+        self.db.run_script(
+            f"keyset[ns, key] <- $keys\n"
+            f"?[ns, key, value, ns_parts, created_at, updated_at, expires_at, ttl_minutes] := "
+            f"keyset[ns, key], "
+            f"*{self._items}{{ns, key, value, ns_parts, created_at, updated_at, ttl_minutes}}, "
+            f"!is_null(ttl_minutes), "
+            f"expires_at = $now + coalesce(ttl_minutes, 0.0) * 60.0\n"
+            f":put {self._items} {{ns, key => value, ns_parts, created_at, updated_at, "
+            f"expires_at, ttl_minutes}}",
+            {"keys": keys, "now": self._now()},
+            False,
+        )
+
+    def sweep_ttl(self) -> int:
+        """Physically remove expired items (and their index rows). Returns the
+        number of removed items. Correctness never depends on this — every read
+        path filters expired rows — but it reclaims space."""
+        now = self._now()
+        tx = self.db.multi_transact(True)
+        try:
+            rows = tx.run_script(
+                f"?[ns, key] := *{self._items}{{ns, key, expires_at}}, "
+                f"if(is_null(expires_at), false, expires_at <= $now)",
+                {"now": now},
+            )["rows"]
+            if rows:
+                keys = [[r[0], r[1]] for r in rows]
+                tx.run_script(
+                    f"?[ns, key] <- $keys :rm {self._items} {{ns, key}}", {"keys": keys}
+                )
+                tx.run_script(
+                    f"keyset[ns, key] <- $keys\n"
+                    f"?[ns, key, field, seq] := keyset[ns, key], "
+                    f"*{self._vecs}{{ns, key, field, seq}}\n"
+                    f":rm {self._vecs} {{ns, key, field, seq}}",
+                    {"keys": keys},
+                )
+            tx.commit()
+            return len(rows)
+        except BaseException:
+            try:
+                tx.abort()
+            except Exception:
+                pass
+            raise
+
+    def start_ttl_sweeper(self) -> None:
+        if self._sweeper_thread is not None:
+            return
+        interval_min = 5.0
+        if self.ttl_config is not None:
+            interval_min = float(self.ttl_config.get("sweep_interval_minutes") or 5.0)
+        stop = threading.Event()
+
+        def _loop() -> None:
+            while not stop.wait(interval_min * 60.0):
+                try:
+                    self.sweep_ttl()
+                except Exception:  # pragma: no cover - keep the sweeper alive
+                    pass
+
+        thread = threading.Thread(target=_loop, name="mnestic-store-ttl-sweeper", daemon=True)
+        self._sweeper_stop = stop
+        self._sweeper_thread = thread
+        thread.start()
+
+    def stop_ttl_sweeper(self) -> None:
+        if self._sweeper_stop is not None:
+            self._sweeper_stop.set()
+        if self._sweeper_thread is not None:
+            self._sweeper_thread.join(timeout=5.0)
+        self._sweeper_stop = None
+        self._sweeper_thread = None
+
+    # --- lifecycle ---
+
+    def close(self) -> None:
+        self.stop_ttl_sweeper()
+
+    def __enter__(self) -> "MnesticStore":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self.close()

--- a/cozo-lib-python/integrations/langgraph-store-mnestic/pyproject.toml
+++ b/cozo-lib-python/integrations/langgraph-store-mnestic/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "langgraph-store-mnestic"
+version = "0.1.0"
+description = "LangGraph BaseStore backed by mnestic — embedded agent memory with atomic batches and one-call BM25+vector hybrid search."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MPL-2.0" }
+authors = [{ name = "Shan Rizvi" }]
+keywords = ["langgraph", "mnestic", "agent-memory", "basestore", "hybrid-search", "cozodb"]
+dependencies = [
+    "mnestic>=0.12.2",
+    "langgraph-checkpoint>=4.1,<5",
+]
+
+[project.urls]
+Homepage = "https://github.com/shuruheel/mnestic"
+Repository = "https://github.com/shuruheel/mnestic"
+
+[tool.hatch.build.targets.wheel]
+packages = ["langgraph_store_mnestic"]

--- a/cozo-lib-python/integrations/langgraph-store-mnestic/tests/conftest.py
+++ b/cozo-lib-python/integrations/langgraph-store-mnestic/tests/conftest.py
@@ -1,0 +1,59 @@
+"""Shared fixtures: deterministic keyword embedder (no network/ML deps) and
+store factories over mem + sqlite. Persistent-path tests use sqlite — the mem
+backend uses a different join operator than the stored backends, so sqlite is
+the one that exercises the real path."""
+
+from typing import List
+
+import pytest
+
+from langgraph_store_mnestic import MnesticStore
+
+# Token -> vector gradient. For a query embedding [1, 0] ("alpha...") the
+# vector ranking over docs a/b/c/d is strict: alpha > beta > gamma > delta.
+# "omega" is orthogonal. Chosen tokens are not English stopwords (the FTS
+# index stopwords common words — "hello" matches nothing on the text leg).
+GRADIENT = {
+    "alpha": [1.0, 0.0],
+    "beta": [0.95, 0.05],
+    "gamma": [0.85, 0.15],
+    "delta": [0.7, 0.3],
+    "omega": [0.0, 1.0],
+}
+
+
+def gvec(text: str) -> List[float]:
+    t = text.lower()
+    for tok, vec in GRADIENT.items():
+        if tok in t:
+            return list(vec)
+    return [0.5, 0.5]
+
+
+def kw_embed(texts) -> List[List[float]]:
+    return [gvec(t) for t in texts]
+
+
+INDEX = {"dims": 2, "embed": kw_embed}
+
+
+def make_store(engine: str, tmp_path, *, index=INDEX, ttl=None, **kwargs) -> MnesticStore:
+    if engine == "sqlite":
+        kwargs = {"engine": "sqlite", "path": str(tmp_path / "store.db"), **kwargs}
+    else:
+        kwargs = {"engine": "mem", **kwargs}
+    return MnesticStore(index=index, ttl=ttl, **kwargs)
+
+
+@pytest.fixture(params=["mem", "sqlite"])
+def store(request, tmp_path):
+    s = make_store(request.param, tmp_path)
+    yield s
+    s.close()
+
+
+@pytest.fixture()
+def sqlite_store(tmp_path):
+    s = make_store("sqlite", tmp_path)
+    yield s
+    s.close()

--- a/cozo-lib-python/integrations/langgraph-store-mnestic/tests/test_concurrency.py
+++ b/cozo-lib-python/integrations/langgraph-store-mnestic/tests/test_concurrency.py
@@ -1,0 +1,156 @@
+"""The non-optional concurrency matrix. A prior prototype passed 30/30
+sequential checks and then lost 36.4% of concurrent semantic reads because its
+batch() was not atomic — a sequential suite is structurally blind here. These
+tests are the permanent gate."""
+
+import threading
+
+import pytest
+from langgraph.store.base import PutOp
+
+from tests.conftest import make_store
+
+ENGINES = ["mem", "sqlite"]
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+@pytest.mark.parametrize("n_threads", [4, 12])
+def test_no_lost_writes(engine, n_threads, tmp_path):
+    s = make_store(engine, tmp_path)
+    per_thread = 25
+    errors = []
+
+    def writer(tid: int):
+        try:
+            for i in range(per_thread):
+                s.put(("w", str(tid)), f"k{i}", {"tid": tid, "i": i, "text": f"omega {tid} {i}"})
+        except Exception as e:  # pragma: no cover
+            errors.append(e)
+
+    threads = [threading.Thread(target=writer, args=(t,)) for t in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    for tid in range(n_threads):
+        for i in range(per_thread):
+            item = s.get(("w", str(tid)), f"k{i}")
+            assert item is not None and item.value["i"] == i
+    s.close()
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_always_present_item_never_lost_under_write_load(engine, tmp_path):
+    """The 36.4% regression test: readers hybrid-search an always-present item
+    while writers hammer the same namespace. Zero zero-result reads allowed."""
+    s = make_store(engine, tmp_path)
+    ns = ("agent", "memories")
+    s.put(ns, "anchor", {"text": "omega anchor fact"})
+
+    n_writers, n_readers, writes_each, min_reads = 8, 8, 30, 600
+    zero_results = []
+    read_count = [0]
+    errors = []
+    writers_done = threading.Event()
+    lock = threading.Lock()
+
+    def writer(tid: int):
+        try:
+            for i in range(writes_each):
+                s.batch(
+                    [
+                        PutOp(
+                            namespace=ns,
+                            key=f"w{tid}-{i}",
+                            value={"text": f"filler note {tid} {i}"},
+                        )
+                    ]
+                )
+        except Exception as e:  # pragma: no cover
+            errors.append(e)
+
+    def reader():
+        try:
+            while True:
+                with lock:
+                    if writers_done.is_set() and read_count[0] >= min_reads:
+                        return
+                    read_count[0] += 1
+                hits = s.search(ns, query="omega anchor")
+                if not any(h.key == "anchor" for h in hits):
+                    zero_results.append(1)
+        except Exception as e:  # pragma: no cover
+            errors.append(e)
+
+    wthreads = [threading.Thread(target=writer, args=(t,)) for t in range(n_writers)]
+    rthreads = [threading.Thread(target=reader) for _ in range(n_readers)]
+    for t in wthreads + rthreads:
+        t.start()
+    for t in wthreads:
+        t.join()
+    writers_done.set()
+    for t in rthreads:
+        t.join()
+
+    assert not errors, errors[:3]
+    assert read_count[0] >= min_reads
+    assert len(zero_results) == 0, (
+        f"{len(zero_results)}/{read_count[0]} reads lost the always-present item"
+    )
+    s.close()
+
+
+@pytest.mark.parametrize("engine", ENGINES)
+def test_correlated_pair_writes_stay_atomic(engine, tmp_path):
+    """A writer updates k1 and k2 with the same counter in one batch. Readers
+    (reading k1 then k2) must never observe k2 behind k1 — which a non-atomic
+    batch would produce constantly."""
+    s = make_store(engine, tmp_path)
+    ns = ("pair",)
+    s.batch(
+        [
+            PutOp(namespace=ns, key="k1", value={"v": 0}),
+            PutOp(namespace=ns, key="k2", value={"v": 0}),
+        ]
+    )
+    violations = []
+    errors = []
+    done = threading.Event()
+
+    def writer():
+        try:
+            for i in range(1, 120):
+                s.batch(
+                    [
+                        PutOp(namespace=ns, key="k1", value={"v": i}),
+                        PutOp(namespace=ns, key="k2", value={"v": i}),
+                    ]
+                )
+        except Exception as e:  # pragma: no cover
+            errors.append(e)
+        finally:
+            done.set()
+
+    def reader():
+        try:
+            while not done.is_set():
+                v1 = s.get(ns, "k1").value["v"]
+                v2 = s.get(ns, "k2").value["v"]
+                if v2 < v1:
+                    violations.append((v1, v2))
+        except Exception as e:  # pragma: no cover
+            errors.append(e)
+
+    threads = [threading.Thread(target=writer)] + [
+        threading.Thread(target=reader) for _ in range(4)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors, errors[:3]
+    assert not violations, violations[:5]
+    s.close()

--- a/cozo-lib-python/integrations/langgraph-store-mnestic/tests/test_contract.py
+++ b/cozo-lib-python/integrations/langgraph-store-mnestic/tests/test_contract.py
@@ -1,0 +1,173 @@
+"""BaseStore contract parity: CRUD, list_namespaces, filters, pagination, and
+the batch semantics mirrored from the reference InMemoryStore (reads observe
+the pre-batch state; puts dedupe last-write-wins and apply atomically)."""
+
+import pytest
+from langgraph.store.base import GetOp, ListNamespacesOp, PutOp, SearchOp
+
+from tests.conftest import make_store
+
+
+def test_put_get_roundtrip(store):
+    value = {
+        "text": "alpha memo",
+        "nested": {"a": [1, 2, {"b": "c"}], "unicode": "héllo wörld ✓"},
+        "n": 42,
+        "f": 1.5,
+        "flag": True,
+        "none": None,
+    }
+    store.put(("users", "u1"), "k1", value)
+    item = store.get(("users", "u1"), "k1")
+    assert item is not None
+    assert item.value == value
+    assert item.key == "k1"
+    assert item.namespace == ("users", "u1")
+    assert item.created_at is not None and item.updated_at is not None
+
+
+def test_update_preserves_created_at(store):
+    clock = {"t": 1000.0}
+    store._now = lambda: clock["t"]
+    store.put(("ns",), "k", {"v": 1})
+    first = store.get(("ns",), "k")
+    clock["t"] = 2000.0
+    store.put(("ns",), "k", {"v": 2})
+    second = store.get(("ns",), "k")
+    assert second.value == {"v": 2}
+    assert second.created_at == first.created_at
+    assert second.updated_at > first.updated_at
+
+
+def test_delete_and_missing(store):
+    store.put(("ns",), "k", {"v": 1})
+    assert store.get(("ns",), "k") is not None
+    store.delete(("ns",), "k")
+    assert store.get(("ns",), "k") is None
+    assert store.get(("nowhere",), "nope") is None
+
+
+def test_batch_reads_see_pre_batch_state(store):
+    # Mirrors InMemoryStore: a Get/Search in the same batch as a Put observes
+    # the pre-batch state; the Put becomes visible only after the batch.
+    results = store.batch(
+        [
+            PutOp(namespace=("b",), key="k", value={"text": "alpha item"}),
+            GetOp(namespace=("b",), key="k"),
+            SearchOp(namespace_prefix=("b",), query="alpha"),
+        ]
+    )
+    assert results[0] is None
+    assert results[1] is None  # pre-batch state: not there yet
+    assert results[2] == []
+    assert store.get(("b",), "k") is not None
+    found = store.search(("b",), query="alpha")
+    assert [i.key for i in found] == ["k"]
+
+
+def test_batch_put_dedupe_last_write_wins(store):
+    store.batch(
+        [
+            PutOp(namespace=("d",), key="k", value={"v": 1}),
+            PutOp(namespace=("d",), key="k", value={"v": 2}),
+        ]
+    )
+    assert store.get(("d",), "k").value == {"v": 2}
+
+
+def test_batch_atomic_abort_on_bad_value(store):
+    store.put(("a",), "pre", {"v": 0})
+    with pytest.raises(Exception):
+        store.batch(
+            [
+                PutOp(namespace=("a",), key="good", value={"v": 1}),
+                # a set() cannot cross the binding — fails mid-transaction
+                PutOp(namespace=("a",), key="bad", value={"v": {1, 2, 3}}),
+            ]
+        )
+    # nothing from the failed batch may be visible
+    assert store.get(("a",), "good") is None
+    assert store.get(("a",), "pre") is not None
+
+
+def test_batch_rejects_bad_ops(store):
+    with pytest.raises(ValueError):
+        store.batch([PutOp(namespace=(), key="k", value={})])
+    with pytest.raises((TypeError, ValueError)):
+        store.batch([PutOp(namespace=("a",), key="k", value=["not", "a", "dict"])])
+    with pytest.raises(ValueError):
+        store.batch(["not an op"])
+
+
+def test_list_namespaces(store):
+    for ns in [("a", "b", "c"), ("a", "b", "d"), ("a", "x"), ("z",)]:
+        store.put(ns, "k", {"v": 1})
+
+    all_ns = store.list_namespaces()
+    assert all_ns == sorted([("a", "b", "c"), ("a", "b", "d"), ("a", "x"), ("z",)])
+
+    assert store.list_namespaces(prefix=("a", "b")) == [("a", "b", "c"), ("a", "b", "d")]
+    assert store.list_namespaces(suffix=("d",)) == [("a", "b", "d")]
+    assert store.list_namespaces(prefix=("a", "*", "c")) == [("a", "b", "c")]
+    assert store.list_namespaces(max_depth=2) == [("a", "b"), ("a", "x"), ("z",)]
+    assert store.list_namespaces(limit=2) == [("a", "b", "c"), ("a", "b", "d")]
+    assert store.list_namespaces(offset=3) == [("z",)]
+
+
+def test_scan_search_filters_and_pagination(store):
+    for i in range(6):
+        store.put(
+            ("f",),
+            f"k{i}",
+            {"i": i, "even": i % 2 == 0, "tag": {"deep": f"t{i % 3}"}, "text": "omega row"},
+        )
+
+    assert {i.key for i in store.search(("f",), filter={"even": True})} == {"k0", "k2", "k4"}
+    assert {i.key for i in store.search(("f",), filter={"i": {"$gte": 2, "$lt": 5}})} == {
+        "k2",
+        "k3",
+        "k4",
+    }
+    assert {i.key for i in store.search(("f",), filter={"i": {"$ne": 0}, "even": True})} == {
+        "k2",
+        "k4",
+    }
+    assert {i.key for i in store.search(("f",), filter={"tag": {"deep": "t1"}})} == {"k1", "k4"}
+    assert {i.key for i in store.search(("f",), filter={"i": {"$eq": 3}})} == {"k3"}
+    assert {i.key for i in store.search(("f",), filter={"i": {"$lte": 0}})} == {"k0"}
+    assert {i.key for i in store.search(("f",), filter={"i": {"$gt": 4}})} == {"k5"}
+
+    page1 = store.search(("f",), limit=2)
+    page2 = store.search(("f",), limit=2, offset=2)
+    assert [i.key for i in page1] == ["k0", "k1"]
+    assert [i.key for i in page2] == ["k2", "k3"]
+    assert all(i.score is None for i in page1)
+
+
+def test_async_twins(store):
+    import asyncio
+
+    async def flow():
+        await store.aput(("as",), "k", {"text": "alpha async"})
+        item = await store.aget(("as",), "k")
+        hits = await store.asearch(("as",), query="alpha")
+        namespaces = await store.alist_namespaces()
+        await store.adelete(("as",), "k")
+        gone = await store.aget(("as",), "k")
+        return item, hits, namespaces, gone
+
+    item, hits, namespaces, gone = asyncio.run(flow())
+    assert item is not None and item.value["text"] == "alpha async"
+    assert [h.key for h in hits] == ["k"]
+    assert ("as",) in namespaces
+    assert gone is None
+
+
+def test_bm25_only_store(tmp_path):
+    s = make_store("mem", tmp_path, index=None)
+    s.put(("b",), "k1", {"text": "zebra migration patterns"})
+    s.put(("b",), "k2", {"text": "unrelated content entirely"})
+    hits = s.search(("b",), query="zebra")
+    assert [h.key for h in hits] == ["k1"]
+    assert hits[0].score is not None
+    s.close()

--- a/cozo-lib-python/integrations/langgraph-store-mnestic/tests/test_langgraph_integration.py
+++ b/cozo-lib-python/integrations/langgraph-store-mnestic/tests/test_langgraph_integration.py
@@ -1,0 +1,60 @@
+"""The challenger's test as a permanent gate: a real compiled LangGraph with a
+parallel fan-out superstep doing store writes + hybrid searches against a
+shared namespace. Every node of every invocation must recall the anchor —
+parallel superstep execution is LangGraph's reason for existing, and it is
+exactly the load that exposed the prototype's non-atomic batch()."""
+
+import asyncio
+import operator
+import uuid
+from typing import Annotated, TypedDict
+
+import pytest
+
+pytest.importorskip("langgraph")
+
+from langgraph.config import get_store  # noqa: E402
+from langgraph.graph import END, START, StateGraph  # noqa: E402
+
+from tests.conftest import make_store  # noqa: E402
+
+
+class State(TypedDict):
+    results: Annotated[list, operator.add]
+
+
+def _make_node(i: int):
+    def node(state: State):
+        store = get_store()
+        store.put(("shared",), f"note-{i}-{uuid.uuid4().hex[:8]}", {"text": f"filler {i}"})
+        hits = store.search(("shared",), query="omega anchor", limit=5)
+        return {"results": [any(h.key == "anchor" for h in hits)]}
+
+    return node
+
+
+@pytest.mark.parametrize("engine", ["mem", "sqlite"])
+def test_compiled_graph_parallel_fanout(engine, tmp_path):
+    store = make_store(engine, tmp_path)
+    store.put(("shared",), "anchor", {"text": "omega anchor fact"})
+
+    builder = StateGraph(State)
+    for i in range(8):
+        builder.add_node(f"n{i}", _make_node(i))
+        builder.add_edge(START, f"n{i}")
+        builder.add_edge(f"n{i}", END)
+    graph = builder.compile(store=store)
+
+    for _ in range(10):
+        out = graph.invoke({"results": []})
+        assert len(out["results"]) == 8
+        assert all(out["results"]), "a parallel node lost the always-present anchor"
+
+    async def arun():
+        for _ in range(10):
+            out = await graph.ainvoke({"results": []})
+            assert len(out["results"]) == 8
+            assert all(out["results"])
+
+    asyncio.run(arun())
+    store.close()

--- a/cozo-lib-python/integrations/langgraph-store-mnestic/tests/test_namespaces.py
+++ b/cozo-lib-python/integrations/langgraph-store-mnestic/tests/test_namespaces.py
@@ -1,0 +1,80 @@
+"""THE discriminating namespace tests: a prior prototype validated namespaces
+only in put() (never in batch()), so `('a.b',)` silently overwrote the row for
+`('a', 'b')`. The collision-safe encoding must keep every distinct tuple
+distinct — for any label content."""
+
+import random
+
+from langgraph.store.base import PutOp
+
+from langgraph_store_mnestic._ns import decode_ns, encode_ns, encode_prefix
+
+
+def test_dot_label_does_not_collide(store):
+    # direct batch() bypasses put()'s upstream validation — exactly the path
+    # LangGraph itself uses. These MUST be two distinct rows.
+    store.batch(
+        [
+            PutOp(namespace=("a.b",), key="k", value={"who": "dotted"}),
+            PutOp(namespace=("a", "b"), key="k", value={"who": "nested"}),
+        ]
+    )
+    assert store.get(("a.b",), "k").value == {"who": "dotted"}
+    assert store.get(("a", "b"), "k").value == {"who": "nested"}
+
+    under_a = store.search(("a",))
+    assert [i.value["who"] for i in under_a] == ["nested"]
+    assert {tuple(ns) for ns in store.list_namespaces()} == {("a.b",), ("a", "b")}
+
+
+def test_hostile_labels(store):
+    hostile = [
+        ("a\x1fb",),          # raw separator inside a label
+        ("a", "\x1e"),        # raw escape char
+        ("a\x1eS", "b"),      # escape sequence lookalike
+        ("a\x1f", "b\x1e\x1e"),
+    ]
+    for i, ns in enumerate(hostile):
+        store.batch([PutOp(namespace=ns, key="k", value={"i": i})])
+    for i, ns in enumerate(hostile):
+        assert store.get(ns, "k").value == {"i": i}, ns
+    encoded = [encode_ns(ns) for ns in hostile]
+    assert len(set(encoded)) == len(encoded)
+
+
+def test_prefix_boundary():
+    # ('a',) must never prefix-match ('ab', ...)
+    assert not encode_ns(("ab",)).startswith(encode_prefix(("a",)))
+    assert encode_ns(("a", "b")).startswith(encode_prefix(("a",)))
+
+
+def test_prefix_search_boundary(store):
+    store.put(("a",), "k", {"v": "short"})
+    store.put(("ab",), "k", {"v": "long"})
+    hits = store.search(("a",))
+    assert [i.value["v"] for i in hits] == ["short"]
+
+
+def test_encode_decode_fuzz():
+    rng = random.Random(42)
+    alphabet = "ab.\x1f\x1eS*é"
+    seen = {}
+    for _ in range(200):
+        ns = tuple(
+            "".join(rng.choice(alphabet) for _ in range(rng.randint(1, 6)))
+            for _ in range(rng.randint(1, 4))
+        )
+        enc = encode_ns(ns)
+        assert decode_ns(enc) == ns
+        if enc in seen:
+            assert seen[enc] == ns
+        seen[enc] = ns
+
+        # tuple-prefix <=> string-prefix equivalence against a random other
+        other = tuple(
+            "".join(rng.choice(alphabet) for _ in range(rng.randint(1, 6)))
+            for _ in range(rng.randint(1, 4))
+        )
+        is_tuple_prefix = other == ns[: len(other)]
+        is_str_prefix = enc.startswith(encode_prefix(other))
+        assert is_tuple_prefix == is_str_prefix, (ns, other)

--- a/cozo-lib-python/integrations/langgraph-store-mnestic/tests/test_search_hybrid.py
+++ b/cozo-lib-python/integrations/langgraph-store-mnestic/tests/test_search_hybrid.py
@@ -1,0 +1,114 @@
+"""Hybrid search: BM25 must demonstrably contribute (not just ride along), the
+namespace filter must be pushed into the index legs, and per-op index controls
+must hold across both legs."""
+
+import pytest
+from langgraph.store.base import PutOp
+
+from langgraph_store_mnestic import MnesticStore
+
+from tests.conftest import INDEX, make_store
+
+
+def _seed_gradient(store):
+    # vector ranking for query "alpha ...": a > b > c > d (strict gradient);
+    # only d's text contains the rare keyword "zebra".
+    store.put(("g",), "a", {"text": "alpha doc"})
+    store.put(("g",), "b", {"text": "beta doc"})
+    store.put(("g",), "c", {"text": "gamma doc"})
+    store.put(("g",), "d", {"text": "delta doc zebra"})
+
+
+def test_bm25_leg_changes_ranking(store):
+    _seed_gradient(store)
+    # Pure vector order would be [a, b, c, d]. The query keyword "zebra"
+    # matches only d's text, so hybrid RRF must fuse d above b and c —
+    # something the vector leg alone can never produce.
+    hits = store.search(("g",), query="alpha zebra")
+    keys = [h.key for h in hits]
+    assert keys[0] == "a"
+    assert keys.index("d") < keys.index("b")
+    assert keys.index("d") < keys.index("c")
+    assert all(isinstance(h.score, float) for h in hits)
+
+
+def test_namespace_filter_pushdown_with_distractors(store):
+    # 500 distractors that are all vector-identical to the target: a global
+    # top-k that ignored the namespace filter would drown the target out.
+    target_ns = ("team", "x")
+    store.put(target_ns, "needle", {"text": "omega target row"})
+    ops = [
+        PutOp(namespace=("other",), key=f"d{i}", value={"text": f"omega distractor {i}"})
+        for i in range(500)
+    ]
+    store.batch(ops)
+
+    hits = store.search(target_ns, query="omega target", limit=5)
+    assert [h.key for h in hits] == ["needle"]
+
+
+def test_index_false_excluded_from_query_but_scannable(store):
+    store.put(("ix",), "indexed", {"text": "omega indexed"})
+    store.put(("ix",), "hidden", {"text": "omega hidden"}, index=False)
+
+    hits = store.search(("ix",), query="omega")
+    assert {h.key for h in hits} == {"indexed"}
+
+    scan = store.search(("ix",))
+    assert {h.key for h in scan} == {"indexed", "hidden"}
+    assert store.get(("ix",), "hidden") is not None
+
+
+def test_per_op_index_fields_and_multi_instance(store):
+    store.put(
+        ("mv",),
+        "k",
+        {"title": "omega title", "tags": ["alpha special", "zebra unusual"], "skip": "gamma"},
+        index=["tags[*]"],
+    )
+    # findable via either tag instance...
+    assert [h.key for h in store.search(("mv",), query="zebra unusual")] == ["k"]
+    assert [h.key for h in store.search(("mv",), query="alpha special")] == ["k"]
+    # ...but no duplicate results despite two matching vector rows
+    hits = store.search(("mv",), query="alpha zebra")
+    assert [h.key for h in hits] == ["k"]
+    # only the tags[*] instances were indexed — not title/skip (asserted on
+    # the stored rows: the vector leg would match ANY query text, so a
+    # public-API "no result" assertion cannot discriminate here)
+    rows = store.db.run_script(
+        f"?[field, seq, text] := *{store._vecs}{{field, seq, text}}", {}, True
+    )["rows"]
+    assert sorted(rows) == [["tags[*]", 0, "alpha special"], ["tags[*]", 1, "zebra unusual"]]
+
+
+def test_hostile_fts_queries_do_not_raise(store):
+    store.put(("h",), "k", {"text": "alpha content"})
+    for q in ["cat AND (", 'quote " unbalanced', "NEAR^ * ;", "  ", "AND OR NOT"]:
+        store.search(("h",), query=q)  # must not raise
+
+
+def test_dims_mismatch_reopen_raises(tmp_path):
+    s = make_store("sqlite", tmp_path)
+    s.put(("r",), "k", {"text": "alpha"})
+    s.close()
+
+    with pytest.raises(ValueError, match="dim"):
+        MnesticStore(
+            engine="sqlite",
+            path=str(tmp_path / "store.db"),
+            index={"dims": 3, "embed": lambda texts: [[0.0, 0.0, 0.0] for _ in texts]},
+        )
+    with pytest.raises(ValueError, match="IndexConfig"):
+        MnesticStore(engine="sqlite", path=str(tmp_path / "store.db"), index=None)
+
+
+def test_query_on_index_config_fields(tmp_path):
+    s = make_store(
+        "mem", tmp_path, index={**INDEX, "fields": ["summary"]}
+    )
+    s.put(("cf",), "k", {"summary": "zebra findings", "body": "omega body text"})
+    assert [h.key for h in s.search(("cf",), query="zebra")] == ["k"]
+    # only the configured field was extracted/indexed
+    rows = s.db.run_script(f"?[field, text] := *{s._vecs}{{field, text}}", {}, True)["rows"]
+    assert rows == [["summary", "zebra findings"]]
+    s.close()

--- a/cozo-lib-python/integrations/langgraph-store-mnestic/tests/test_ttl.py
+++ b/cozo-lib-python/integrations/langgraph-store-mnestic/tests/test_ttl.py
@@ -1,0 +1,116 @@
+"""TTL: lazy expiry on every read path, refresh-on-read, defaults, and the
+physical sweeper. Uses the injectable clock — no sleeps."""
+
+from tests.conftest import make_store
+
+
+def _clocked(engine, tmp_path, ttl=None):
+    s = make_store(engine, tmp_path, ttl=ttl)
+    clock = {"t": 1000.0}
+    s._now = lambda: clock["t"]
+    return s, clock
+
+
+def test_expiry_across_read_paths(tmp_path):
+    s, clock = _clocked("sqlite", tmp_path)
+    s.put(("t",), "ephemeral", {"text": "alpha fleeting"}, ttl=1.0)  # 1 minute
+    s.put(("t",), "durable", {"text": "alpha lasting"})
+
+    assert s.get(("t",), "ephemeral") is not None
+    clock["t"] = 1000.0 + 61.0
+    assert s.get(("t",), "ephemeral") is None
+    assert s.get(("t",), "durable") is not None
+    assert {i.key for i in s.search(("t",))} == {"durable"}
+    assert {i.key for i in s.search(("t",), query="alpha")} == {"durable"}
+    assert s.list_namespaces() == [("t",)]  # ns survives via the durable item
+    s.close()
+
+
+def test_expired_namespace_disappears(tmp_path):
+    s, clock = _clocked("mem", tmp_path)
+    s.put(("gone",), "only", {"v": 1}, ttl=1.0)
+    assert s.list_namespaces() == [("gone",)]
+    clock["t"] += 120.0
+    assert s.list_namespaces() == []
+    s.close()
+
+
+def test_refresh_on_read_extends(tmp_path):
+    s, clock = _clocked("sqlite", tmp_path, ttl={"refresh_on_read": True})
+    s.put(("t",), "k", {"v": 1}, ttl=1.0)  # expires at t=1060
+
+    clock["t"] = 1050.0
+    item = s.get(("t",), "k", refresh_ttl=True)  # re-arms to 1050+60=1110
+    assert item is not None
+    clock["t"] = 1100.0
+    assert s.get(("t",), "k") is not None  # would be gone without the refresh
+    clock["t"] = 1200.0
+    assert s.get(("t",), "k") is None
+    s.close()
+
+
+def test_refresh_false_does_not_extend(tmp_path):
+    s, clock = _clocked("mem", tmp_path, ttl={"refresh_on_read": True})
+    s.put(("t",), "k", {"v": 1}, ttl=1.0)
+    clock["t"] = 1050.0
+    assert s.get(("t",), "k", refresh_ttl=False) is not None
+    clock["t"] = 1065.0
+    assert s.get(("t",), "k") is None
+    s.close()
+
+
+def test_refresh_config_off_wins(tmp_path):
+    s, clock = _clocked("mem", tmp_path, ttl={"refresh_on_read": False})
+    s.put(("t",), "k", {"v": 1}, ttl=1.0)
+    clock["t"] = 1050.0
+    # base wrapper resolves refresh_ttl from config -> False; even a direct
+    # refresh request must be a no-op because _apply_refresh checks the config
+    assert s.get(("t",), "k", refresh_ttl=True) is not None
+    clock["t"] = 1065.0
+    assert s.get(("t",), "k") is None
+    s.close()
+
+
+def test_default_ttl_applied(tmp_path):
+    s, clock = _clocked("mem", tmp_path, ttl={"default_ttl": 1.0, "refresh_on_read": False})
+    s.put(("t",), "defaulted", {"v": 1})          # picks up default_ttl=1min
+    s.put(("t",), "explicit_none", {"v": 2}, ttl=None)  # explicit None = no TTL
+    clock["t"] = 1075.0
+    assert s.get(("t",), "defaulted") is None
+    assert s.get(("t",), "explicit_none") is not None
+    s.close()
+
+
+def test_refresh_preserves_value_and_updated_at(tmp_path):
+    s, clock = _clocked("sqlite", tmp_path, ttl={"refresh_on_read": True})
+    s.put(("t",), "k", {"payload": "alpha original"}, ttl=10.0)
+    before = s.get(("t",), "k", refresh_ttl=False)
+    clock["t"] = 1030.0
+    refreshed = s.get(("t",), "k", refresh_ttl=True)
+    assert refreshed.value == before.value
+    assert refreshed.updated_at == before.updated_at  # refresh is not an update
+    s.close()
+
+
+def test_sweeper_removes_items_and_index_rows(tmp_path):
+    s, clock = _clocked("sqlite", tmp_path)
+    s.put(("t",), "dead", {"text": "alpha doomed"}, ttl=1.0)
+    s.put(("t",), "alive", {"text": "alpha fine"})
+    clock["t"] = 2000.0
+
+    removed = s.sweep_ttl()
+    assert removed == 1
+
+    items = s.db.run_script(f"?[ns, key] := *{s._items}{{ns, key}}", {}, True)["rows"]
+    vec_keys = {r[1] for r in s.db.run_script(f"?[ns, key] := *{s._vecs}{{ns, key}}", {}, True)["rows"]}
+    assert [r[1] for r in items] == ["alive"]
+    assert vec_keys == {"alive"}
+    s.close()
+
+
+def test_sweeper_thread_lifecycle(tmp_path):
+    s, _clock = _clocked("mem", tmp_path, ttl={"sweep_interval_minutes": 60})
+    s.start_ttl_sweeper()
+    assert s._sweeper_thread is not None and s._sweeper_thread.is_alive()
+    s.close()  # stops the sweeper
+    assert s._sweeper_thread is None

--- a/cozo-lib-python/integrations/mnestic-mcp/README.md
+++ b/cozo-lib-python/integrations/mnestic-mcp/README.md
@@ -1,0 +1,66 @@
+# mnestic-mcp
+
+A local **memory MCP server** backed by
+[mnestic](https://github.com/shuruheel/mnestic) — an embedded graph + vector +
+full-text database (a maintained fork of CozoDB). One process, one file, fully
+local: your agent's memory never leaves the machine.
+
+> mnestic is a maintained fork of [CozoDB](https://github.com/cozodb/cozo); it is not the official CozoDB. Original design credit belongs to Ziyang Hu and the Cozo Project Authors.
+
+## Install
+
+Add to any MCP client (Claude Desktop, Claude Code, Cursor, ...):
+
+```json
+{ "command": "uvx", "args": ["mnestic-mcp"] }
+```
+
+That's it. The database lives in your platform data dir (override with
+`--db PATH` or `MNESTIC_MCP_DB`); embeddings run locally via
+[fastembed](https://github.com/qdrant/fastembed) (default
+`BAAI/bge-small-en-v1.5`, a one-time ~67 MB download that happens in the
+background — keyword search works immediately, before the model arrives).
+Pre-provision with `uvx mnestic-mcp --download-model`.
+
+## Tools
+
+`store`, `store_batch`, `search`, `find_related`, `list_recent`, `update`,
+`delete`, `link`, `recall_as_of`, `stats` — plus the two things no other local
+memory server has:
+
+- **`search(explain=true)`** — per-leg attribution: exactly how much the
+  keyword (BM25), vector (HNSW), and graph-proximity legs each contributed to
+  every result, straight from the engine's fused three-way retrieval. Ask
+  your agent *"why did you recall that?"* and get a real answer.
+- **`recall_as_of(t)`** — time travel. Updates and deletes are never
+  destructive (valid-time history in the engine's bitemporal storage):
+  *"what did you know about this before last Tuesday?"* just works.
+
+`search` is keyword-first with an automatic hybrid fallback; `link` builds a
+typed, weighted memory graph that both `find_related` (budget-bounded
+traversal) and the hybrid graph leg exploit.
+
+## Configuration
+
+| Flag / env | Default | Meaning |
+|---|---|---|
+| `--db` / `MNESTIC_MCP_DB` | per-OS data dir | database file |
+| `--engine` / `MNESTIC_MCP_ENGINE` | `sqlite` | `sqlite` \| `rocksdb` (single-instance) \| `mem` |
+| `--model` / `MNESTIC_MCP_MODEL` | `BAAI/bge-small-en-v1.5` | any fastembed model |
+| `MNESTIC_MCP_CACHE` | data dir `/models` | model cache location |
+
+A database pins the embedding model it was built with — mixing embedding
+spaces is refused with an actionable error, never a silent quality collapse.
+
+## Notes
+
+- Requires Python ≥ 3.10. Storage engines ship in the `mnestic` wheel
+  (`sqlite`/`mem` also in the sdist; `rocksdb` wheel-only).
+- Several MCP clients may share one sqlite database; writes serialize on the
+  file. `rocksdb` is strictly single-instance.
+- Deleting memories under heavy churn can slowly degrade vector recall
+  (a known engine-side HNSW defect, tracked upstream); updates are safe.
+
+## License
+
+Mozilla Public License 2.0.

--- a/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/__init__.py
+++ b/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""Local memory MCP server backed by mnestic."""
+
+__version__ = "0.1.0"

--- a/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/__main__.py
+++ b/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/__main__.py
@@ -1,0 +1,5 @@
+import sys
+
+from mnestic_mcp.cli import main
+
+sys.exit(main())

--- a/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/cli.py
+++ b/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/cli.py
@@ -1,0 +1,80 @@
+"""`mnestic-mcp` entry point: resolve paths, open the db, start the embedder
+warmup in the background, serve MCP over stdio."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+from mnestic_mcp import __version__
+from mnestic_mcp.embeddings import (
+    DEFAULT_MODEL,
+    FastEmbedEmbedder,
+    configure_stderr_logging,
+)
+from mnestic_mcp.memory import MemoryStore
+from mnestic_mcp.paths import default_db_path, model_cache_dir
+from mnestic_mcp.server import build_server
+
+logger = logging.getLogger("mnestic-mcp")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="mnestic-mcp",
+        description="Local memory MCP server backed by mnestic (stdio transport).",
+    )
+    parser.add_argument("--db", default=None, help="database path (default: per-OS data dir, or MNESTIC_MCP_DB)")
+    parser.add_argument(
+        "--engine",
+        default=os.environ.get("MNESTIC_MCP_ENGINE", "sqlite"),
+        choices=["sqlite", "rocksdb", "mem"],
+        help="storage engine (default sqlite; rocksdb is single-instance only)",
+    )
+    parser.add_argument(
+        "--model",
+        default=os.environ.get("MNESTIC_MCP_MODEL", DEFAULT_MODEL),
+        help=f"fastembed model name (default {DEFAULT_MODEL})",
+    )
+    parser.add_argument(
+        "--download-model",
+        action="store_true",
+        help="download/load the embedding model, then exit (for provisioning)",
+    )
+    parser.add_argument("--version", action="version", version=f"mnestic-mcp {__version__}")
+    args = parser.parse_args(argv)
+
+    configure_stderr_logging()
+
+    embedder = FastEmbedEmbedder(model_name=args.model, cache_dir=model_cache_dir())
+    if args.download_model:
+        embedder.wait_ready(timeout=3600.0)
+        logger.info("model %s ready in cache", args.model)
+        return 0
+
+    db_path = args.db or (default_db_path() if args.engine != "mem" else "")
+    from mnestic import CozoDbPy
+
+    try:
+        db = CozoDbPy(args.engine, db_path, "{}")
+    except Exception as e:
+        if args.engine == "rocksdb" and "lock" in str(e).lower():
+            logger.error(
+                "another mnestic-mcp instance already has %s open (rocksdb is "
+                "single-instance). Close it, or use --engine sqlite.",
+                db_path,
+            )
+            return 1
+        raise
+
+    store = MemoryStore(db, embedder, db_path=db_path, engine=args.engine)
+    embedder.start_warmup()  # download races the first minutes of conversation
+    logger.info("serving memory at %s (%s), model %s", db_path or "<mem>", args.engine, args.model)
+    build_server(store).run()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/embeddings.py
+++ b/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/embeddings.py
@@ -1,0 +1,123 @@
+"""Embedding provider. Production uses fastembed (ONNX, local, ~67 MB one-time
+model download for the default BAAI/bge-small-en-v1.5); tests inject a
+deterministic embedder with the same duck-typed surface:
+
+    dim: int, model_name: str, embed_documents(texts), embed_query(text),
+    ready() -> bool, wait_ready(timeout) -> None (raises if unavailable)
+
+The fastembed import lives ONLY in this module, behind `FastEmbedEmbedder`.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import time
+from typing import List, Optional
+
+logger = logging.getLogger("mnestic-mcp")
+
+DEFAULT_MODEL = "BAAI/bge-small-en-v1.5"
+
+
+def model_dim(model_name: str) -> int:
+    """Resolve a model's embedding dimension from fastembed's offline registry
+    (no download). Raises for unknown models with the supported list."""
+    from fastembed import TextEmbedding
+
+    for entry in TextEmbedding.list_supported_models():
+        if entry["model"].lower() == model_name.lower():
+            return int(entry["dim"])
+    known = ", ".join(sorted(e["model"] for e in TextEmbedding.list_supported_models())[:10])
+    raise ValueError(
+        f"unknown fastembed model {model_name!r}. First supported models: {known}, ..."
+    )
+
+
+class FastEmbedEmbedder:
+    """Lazy/background-eager fastembed wrapper.
+
+    `start_warmup()` loads (and on first run downloads) the model on a daemon
+    thread so the MCP server answers `initialize` instantly; embedding tools
+    call `wait_ready()` and get a crisp, actionable error if the model could
+    not be fetched (keyword search never needs it)."""
+
+    def __init__(self, model_name: str = DEFAULT_MODEL, cache_dir: Optional[str] = None) -> None:
+        self.model_name = model_name
+        self.cache_dir = cache_dir
+        self.dim = model_dim(model_name)
+        self._model = None
+        self._lock = threading.Lock()
+        self._ready = threading.Event()
+        self._error: Optional[BaseException] = None
+        self._warmup_thread: Optional[threading.Thread] = None
+
+    def ready(self) -> bool:
+        return self._ready.is_set() and self._error is None
+
+    def start_warmup(self) -> None:
+        if self._warmup_thread is not None or self._ready.is_set():
+            return
+        thread = threading.Thread(target=self._load, name="mnestic-mcp-embed-warmup", daemon=True)
+        self._warmup_thread = thread
+        thread.start()
+
+    def _load(self) -> None:
+        try:
+            from fastembed import TextEmbedding
+
+            started = time.monotonic()
+            logger.info(
+                "loading embedding model %s (first run downloads ~tens of MB, once, to %s)...",
+                self.model_name,
+                self.cache_dir or "the fastembed cache",
+            )
+            model = TextEmbedding(model_name=self.model_name, cache_dir=self.cache_dir)
+            next(iter(model.embed(["warmup"])))  # force ONNX session init
+            with self._lock:
+                self._model = model
+            logger.info("embedding model ready (%.1fs)", time.monotonic() - started)
+        except BaseException as e:  # noqa: BLE001 - captured and re-raised on use
+            self._error = e
+            logger.error("embedding model failed to load: %s", e)
+        finally:
+            self._ready.set()
+
+    def wait_ready(self, timeout: float = 120.0) -> None:
+        self.start_warmup()
+        if not self._ready.wait(timeout):
+            raise RuntimeError(
+                f"the embedding model ({self.model_name}) is still downloading/loading. "
+                "Keyword search, list_recent, recall_as_of and stats work now; retry "
+                "semantic search shortly, or pre-download with `mnestic-mcp --download-model`."
+            )
+        if self._error is not None:
+            raise RuntimeError(
+                f"the embedding model ({self.model_name}) could not be loaded: {self._error}. "
+                "Keyword search still works. Check network access (HuggingFace Hub) and disk "
+                "space, then retry or run `mnestic-mcp --download-model`."
+            )
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        self.wait_ready()
+        with self._lock:
+            return [[float(x) for x in v] for v in self._model.embed(list(texts))]
+
+    def embed_query(self, text: str) -> List[float]:
+        self.wait_ready()
+        with self._lock:
+            return [float(x) for x in next(iter(self._model.query_embed(text)))]
+
+
+def configure_stderr_logging() -> None:
+    """stdout is the MCP wire — everything human-facing goes to stderr."""
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.INFO,
+        format="mnestic-mcp: %(message)s",
+    )
+    if not sys.stderr.isatty():
+        import os
+
+        os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")

--- a/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/instructions.py
+++ b/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/instructions.py
@@ -1,0 +1,40 @@
+"""Server instructions surfaced to the model at `initialize`. Structure adapted
+from mindgraph-mcp's keyword-first retrieval ladder — prose only, no ontology."""
+
+INSTRUCTIONS = """\
+You have a persistent local memory (mnestic-mcp). Everything stays on this machine.
+
+## #1 RULE: go straight to the user's topic
+One `search` call with 1-3 discriminating keyword terms from their message. Nothing
+else first. There is no session to open and no context to pre-load.
+  YES: search({query: "Kissinger NATO"})
+  NO:  search({query: "what did the user previously say about..."})
+
+## Search ladder — keyword first, semantic as fallback
+The default mode "auto" tries keywords (BM25) first and falls back to hybrid.
+Escalate yourself when results are thin:
+1. fewer, more discriminating terms (proper nouns, technical terms; drop filler)
+2. synonyms
+3. mode "semantic" (natural-language queries are fine there)
+4. mode "hybrid" — BM25 + vector + graph proximity fused in one call.
+Very common words are stopworded on the keyword leg; prefer distinctive terms.
+
+## Orient, then expand
+`search` returns compact results. To explore around a strong hit, call
+`find_related(id)` (budget-bounded graph walk over links). For "what have I
+told you lately", use `list_recent`.
+
+## When to WRITE
+Store durable facts, preferences, decisions, and outcomes as they occur — one
+fact per memory, a sentence or two, with meta tags like {"topic": ..., "kind": ...}.
+Use `link(src, dst, rel)` when two memories belong together (rel names a
+mechanism: "relates_to", "follows", "contradicts"). Use `update` for
+corrections — never store a duplicate. Don't narrate tool usage.
+
+## The two tools no other memory server has
+- search(explain=true): per-leg attribution — exactly how much the keyword,
+  vector, and graph legs each contributed to every result. Use when the user
+  asks "why did you recall that?" or when retrieval needs debugging.
+- recall_as_of(t): the memory store as it existed at time t — updates and
+  deletes are never destructive. Use for "what did you know before X?".
+"""

--- a/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/memory.py
+++ b/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/memory.py
@@ -1,0 +1,494 @@
+"""`MemoryStore` — all engine access for the MCP server. Embedder- and
+MCP-agnostic (takes an injected embedder; tests use a deterministic one).
+
+Storage layout (targets the published mnestic 0.12.2 wheel):
+
+- `memories {id => text, meta, created_at, updated_at, emb}` — current state,
+  with HNSW (`:vec`) + FTS (`:fts`) indexes created at init, before any data.
+- `memories_hist {id, at: Validity => text, meta, created_at}` — valid-time
+  history, app-stamped integer MICROseconds (a per-process monotonic clock).
+  Updates assert a new interval; deletes assert a retraction — `recall_as_of`
+  reads `@ t`. Timestamps are validated `>= 0` in Python: the 0.12.2 engine
+  panics on pre-epoch validity stamps.
+- `links {src, dst, rel => weight, created_at}` — typed weighted edges,
+  mechanism-named rels. Feeds the hybrid graph leg and `find_related`.
+- `db_meta {k => v}` — schema version + embedding-model pinning (a db built
+  with one model must never silently mix embedding spaces with another).
+
+Every multi-statement write is one `{...} {...}` script = one atomic engine
+transaction (verified: a failing later block rolls back the earlier ones).
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+SCHEMA_VERSION = "1"
+
+_WORD = re.compile(r"\w+", re.UNICODE)
+
+
+def _iso(us: int) -> str:
+    return datetime.fromtimestamp(us / 1e6, tz=timezone.utc).isoformat()
+
+
+def _fts_query(text: str) -> str:
+    # Lowercased word tokens, comma-joined = OR-of-terms (whitespace would be
+    # AND; bare uppercase AND/OR/NOT/NEAR are operators; punctuation can fail
+    # the FTS grammar). Note the index stopwords very common English words.
+    return ", ".join(t.lower() for t in _WORD.findall(text or ""))
+
+
+def parse_when(t: str) -> str:
+    """Validate an ISO-8601 timestamp and return it in the form the engine's
+    validity parser accepts. Pre-epoch instants are rejected in Python — the
+    0.12.2 engine panics on them."""
+    raw = (t or "").strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError as e:
+        raise ValueError(f"not an ISO-8601 timestamp: {t!r} ({e})") from None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    if dt.timestamp() < 0:
+        raise ValueError(f"timestamps before 1970-01-01 are not supported (got {t!r})")
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+class MemoryStore:
+    def __init__(
+        self,
+        db: Any,
+        embedder: Any,
+        *,
+        db_path: str = "",
+        engine: str = "",
+        rrf_k: float = 60.0,
+    ) -> None:
+        self.db = db
+        self.embedder = embedder
+        self.db_path = db_path
+        self.engine = engine
+        self.rrf_k = float(rrf_k)
+        self._clock_lock = threading.Lock()
+        self._last_us = 0
+        self._time_us = lambda: time.time_ns() // 1000  # injectable (tests)
+        self.ensure_schema()
+
+    # --- clock ---
+
+    def _now_us(self) -> int:
+        with self._clock_lock:
+            t = int(self._time_us())
+            if t < 0:
+                raise ValueError("system clock reports a pre-1970 time; refusing to write")
+            if t <= self._last_us:
+                t = self._last_us + 1
+            self._last_us = t
+            return t
+
+    # --- schema ---
+
+    def ensure_schema(self) -> None:
+        dim = int(self.embedder.dim)
+        rels = {r[0] for r in self.db.run_script("::relations", {}, True)["rows"]}
+        if "memories" not in rels:
+            self.db.run_script(
+                f":create memories {{id: String => text: String, meta: Json, "
+                f"created_at: Int, updated_at: Int, emb: <F32; {dim}>}}",
+                {},
+                False,
+            )
+        if "memories_hist" not in rels:
+            self.db.run_script(
+                ":create memories_hist {id: String, at: Validity => text: String, "
+                "meta: Json, created_at: Int}",
+                {},
+                False,
+            )
+        if "links" not in rels:
+            self.db.run_script(
+                ":create links {src: String, dst: String, rel: String => "
+                "weight: Float, created_at: Int}",
+                {},
+                False,
+            )
+        if "db_meta" not in rels:
+            self.db.run_script(":create db_meta {k: String => v: String}", {}, False)
+
+        idx = {r[0] for r in self.db.run_script("::indices memories", {}, True)["rows"]}
+        if "vec" not in idx:
+            self.db.run_script(
+                f"::hnsw create memories:vec {{dim: {dim}, m: 16, dtype: F32, "
+                f"fields: [emb], distance: Cosine, ef_construction: 50}}",
+                {},
+                False,
+            )
+        if "fts" not in idx:
+            self.db.run_script(
+                "::fts create memories:fts {extractor: text, tokenizer: Simple, "
+                "filters: [Lowercase, Stemmer('English'), Stopwords('en')]}",
+                {},
+                False,
+            )
+        self._pin_model(dim)
+
+    def _pin_model(self, dim: int) -> None:
+        rows = self.db.run_script("?[k, v] := *db_meta{k, v}", {}, True)["rows"]
+        meta = {k: v for k, v in rows}
+        model = getattr(self.embedder, "model_name", "unknown")
+        if not meta:
+            self.db.run_script(
+                "?[k, v] <- $rows :put db_meta {k => v}",
+                {
+                    "rows": [
+                        ["schema_version", SCHEMA_VERSION],
+                        ["model_name", model],
+                        ["model_dim", str(dim)],
+                    ]
+                },
+                False,
+            )
+            return
+        pinned_model, pinned_dim = meta.get("model_name"), meta.get("model_dim")
+        if pinned_model != model or pinned_dim != str(dim):
+            raise ValueError(
+                f"this database was built with embedding model {pinned_model!r} "
+                f"({pinned_dim}-d); you asked for {model!r} ({dim}-d). Embedding "
+                "spaces cannot be mixed — use a different --db, or re-store your "
+                "memories with the new model."
+            )
+
+    # --- writes ---
+
+    def store(self, text: str, meta: Optional[dict] = None, id: Optional[str] = None) -> dict:
+        out = self.store_batch([{"text": text, "meta": meta or {}, "id": id}])
+        return {"id": out["ids"][0], "created_at": out["created_at"]}
+
+    def store_batch(self, items: List[dict]) -> dict:
+        if not items:
+            return {"ids": [], "count": 0, "created_at": None}
+        texts = [str(it["text"]) for it in items]
+        ids = [it.get("id") or uuid.uuid4().hex for it in items]
+        metas = [dict(it.get("meta") or {}) for it in items]
+        embs = self.embedder.embed_documents(texts)
+        t = self._now_us()
+        rows = [[i, tx, m, t, t, e] for i, tx, m, e in zip(ids, texts, metas, embs)]
+        hrows = [[i, [t, True], tx, m, t] for i, tx, m in zip(ids, texts, metas)]
+        self.db.run_script(
+            "{?[id, text, meta, created_at, updated_at, emb] <- $rows "
+            ":put memories {id => text, meta, created_at, updated_at, emb}} "
+            "{?[id, at, text, meta, created_at] <- $hrows "
+            ":put memories_hist {id, at => text, meta, created_at}}",
+            {"rows": rows, "hrows": hrows},
+            False,
+        )
+        return {"ids": ids, "count": len(ids), "created_at": _iso(t)}
+
+    def update(
+        self, id: str, text: Optional[str] = None, meta: Optional[dict] = None
+    ) -> dict:
+        cur = self._fetch([id])
+        if id not in cur:
+            raise ValueError(f"no memory with id {id!r}")
+        cur_text, cur_meta, created_at = cur[id]
+        new_text = cur_text if text is None else str(text)
+        new_meta = {**cur_meta, **(meta or {})}
+        if text is not None and new_text != cur_text:
+            emb = self.embedder.embed_documents([new_text])[0]
+        else:
+            emb = None
+        t = self._now_us()
+        blocks = [
+            "{?[id, at, text, meta, created_at] <- $hrows "
+            ":put memories_hist {id, at => text, meta, created_at}}"
+        ]
+        params: Dict[str, Any] = {
+            "hrows": [[id, [t, True], new_text, new_meta, created_at]],
+        }
+        if emb is not None:
+            blocks.insert(
+                0,
+                "{?[id, text, meta, created_at, updated_at, emb] <- $rows "
+                ":put memories {id => text, meta, created_at, updated_at, emb}}",
+            )
+            params["rows"] = [[id, new_text, new_meta, created_at, t, emb]]
+        else:
+            blocks.insert(
+                0,
+                "{keep[id, emb] := id = $id, *memories{id, emb} "
+                "?[id, text, meta, created_at, updated_at, emb] := keep[id, emb], "
+                "text = $text, meta = $meta, created_at = $ca, updated_at = $ua "
+                ":put memories {id => text, meta, created_at, updated_at, emb}}",
+            )
+            params.update(
+                {"id": id, "text": new_text, "meta": new_meta, "ca": created_at, "ua": t}
+            )
+        self.db.run_script(" ".join(blocks), params, False)
+        return {"id": id, "updated_at": _iso(t)}
+
+    def delete(self, id: str) -> dict:
+        existed = id in self._fetch([id])
+        if not existed:
+            return {"deleted": False}
+        t = self._now_us()
+        self.db.run_script(
+            "{?[id] <- [[$id]] :rm memories {id}} "
+            "{?[id, at, text, meta, created_at] <- [[$id, [$t, false], '', {}, $t]] "
+            ":put memories_hist {id, at => text, meta, created_at}} "
+            "{?[src, dst, rel] := *links{src, dst, rel}, (src == $id or dst == $id) "
+            ":rm links {src, dst, rel}}",
+            {"id": id, "t": t},
+            False,
+        )
+        return {"deleted": True}
+
+    def link(self, src: str, dst: str, rel: str = "relates_to", weight: float = 1.0) -> dict:
+        present = self._fetch([src, dst])
+        missing = [x for x in (src, dst) if x not in present]
+        if missing:
+            raise ValueError(f"unknown memory id(s): {missing}")
+        self.db.run_script(
+            "?[src, dst, rel, weight, created_at] <- [[$src, $dst, $rel, $w, $t]] "
+            ":put links {src, dst, rel => weight, created_at}",
+            {"src": src, "dst": dst, "rel": str(rel), "w": float(weight), "t": self._now_us()},
+            False,
+        )
+        return {"linked": True}
+
+    # --- reads ---
+
+    def _fetch(self, ids: List[str]) -> Dict[str, tuple]:
+        rows = self.db.run_script(
+            "idset[id] <- $ids "
+            "?[id, text, meta, created_at] := idset[id], *memories{id, text, meta, created_at}",
+            {"ids": [[i] for i in ids]},
+            True,
+        )["rows"]
+        return {r[0]: (r[1], r[2], r[3]) for r in rows}
+
+    def _row_out(self, id: str, text: str, meta: dict, created_at: int, score=None) -> dict:
+        out = {"id": id, "text": text, "meta": meta, "created_at": _iso(created_at)}
+        if score is not None:
+            out["score"] = float(score)
+        return out
+
+    def search(
+        self,
+        query: str,
+        k: int = 8,
+        mode: str = "auto",
+        explain: bool = False,
+        expand_graph: bool = True,
+    ) -> dict:
+        if mode not in ("auto", "keyword", "semantic", "hybrid"):
+            raise ValueError(f"unknown mode {mode!r}")
+        k = max(1, min(int(k), 100))
+        if explain:
+            mode = "hybrid"
+
+        if mode in ("auto", "keyword"):
+            results = self._search_keyword(query, k)
+            if mode == "keyword" or results:
+                return {"results": results, "mode_used": "keyword"}
+            mode = "hybrid"  # auto fallback
+
+        if mode == "semantic":
+            return {"results": self._search_semantic(query, k), "mode_used": "semantic"}
+
+        return self._search_hybrid(query, k, explain=explain, expand_graph=expand_graph)
+
+    def _search_keyword(self, query: str, k: int) -> List[dict]:
+        qt = _fts_query(query)
+        if not qt:
+            return []
+        rows = self.db.run_script(
+            f"?[id, text, meta, created_at, score] := "
+            f"~memories:fts{{id, text, meta, created_at | query: $q, k: {k}, bind_score: score}}\n"
+            f":order -score\n:limit {k}",
+            {"q": qt},
+            True,
+        )["rows"]
+        return [self._row_out(r[0], r[1], r[2], r[3], r[4]) for r in rows]
+
+    def _search_semantic(self, query: str, k: int) -> List[dict]:
+        qv = self.embedder.embed_query(query)
+        rows = self.db.run_script(
+            f"?[id, text, meta, created_at, dist] := "
+            f"~memories:vec{{id, text, meta, created_at | query: vec($qv), k: {k}, "
+            f"ef: {max(50, 2 * k)}, bind_distance: dist}}\n"
+            f":order dist\n:limit {k}",
+            {"qv": [float(x) for x in qv]},
+            True,
+        )["rows"]
+        return [self._row_out(r[0], r[1], r[2], r[3], -r[4]) for r in rows]
+
+    def _has_links(self) -> bool:
+        return bool(self.db.run_script("?[src] := *links{src} :limit 1", {}, True)["rows"])
+
+    def _search_hybrid(self, query: str, k: int, *, explain: bool, expand_graph: bool) -> dict:
+        qv = self.embedder.embed_query(query)
+        qt = _fts_query(query)
+        # All hybrid_search construction lives here — single upgrade site when
+        # an engine with optional legs / seed_from_legs ships (0.14.0+).
+        hq: Dict[str, Any] = {
+            "relation": "memories",
+            "id_col": "id",
+            "vector_index": "vec",
+            "query_vector": [float(x) for x in qv],
+            "vector_k": max(k, 10),
+            "ef": max(50, 2 * k),
+            "fts_index": "fts",
+            # 0.12.2 requires both legs. When sanitization leaves no tokens
+            # (punctuation/whitespace-only queries) use a harmless placeholder
+            # term — never the raw text, which can fail the FTS grammar.
+            "query_text": qt or "xnomatchx",
+            "fts_k": max(k, 10),
+            "rrf_k": self.rrf_k,
+            "limit": max(k, 10),
+            "detailed": bool(explain),
+        }
+        seeds: List[str] = []
+        if expand_graph and self._has_links():
+            seeds = [r["id"] for r in self._search_keyword(query, 3)]
+            if seeds:
+                hq["graph_legs"] = [
+                    {
+                        "edge_relation": "links",
+                        "from_col": "src",
+                        "to_col": "dst",
+                        "seeds": seeds,
+                        "max_hops": 2,
+                        "undirected": True,
+                        "label": "graph",
+                    }
+                ]
+        res = self.db.hybrid_search(hq)
+        out: Dict[str, Any] = {"mode_used": "hybrid"}
+        if explain:
+            ranked, per_result = self._parse_detailed(res["rows"], k)
+            legs = {
+                "semantic": "vector (HNSW cosine)",
+                "text": "keyword (BM25)",
+            }
+            if seeds:
+                legs["graph"] = f"graph proximity within 2 hops of seeds {seeds}"
+            out["explain"] = {"legs": legs, "per_result": per_result}
+        else:
+            ranked = [(r[0], float(r[1])) for r in res["rows"]][:k]
+        by_id = self._fetch([rid for rid, _ in ranked])
+        out["results"] = [
+            self._row_out(rid, *by_id[rid], score=score)
+            for rid, score in ranked
+            if rid in by_id
+        ]
+        return out
+
+    @staticmethod
+    def _parse_detailed(rows: List[list], k: int):
+        """Long-format rows [id, score, list_id, leg_rank, leg_score] ->
+        (fused ranking, per-result leg contributions)."""
+        fused: Dict[str, float] = {}
+        contribs: Dict[str, List[dict]] = {}
+        for rid, score, list_id, leg_rank, leg_score in rows:
+            fused.setdefault(rid, float(score))
+            contribs.setdefault(rid, []).append(
+                {"leg": list_id, "rank": int(leg_rank), "raw_score": float(leg_score)}
+            )
+        ranked = sorted(fused.items(), key=lambda kv: -kv[1])[:k]
+        per_result = [
+            {"id": rid, "fused_score": score, "contributions": contribs[rid]}
+            for rid, score in ranked
+        ]
+        return ranked, per_result
+
+    def find_related(
+        self, id: str, max_nodes: int = 25, max_depth: int = 3, weighted: bool = False
+    ) -> dict:
+        if id not in self._fetch([id]):
+            raise ValueError(f"no memory with id {id!r}")
+        edge_rule = (
+            "e[fr, to, w] := *links{src: fr, dst: to, weight: w}"
+            if weighted
+            else "e[fr, to] := *links{src: fr, dst: to}"
+        )
+        edge_head = "e[fr, to, w]" if weighted else "e[fr, to]"
+        rows = self.db.run_script(
+            f"seeds[n] <- [[$id]]\n{edge_rule}\n"
+            f"?[node, cost, parent, depth] <~ BudgetedTraversal({edge_head}, seeds[n], "
+            f"max_nodes: {max(1, min(int(max_nodes), 500))}, "
+            f"max_depth: {max(1, min(int(max_depth), 16))}, undirected: true)",
+            {"id": id},
+            True,
+        )["rows"]
+        related_rows = [r for r in rows if r[0] != id]
+        by_id = self._fetch([r[0] for r in related_rows])
+        related = []
+        for node, cost, parent, depth in sorted(related_rows, key=lambda r: (r[1], r[0])):
+            if node not in by_id:
+                continue
+            text, meta, created_at = by_id[node]
+            entry = self._row_out(node, text, meta, created_at)
+            entry.update({"cost": float(cost), "depth": int(depth), "parent": parent})
+            related.append(entry)
+        return {"related": related}
+
+    def list_recent(self, n: int = 10) -> dict:
+        rows = self.db.run_script(
+            f"?[id, text, meta, created_at, updated_at] := "
+            f"*memories{{id, text, meta, created_at, updated_at}}\n"
+            f":order -updated_at\n:limit {max(1, min(int(n), 200))}",
+            {},
+            True,
+        )["rows"]
+        return {"memories": [self._row_out(r[0], r[1], r[2], r[3]) for r in rows]}
+
+    def recall_as_of(self, t: str, query: Optional[str] = None, k: int = 20) -> dict:
+        when = parse_when(t)
+        k = max(1, min(int(k), 200))
+        if query:
+            script = (
+                f"?[id, text, meta, created_at] := "
+                f"*memories_hist{{id, text, meta, created_at @ $t}}, "
+                f"str_includes(lowercase(text), lowercase($q))\n"
+                f":order -created_at\n:limit {k}"
+            )
+            params = {"t": when, "q": str(query)}
+        else:
+            script = (
+                f"?[id, text, meta, created_at] := "
+                f"*memories_hist{{id, text, meta, created_at @ $t}}\n"
+                f":order -created_at\n:limit {k}"
+            )
+            params = {"t": when}
+        rows = self.db.run_script(script, params, True)["rows"]
+        return {
+            "as_of": when,
+            "memories": [self._row_out(r[0], r[1], r[2], r[3]) for r in rows],
+        }
+
+    def stats(self) -> dict:
+        def _count(script: str) -> int:
+            rows = self.db.run_script(script, {}, True)["rows"]
+            return int(rows[0][0]) if rows else 0
+
+        indices = [r[0] for r in self.db.run_script("::indices memories", {}, True)["rows"]]
+        return {
+            "db_path": self.db_path,
+            "engine": self.engine,
+            "memories": _count("?[count(id)] := *memories{id}"),
+            "links": _count("?[count(rel)] := *links{src, dst, rel}"),
+            "history_rows": _count("?[count(at)] := *memories_hist{id, at}"),
+            "indices": indices,
+            "model": getattr(self.embedder, "model_name", "unknown"),
+            "dim": int(self.embedder.dim),
+            "embedder_ready": bool(self.embedder.ready()),
+            "schema_version": SCHEMA_VERSION,
+        }

--- a/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/paths.py
+++ b/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/paths.py
@@ -1,0 +1,35 @@
+"""Per-OS data/model directory resolution. No platformdirs dependency."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def data_dir() -> Path:
+    if sys.platform == "darwin":
+        base = Path.home() / "Library" / "Application Support"
+    elif os.name == "nt":
+        base = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / "AppData" / "Local")))
+    else:
+        base = Path(os.environ.get("XDG_DATA_HOME", str(Path.home() / ".local" / "share")))
+    return base / "mnestic-mcp"
+
+
+def default_db_path() -> str:
+    env = os.environ.get("MNESTIC_MCP_DB")
+    if env:
+        return env
+    d = data_dir()
+    d.mkdir(parents=True, exist_ok=True)
+    return str(d / "memory.db")
+
+
+def model_cache_dir() -> str:
+    env = os.environ.get("MNESTIC_MCP_CACHE")
+    if env:
+        return env
+    d = data_dir() / "models"
+    d.mkdir(parents=True, exist_ok=True)
+    return str(d)

--- a/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/server.py
+++ b/cozo-lib-python/integrations/mnestic-mcp/mnestic_mcp/server.py
@@ -1,0 +1,89 @@
+"""FastMCP wiring: 10 thin tools delegating to `MemoryStore`. Tool names speak
+mechanism (store/search/link/recall), never a cognitive ontology."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+from mcp.server.fastmcp import FastMCP
+
+from mnestic_mcp.instructions import INSTRUCTIONS
+from mnestic_mcp.memory import MemoryStore
+
+
+def build_server(store: MemoryStore) -> FastMCP:
+    mcp = FastMCP(name="mnestic-memory", instructions=INSTRUCTIONS)
+
+    @mcp.tool()
+    def store_memory(text: str, meta: Optional[dict] = None, id: Optional[str] = None) -> dict:
+        """Store one memory (a durable fact, preference, decision, or outcome).
+        Returns its id."""
+        return store.store(text, meta=meta, id=id)
+
+    @mcp.tool()
+    def store_batch(items: List[dict]) -> dict:
+        """Store many memories atomically. Each item: {text, meta?, id?}."""
+        return store.store_batch(items)
+
+    @mcp.tool()
+    def search(
+        query: str,
+        k: int = 8,
+        mode: str = "auto",
+        explain: bool = False,
+        expand_graph: bool = True,
+    ) -> dict:
+        """Search memories. mode: auto (keyword-first, hybrid fallback),
+        keyword (BM25), semantic (vector), hybrid (BM25+vector+graph fused).
+        explain=true returns per-leg attribution for every result."""
+        return store.search(query, k=k, mode=mode, explain=explain, expand_graph=expand_graph)
+
+    @mcp.tool()
+    def find_related(
+        id: str, max_nodes: int = 25, max_depth: int = 3, weighted: bool = False
+    ) -> dict:
+        """Walk the link graph outward from a memory (budget-bounded traversal);
+        returns related memories with cost/depth/parent."""
+        return store.find_related(id, max_nodes=max_nodes, max_depth=max_depth, weighted=weighted)
+
+    @mcp.tool()
+    def list_recent(n: int = 10) -> dict:
+        """The most recently stored or updated memories."""
+        return store.list_recent(n)
+
+    @mcp.tool()
+    def update(id: str, text: Optional[str] = None, meta: Optional[dict] = None) -> dict:
+        """Correct or extend a memory (meta is merged). History is preserved
+        for recall_as_of."""
+        return store.update(id, text=text, meta=meta)
+
+    @mcp.tool()
+    def delete(id: str) -> dict:
+        """Delete a memory (its history stays recallable via recall_as_of)."""
+        return store.delete(id)
+
+    @mcp.tool()
+    def link(src: str, dst: str, rel: str = "relates_to", weight: float = 1.0) -> dict:
+        """Create a typed, weighted edge between two memories (rel names a
+        mechanism, e.g. relates_to / follows / contradicts)."""
+        return store.link(src, dst, rel=rel, weight=weight)
+
+    @mcp.tool()
+    def recall_as_of(t: str, query: Optional[str] = None, k: int = 20) -> dict:
+        """What the memory store contained at ISO-8601 instant t (time travel;
+        updates/deletes are never destructive)."""
+        return store.recall_as_of(t, query=query, k=k)
+
+    @mcp.tool()
+    def stats() -> dict:
+        """Store diagnostics: counts, indices, db path, embedding model."""
+        return store.stats()
+
+    return mcp
+
+
+def tool_names(mcp: FastMCP) -> List[str]:  # pragma: no cover - trivial
+    return [t.name for t in mcp._tool_manager.list_tools()]
+
+
+__all__: Any = ["build_server", "tool_names"]

--- a/cozo-lib-python/integrations/mnestic-mcp/pyproject.toml
+++ b/cozo-lib-python/integrations/mnestic-mcp/pyproject.toml
@@ -1,0 +1,28 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "mnestic-mcp"
+version = "0.1.0"
+description = "Local memory MCP server backed by mnestic — hybrid BM25+vector+graph recall with per-leg attribution and time travel, all on your machine."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MPL-2.0" }
+authors = [{ name = "Shan Rizvi" }]
+keywords = ["mcp", "model-context-protocol", "memory", "agent-memory", "mnestic", "hybrid-search", "cozodb"]
+dependencies = [
+    "mnestic>=0.12.2",
+    "mcp>=1.27,<2",
+    "fastembed>=0.8",
+]
+
+[project.scripts]
+mnestic-mcp = "mnestic_mcp.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/shuruheel/mnestic"
+Repository = "https://github.com/shuruheel/mnestic"
+
+[tool.hatch.build.targets.wheel]
+packages = ["mnestic_mcp"]

--- a/cozo-lib-python/integrations/mnestic-mcp/tests/conftest.py
+++ b/cozo-lib-python/integrations/mnestic-mcp/tests/conftest.py
@@ -1,0 +1,71 @@
+"""Deterministic 2-D keyword embedder (house pattern — no network/ML deps) and
+a tmp-sqlite MemoryStore fixture. The schema takes its dim from the embedder,
+so tests build 2-d HNSW indexes."""
+
+from typing import List
+
+import pytest
+
+from mnestic_mcp.memory import MemoryStore
+
+GRADIENT = {
+    "alpha": [1.0, 0.0],
+    "beta": [0.95, 0.05],
+    "gamma": [0.85, 0.15],
+    "delta": [0.7, 0.3],
+    "omega": [0.0, 1.0],
+}
+
+
+def gvec(text: str) -> List[float]:
+    t = text.lower()
+    for tok, vec in GRADIENT.items():
+        if tok in t:
+            return list(vec)
+    return [0.5, 0.5]
+
+
+class KeywordEmbedder:
+    model_name = "test-keyword-2d"
+    dim = 2
+
+    def embed_documents(self, texts):
+        return [gvec(t) for t in texts]
+
+    def embed_query(self, text):
+        return gvec(text)
+
+    def ready(self):
+        return True
+
+    def wait_ready(self, timeout: float = 0.0):
+        return None
+
+
+class NeverReadyEmbedder(KeywordEmbedder):
+    model_name = "test-never-ready"
+
+    def ready(self):
+        return False
+
+    def wait_ready(self, timeout: float = 0.0):
+        raise RuntimeError("the embedding model (test) is still downloading/loading")
+
+    def embed_documents(self, texts):
+        self.wait_ready()
+
+    def embed_query(self, text):
+        self.wait_ready()
+
+
+def make_memory(tmp_path, engine: str = "sqlite", embedder=None) -> MemoryStore:
+    from mnestic import CozoDbPy
+
+    path = str(tmp_path / "memory.db") if engine == "sqlite" else ""
+    db = CozoDbPy(engine, path, "{}")
+    return MemoryStore(db, embedder or KeywordEmbedder(), db_path=path, engine=engine)
+
+
+@pytest.fixture()
+def mem(tmp_path):
+    return make_memory(tmp_path)

--- a/cozo-lib-python/integrations/mnestic-mcp/tests/test_fastembed_real.py
+++ b/cozo-lib-python/integrations/mnestic-mcp/tests/test_fastembed_real.py
@@ -1,0 +1,30 @@
+"""Real fastembed integration — downloads the model (~67 MB, once). Opt-in:
+MNESTIC_MCP_TEST_FASTEMBED=1 pytest tests/test_fastembed_real.py"""
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("MNESTIC_MCP_TEST_FASTEMBED"),
+    reason="set MNESTIC_MCP_TEST_FASTEMBED=1 to run the real-model test",
+)
+
+
+def test_real_model_roundtrip(tmp_path):
+    from mnestic import CozoDbPy
+
+    from mnestic_mcp.embeddings import DEFAULT_MODEL, FastEmbedEmbedder
+    from mnestic_mcp.memory import MemoryStore
+
+    emb = FastEmbedEmbedder(model_name=DEFAULT_MODEL, cache_dir=str(tmp_path / "models"))
+    assert emb.dim == 384  # registry-resolved before any download
+
+    emb.wait_ready(timeout=600.0)
+    db = CozoDbPy("sqlite", str(tmp_path / "m.db"), "{}")
+    store = MemoryStore(db, emb, db_path=str(tmp_path / "m.db"), engine="sqlite")
+
+    store.store("the mitochondria is the powerhouse of the cell")
+    store.store("paris is the capital of france")
+    hits = store.search("cellular energy production", mode="semantic")["results"]
+    assert hits and "mitochondria" in hits[0]["text"]

--- a/cozo-lib-python/integrations/mnestic-mcp/tests/test_mcp_protocol.py
+++ b/cozo-lib-python/integrations/mnestic-mcp/tests/test_mcp_protocol.py
@@ -1,0 +1,62 @@
+"""Protocol-level smoke: a real MCP client session against the server,
+in-process (no subprocess/stdio flakiness)."""
+
+import json
+
+import anyio
+import pytest
+from mcp.shared.memory import create_connected_server_and_client_session
+
+from mnestic_mcp.server import build_server
+
+from tests.conftest import make_memory
+
+
+def test_initialize_list_tools_store_search(tmp_path):
+    store = make_memory(tmp_path)
+    mcp = build_server(store)
+
+    async def flow():
+        async with create_connected_server_and_client_session(
+            mcp._mcp_server
+        ) as client:
+            init = await client.initialize()
+            assert "no session" in (init.instructions or "")
+
+            tools = await client.list_tools()
+            assert len(tools.tools) == 10
+
+            stored = await client.call_tool(
+                "store_memory", {"text": "alpha protocol fact", "meta": {"k": 1}}
+            )
+            assert not stored.isError
+            payload = json.loads(stored.content[0].text)
+            assert payload["id"]
+
+            found = await client.call_tool("search", {"query": "protocol"})
+            assert not found.isError
+            results = json.loads(found.content[0].text)["results"]
+            assert [r["id"] for r in results] == [payload["id"]]
+
+            st = await client.call_tool("stats", {})
+            assert json.loads(st.content[0].text)["memories"] == 1
+
+    anyio.run(flow)
+
+
+def test_tool_error_surfaces_cleanly(tmp_path):
+    store = make_memory(tmp_path)
+    mcp = build_server(store)
+
+    async def flow():
+        async with create_connected_server_and_client_session(
+            mcp._mcp_server
+        ) as client:
+            await client.initialize()
+            res = await client.call_tool(
+                "recall_as_of", {"t": "1969-01-01T00:00:00Z"}
+            )
+            assert res.isError  # a clean tool error — not a crashed server
+            assert "1970" in res.content[0].text
+
+    anyio.run(flow)

--- a/cozo-lib-python/integrations/mnestic-mcp/tests/test_memory.py
+++ b/cozo-lib-python/integrations/mnestic-mcp/tests/test_memory.py
@@ -1,0 +1,205 @@
+"""MemoryStore behavior over a tmp sqlite db with the deterministic embedder."""
+
+import pytest
+
+from mnestic_mcp.memory import MemoryStore, parse_when
+
+from tests.conftest import KeywordEmbedder, make_memory
+
+
+def test_schema_idempotent_across_reopen(tmp_path):
+    m1 = make_memory(tmp_path)
+    r = m1.store("alpha fact about zebras", meta={"topic": "animals"})
+    del m1
+
+    m2 = make_memory(tmp_path)  # same file, fresh handle: ensure_schema re-runs
+    hits = m2.search("zebras", mode="keyword")["results"]
+    assert [h["id"] for h in hits] == [r["id"]]
+
+
+def test_model_pinning_mismatch_raises(tmp_path):
+    make_memory(tmp_path)
+
+    class OtherModel(KeywordEmbedder):
+        model_name = "test-other-model"
+
+    with pytest.raises(ValueError, match="embedding model"):
+        make_memory(tmp_path, embedder=OtherModel())
+
+
+def test_store_and_search_modes(mem):
+    a = mem.store("alpha note about datalog", meta={"k": 1})
+    mem.store("omega note about zebras", meta={"k": 2})
+
+    kw = mem.search("datalog", mode="keyword")
+    assert kw["mode_used"] == "keyword"
+    assert [h["id"] for h in kw["results"]] == [a["id"]]
+    assert kw["results"][0]["score"] > 0
+
+    sem = mem.search("alpha", mode="semantic")
+    assert sem["mode_used"] == "semantic"
+    assert sem["results"][0]["id"] == a["id"]
+
+    hy = mem.search("alpha datalog", mode="hybrid")
+    assert hy["mode_used"] == "hybrid"
+    assert hy["results"][0]["id"] == a["id"]
+
+    # "alphaz" has no FTS token match (stemming doesn't strip the z) but its
+    # embedding maps to the alpha vector -> auto must fall back to hybrid
+    auto = mem.search("alphaz")
+    assert auto["mode_used"] == "hybrid"
+    assert auto["results"][0]["id"] == a["id"]
+
+
+def test_store_batch_atomic(mem):
+    out = mem.store_batch(
+        [{"text": "alpha one"}, {"text": "omega two", "meta": {"t": 2}, "id": "fixed"}]
+    )
+    assert out["count"] == 2 and "fixed" in out["ids"]
+    assert mem.stats()["memories"] == 2
+
+    with pytest.raises(Exception):
+        mem.store_batch([{"text": "ok"}, {"text": "bad", "id": 123}])  # non-string id
+    assert mem.stats()["memories"] == 2  # nothing from the failed batch
+
+
+def test_update_reembeds_and_grows_history(mem):
+    r = mem.store("alpha original", meta={"a": 1})
+    before = mem.stats()["history_rows"]
+
+    mem.update(r["id"], text="omega revised", meta={"b": 2})
+    assert mem.stats()["history_rows"] == before + 1
+
+    sem = mem.search("omega", mode="semantic")["results"]
+    assert sem[0]["id"] == r["id"]  # re-embedded to the new text's vector
+    got = mem.search("revised", mode="keyword")["results"]
+    assert got[0]["meta"] == {"a": 1, "b": 2}  # meta merged
+
+    mem.update(r["id"], meta={"c": 3})  # meta-only update keeps the embedding
+    assert mem.search("omega", mode="semantic")["results"][0]["meta"]["c"] == 3
+
+
+def test_delete_prunes_links_and_keeps_history(mem):
+    clock = {"t": 1_700_000_000_000_000}
+    mem._time_us = lambda: clock["t"]
+
+    a = mem.store("alpha anchor")["id"]
+    clock["t"] += 1_000_000
+    b = mem.store("omega satellite")["id"]
+    clock["t"] += 1_000_000
+    mem.link(a, b)
+    before_delete_us = clock["t"] + 1_000_000
+    clock["t"] = before_delete_us + 1_000_000
+
+    mem.delete(b)
+    assert mem.delete(b) == {"deleted": False}
+    assert mem.stats()["links"] == 0
+    assert [h["id"] for h in mem.search("omega", mode="keyword")["results"]] == []
+
+    from datetime import datetime, timezone
+
+    iso = datetime.fromtimestamp(before_delete_us / 1e6, tz=timezone.utc).isoformat()
+    past = mem.recall_as_of(iso)
+    assert {m["id"] for m in past["memories"]} == {a, b}
+    now_view = mem.recall_as_of(
+        datetime.fromtimestamp((clock["t"] + 500_000) / 1e6, tz=timezone.utc).isoformat()
+    )
+    assert {m["id"] for m in now_view["memories"]} == {a}
+
+
+def test_recall_as_of_between_updates(mem):
+    clock = {"t": 1_700_000_000_000_000}
+    mem._time_us = lambda: clock["t"]
+
+    r = mem.store("alpha version one")
+    t_mid = clock["t"] + 5_000_000
+    clock["t"] = t_mid + 5_000_000
+    mem.update(r["id"], text="alpha version two")
+
+    from datetime import datetime, timezone
+
+    iso_mid = datetime.fromtimestamp(t_mid / 1e6, tz=timezone.utc).isoformat()
+    past = mem.recall_as_of(iso_mid)
+    assert [m["text"] for m in past["memories"]] == ["alpha version one"]
+
+    filtered = mem.recall_as_of(iso_mid, query="version")
+    assert [m["text"] for m in filtered["memories"]] == ["alpha version one"]
+    assert mem.recall_as_of(iso_mid, query="nomatch")["memories"] == []
+
+
+def test_parse_when_guards():
+    assert parse_when("2023-11-14T22:14:10Z").startswith("2023-11-14")
+    assert parse_when("2021-06-01 12:00:00+00:00")
+    with pytest.raises(ValueError, match="1970"):
+        parse_when("1969-12-31T23:59:59Z")  # 0.12.2 engine would PANIC on this
+    with pytest.raises(ValueError, match="ISO-8601"):
+        parse_when("not a date")
+
+
+def test_link_and_find_related(mem):
+    a = mem.store("alpha root")["id"]
+    b = mem.store("beta middle")["id"]
+    c = mem.store("gamma far")["id"]
+    d = mem.store("delta unrelated")["id"]
+    mem.link(a, b, rel="follows")
+    mem.link(b, c, rel="follows", weight=2.0)
+
+    rel = mem.find_related(a, max_depth=2)["related"]
+    assert [e["id"] for e in rel] == [b, c]
+    assert rel[0]["depth"] == 1 and rel[0]["parent"] == a
+    assert rel[1]["depth"] == 2 and rel[1]["parent"] == b
+
+    only_one_hop = mem.find_related(a, max_depth=1)["related"]
+    assert [e["id"] for e in only_one_hop] == [b]
+
+    budget_one = mem.find_related(a, max_nodes=2, max_depth=3)["related"]
+    assert len(budget_one) == 1  # budget covers seed + 1 node
+
+    weighted = mem.find_related(a, max_depth=2, weighted=True)["related"]
+    assert [e["id"] for e in weighted] == [b, c]
+    assert weighted[1]["cost"] == pytest.approx(3.0)  # 1.0 + 2.0
+
+    assert d not in [e["id"] for e in rel]
+    with pytest.raises(ValueError, match="unknown memory"):
+        mem.link(a, "missing-id")
+
+
+def test_hybrid_explain_shows_graph_leg(mem):
+    a = mem.store("alpha zebra report")["id"]
+    b = mem.store("omega linked note")["id"]
+    mem.store("omega distractor")
+    mem.link(a, b)
+
+    out = mem.search("zebra", explain=True)
+    assert out["mode_used"] == "hybrid"
+    assert "graph" in out["explain"]["legs"]
+    by_id = {p["id"]: p for p in out["explain"]["per_result"]}
+    assert b in by_id, "graph leg should surface the linked memory"
+    assert any(c["leg"] == "graph" for c in by_id[b]["contributions"])
+    result_ids = [r["id"] for r in out["results"]]
+    assert result_ids and result_ids[0] == a
+
+
+def test_list_recent_and_stats(mem):
+    clock = {"t": 1_700_000_000_000_000}
+    mem._time_us = lambda: clock["t"]
+    ids = []
+    for i, tok in enumerate(["alpha", "beta", "gamma"]):
+        clock["t"] += 1_000_000
+        ids.append(mem.store(f"{tok} item {i}")["id"])
+
+    recent = mem.list_recent(2)["memories"]
+    assert [m["id"] for m in recent] == [ids[2], ids[1]]
+
+    s = mem.stats()
+    assert s["memories"] == 3
+    assert s["model"] == "test-keyword-2d" and s["dim"] == 2
+    assert set(s["indices"]) == {"vec", "fts"}
+    assert s["engine"] == "sqlite" and s["db_path"]
+
+
+def test_hostile_queries_do_not_raise(mem):
+    mem.store("alpha content")
+    for q in ["cat AND (", 'unbalanced "quote', "NEAR^ * ;", "AND OR NOT", "  "]:
+        mem.search(q)  # must not raise
+    assert mem.search("", mode="keyword")["results"] == []

--- a/cozo-lib-python/integrations/mnestic-mcp/tests/test_tools.py
+++ b/cozo-lib-python/integrations/mnestic-mcp/tests/test_tools.py
@@ -1,0 +1,43 @@
+"""Tool-level behavior: registered surface + the embedder-not-ready path."""
+
+import pytest
+
+from mnestic_mcp.server import build_server, tool_names
+
+from tests.conftest import NeverReadyEmbedder, make_memory
+
+EXPECTED_TOOLS = {
+    "store_memory",
+    "store_batch",
+    "search",
+    "find_related",
+    "list_recent",
+    "update",
+    "delete",
+    "link",
+    "recall_as_of",
+    "stats",
+}
+
+
+def test_server_registers_ten_tools(mem):
+    mcp = build_server(mem)
+    assert set(tool_names(mcp)) == EXPECTED_TOOLS
+    assert len(tool_names(mcp)) == 10
+    assert "no session" in (mcp.instructions or "")
+
+
+def test_embedder_not_ready_paths(tmp_path):
+    m = make_memory(tmp_path, embedder=NeverReadyEmbedder())
+
+    # embedding-dependent tools fail with the actionable message...
+    with pytest.raises(RuntimeError, match="downloading"):
+        m.store("alpha fact")
+    with pytest.raises(RuntimeError, match="downloading"):
+        m.search("anything", mode="semantic")
+
+    # ...while keyword search, recall, and stats keep working
+    assert m.search("anything", mode="keyword")["results"] == []
+    assert m.recall_as_of("2024-01-01T00:00:00Z")["memories"] == []
+    s = m.stats()
+    assert s["embedder_ready"] is False


### PR DESCRIPTION
## What

New PyPI package `mnestic-mcp` (name verified free): a first-party local memory MCP server over the **published mnestic 0.12.2 wheel** — Tier D item 3 (MNESTIC-ROADMAP decision 22; the continuous-write FTS/HNSW gate passed 2026-07-14). Python + `uvx mnestic-mcp`, official `mcp` SDK 1.x (bundled FastMCP), **fastembed** embeddings (owner-decided; default bge-small-en-v1.5, one-time ~67 MB background download — keyword search works before the model arrives).

Stacked on #17; retargets when it merges.

## Highlights

- **10 tools**, mechanism-named (never MindGraph's cognitive layers): `store`, `store_batch`, `search`, `find_related`, `list_recent`, `update`, `delete`, `link`, `recall_as_of`, `stats`. The two only-mnestic differentiators ride the engine directly: **`search(explain=true)`** renders `hybrid_search`'s detailed rows as per-result vector/keyword/graph attribution, and **`recall_as_of(t)`** reads valid-time history (`@` in-brace syntax; ISO strings accepted — verified on the wheel).
- **Storage**: current-state `memories` (HNSW+FTS created before data) + `memories_hist {id, at: Validity}` with an app-stamped monotone µs clock (**vt, not tt** — multiple concurrent `uvx` instances per db is the normal MCP reality, and tt is single-handle on sqlite). Model pinning in `db_meta` refuses mixed embedding spaces loudly. Every multi-relation write is one atomic multi-block script (verified: a failing block rolls back the whole script). **Pre-1970 timestamps rejected in Python** — the 0.12.2 engine panics on pre-epoch validity stamps.
- **Search**: keyword-first auto ladder (comma-joined OR terms — FTS whitespace is AND; sanitized against the FTS grammar), hybrid via one `hybrid_search` call with a links-seeded 7-key graph leg (the 0.12.2 shape). All `hybrid_search` construction in one function = single upgrade site for 0.14.0's optional legs / `seed_from_legs`. `find_related` = `BudgetedTraversal` (in the wheel).
- **First-run UX**: background-eager model warmup (server answers `initialize` instantly), stderr-only logging (stdout is the MCP wire), `--download-model` for provisioning, actionable degradation when the model isn't ready (keyword/recall/stats keep working).
- Instructions prose adapted from mindgraph-mcp's keyword-first ladder (prose only, zero code reuse — it makes 69 HTTP calls to a cloud API).

## Tests: 16 fast + 1 env-gated real-model (all green locally)

MemoryStore behavior (schema idempotency across reopen, all search modes incl. auto fallback, atomic `store_batch`, update re-embeds + history grows, delete prunes links while staying time-travelable, `recall_as_of` between updates, pre-1970 → `ValueError` not an engine panic, `find_related` budget/depth/weighted, explain shows graph-leg contributions, hostile FTS queries), tool surface + embedder-not-ready degradation, an **in-process MCP protocol session** (initialize/list_tools/call_tool + clean tool errors), and the env-gated real-fastembed roundtrip (ran locally: dim 384 from the offline registry, real semantic recall).

## Before first publish (manual)

Register a PyPI **pending trusted publisher** for `mnestic-mcp` → repo `shuruheel/mnestic`, workflow `python-publish.yml`, environment `pypi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)