### PR TITLE
fix(fixed-rule): enforce stored relation read access

### DIFF
--- a/cozo-core/src/fixed_rule/mod.rs
+++ b/cozo-core/src/fixed_rule/mod.rs
@@ -40,6 +40,7 @@ use crate::runtime::graph_projection::{
     graph_source, GraphSource, GraphVariant, ProjectionNegativeWeightError,
     ProjectionNodesInputConflict, ProjectionVariant, VariantSpec,
 };
+use crate::runtime::relation::{AccessLevel, InsufficientAccessLevel};
 use crate::runtime::temp_store::{EpochStore, RegularTempStore};
 use crate::runtime::transact::SessionTx;
 use crate::NamedRows;
@@ -103,6 +104,13 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
                 ..
             } => {
                 let relation = self.tx.get_relation(name, false)?;
+                if relation.access_level < AccessLevel::ReadOnly {
+                    bail!(InsufficientAccessLevel(
+                        relation.name.to_string(),
+                        "reading rows".to_string(),
+                        relation.access_level
+                    ));
+                }
                 if let Some(tt) = tx_valid_at {
                     // bitemporal input (mnestic fork, 4b): two-level scan
                     Box::new(relation.bitemporal_scan_all(self.tx, *valid_at, *tt))
@@ -131,6 +139,13 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
                 ..
             } => {
                 let relation = self.tx.get_relation(name, false)?;
+                if relation.access_level < AccessLevel::ReadOnly {
+                    bail!(InsufficientAccessLevel(
+                        relation.name.to_string(),
+                        "reading rows".to_string(),
+                        relation.access_level
+                    ));
+                }
                 let t = vec![prefix.clone()];
                 if let Some(tt) = tx_valid_at {
                     // bitemporal input (mnestic fork, 4b): two-level scan

--- a/cozo-core/tests/budgeted_traversal.rs
+++ b/cozo-core/tests/budgeted_traversal.rs
@@ -867,6 +867,25 @@ fn j1b_named_gate_binding_parses_and_binds_by_name() {
 }
 
 #[test]
+fn j1c_hidden_gate_is_not_readable_by_fixed_rule() {
+    let (_dir, db) = open_db();
+    run(&db, ":create secret_gate {uid: String => ok: Int}");
+    run(
+        &db,
+        "?[uid, ok] <- [['a',1],['b',1]] :put secret_gate {uid => ok}",
+    );
+    run(&db, "::access_level hidden secret_gate");
+
+    let m = err(
+        &db,
+        "e[f, t, w] <- [['a','b',1.0]]\ns[n] <- [['a']]\n\
+         ?[n, c, p, d] <~ BudgetedTraversal(e[f, t, w], s[n], \
+         *secret_gate{uid, ok}, max_nodes: 10, admit: ok == 1)",
+    );
+    assert!(m.contains("Insufficient access level hidden"), "{m}");
+}
+
+#[test]
 fn j2_gate_not_a_bridge() {
     let (_dir, db) = open_db();
     run(&db, ":create g {uid: String => ok: Int}");


### PR DESCRIPTION
### Motivation

- Fixed-rule stored inputs (`*relation{...}`) were allowed to scan stored relations without enforcing relation `access_level`, enabling a confidentiality bypass when `BudgetedTraversal` used a user-selected `gate_relation` as a fixed-rule input.
- The change closes this side channel by applying the same `ReadOnly` access requirement used for normal relation atoms before any fixed-rule stored scan or prefix scan.

### Description

- Added an access-level check that rejects stored fixed-rule inputs whose relation `access_level` is below `ReadOnly` in `FixedRuleInputRelation::iter` (full scans).    
- Added the same `ReadOnly` check in `FixedRuleInputRelation::prefix_iter` (prefix scans) so `BudgetedTraversal` gate probes cannot read hidden/protected relations.    
- Imported `AccessLevel` and `InsufficientAccessLevel` where needed and surface an `InsufficientAccessLevel` error when checks fail.    
- Added a regression test `j1c_hidden_gate_is_not_readable_by_fixed_rule` that marks a gate relation `hidden` and verifies the fixed-rule path returns an insufficient-access error instead of leaking gate rows via traversal output.

### Testing

- ✅ `rustfmt --edition 2021 --check cozo-core/src/fixed_rule/mod.rs cozo-core/tests/budgeted_traversal.rs` succeeded.    
- ✅ `cargo test -p mnestic --test budgeted_traversal j1c_hidden_gate_is_not_readable_by_fixed_rule` succeeded.    
- ✅ `cargo test -p mnestic --test budgeted_traversal` ran the suite and all 40 tests passed.    
- ✅ `git diff --check -- cozo-core/src/fixed_rule/mod.rs cozo-core/tests/budgeted_traversal.rs` reported no whitespace or diff-check issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a0b887660832b94d3103f9eab48bf)