### PR TITLE
Restrict multi-transactions to mutable authorization grants

### DIFF
--- a/cozo-bin/src/server.rs
+++ b/cozo-bin/src/server.rs
@@ -292,10 +292,20 @@ struct StartTransactPayload {
     write: bool,
 }
 
+fn transaction_access_allowed(mutability: ScriptMutability) -> bool {
+    // MultiTransaction does not accept a ScriptMutability and therefore cannot
+    // enforce read-only bearer grants while running or committing scripts.
+    mutability == ScriptMutability::Mutable
+}
+
 async fn start_transact(
+    Extension(mutability): Extension<ScriptMutability>,
     State(st): State<DbState>,
     Query(payload): Query<StartTransactPayload>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if !transaction_access_allowed(mutability) {
+        return (StatusCode::FORBIDDEN, json!({"ok": false}).into());
+    }
     let tx = st.db.multi_transaction(payload.write);
     let id = st.tx_counter.fetch_add(1, Ordering::SeqCst);
     st.txs.lock().unwrap().insert(id, Arc::new(tx));
@@ -303,10 +313,14 @@ async fn start_transact(
 }
 
 async fn transact_query(
+    Extension(mutability): Extension<ScriptMutability>,
     State(st): State<DbState>,
     Path(id): Path<u32>,
     Json(payload): Json<QueryPayload>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if !transaction_access_allowed(mutability) {
+        return (StatusCode::FORBIDDEN, json!({"ok": false}).into());
+    }
     let tx = match st.txs.lock().unwrap().get(&id) {
         None => return (StatusCode::NOT_FOUND, json!({"ok": false}).into()),
         Some(tx) => tx.clone(),
@@ -338,10 +352,14 @@ struct FinishTransactPayload {
 }
 
 async fn finish_query(
+    Extension(mutability): Extension<ScriptMutability>,
     State(st): State<DbState>,
     Path(id): Path<u32>,
     Json(payload): Json<FinishTransactPayload>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if !transaction_access_allowed(mutability) {
+        return (StatusCode::FORBIDDEN, json!({"ok": false}).into());
+    }
     let tx = match st.txs.lock().unwrap().remove(&id) {
         None => return (StatusCode::NOT_FOUND, json!({"ok": false}).into()),
         Some(tx) => tx,
@@ -358,6 +376,12 @@ async fn finish_query(
             json!({"ok": false, "message": err.to_string()}).into(),
         ),
     }
+}
+
+#[test]
+fn multi_transactions_require_mutable_authorization() {
+    assert!(transaction_access_allowed(ScriptMutability::Mutable));
+    assert!(!transaction_access_allowed(ScriptMutability::Immutable));
 }
 
 #[derive(serde_derive::Deserialize)]


### PR DESCRIPTION
### Motivation

- The server previously allowed bearer-token authorization to apply regardless of query strings, but multi-transaction handlers did not honor the bearer token's `ScriptMutability`, allowing immutable bearer tokens to drive write transactions. 
- The `MultiTransaction` API has no mutability/read-only parameter, so the server must block immutable grants from reaching multi-transaction endpoints to prevent privilege escalation.

### Description

- Add a centralized policy function `transaction_access_allowed` that returns true only for `ScriptMutability::Mutable` and document why this is required. 
- Require `Extension<ScriptMutability>` and enforce the policy in `start_transact`, `transact_query`, and `finish_query`, returning `403 Forbidden` when the request is not mutable. 
- Add a small unit test `multi_transactions_require_mutable_authorization` asserting the policy rejects `Immutable` and accepts `Mutable` grants. 
- Keep changes limited to `cozo-bin/src/server.rs` and avoid modifying core transaction APIs.

### Testing

- `cargo fmt -p cozo-bin -- --check` completed successfully. 
- `cargo test -p cozo-bin multi_transactions_require_mutable_authorization` ran successfully and the test passed. 
- `git diff --check` returned no issues after the change and the fix was committed with message `fix(server): restrict multi-transactions to mutable grants`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a1b451364832b8687b7c04f697e73)