### PR TITLE
fix(ci): restore crates.io publish environment gate

### DIFF
--- a/.github/workflows/crates-publish.yml
+++ b/.github/workflows/crates-publish.yml
@@ -13,7 +13,7 @@
 # Auth: crates.io Trusted Publishing (OIDC) via rust-lang/crates-io-auth-action — no
 # stored token/secret. Requires a Trusted Publisher configured on crates.io for BOTH
 # `mnestic` and `mnestic-rocks` (repo shuruheel/mnestic, workflow crates-publish.yml,
-# environment blank).
+# environment `crates-io`).
 
 name: crates-publish
 
@@ -50,6 +50,7 @@ jobs:
     needs: [test]
     if: github.event_name == 'push' || inputs.publish
     runs-on: ubuntu-latest
+    environment: crates-io
     permissions:
       id-token: write    # OIDC — crates.io Trusted Publishing (no token/secret)
       contents: read
@@ -70,7 +71,7 @@ jobs:
       # Exchange the GitHub OIDC token for a short-lived crates.io token.
       # Requires a Trusted Publisher configured on crates.io for BOTH `mnestic`
       # and `mnestic-rocks`, pointing at repo shuruheel/mnestic + this workflow
-      # file (crates-publish.yml), environment blank.
+      # file (crates-publish.yml), environment `crates-io`.
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
 


### PR DESCRIPTION
### Motivation

- The crates publish job requested OIDC credentials without declaring a GitHub Environment, which removed the repository-side approval gate and weakened the crates.io Trusted Publishing authorization boundary.

### Description

- Restore `environment: crates-io` on the `publish` job so the repository's GitHub Environment protections apply before the job can request a crates.io OIDC token.
- Update workflow comments to document that the Trusted Publisher entries for both `mnestic` and `mnestic-rocks` must reference the `crates-io` environment.
- Preserve the existing OIDC-based short-lived credential flow (`id-token: write` and `rust-lang/crates-io-auth-action@v1`) and the publish logic that uses `steps.auth.outputs.token` as `CARGO_REGISTRY_TOKEN`.

### Testing

- Ran `git diff --check` which reported no whitespace or diff errors.
- Executed an offline workflow assertion script that verified the `publish` job contains `environment: crates-io`, retains `id-token: write`, and includes `rust-lang/crates-io-auth-action@v1`, and the assertion succeeded.
- Verified staged diff checks with `git diff --cached --check` which passed; `actionlint` was not available in the environment so workflow linting was not run.
- Confirmed repository status shows the workflow file modified as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a10a0bc98832babdeddbe360c8fc5)