### PR TITLE
fix(server): enforce mutable bearer grants on import and backup routes

### DIFF
--- a/cozo-bin/src/server.rs
+++ b/cozo-bin/src/server.rs
@@ -181,8 +181,30 @@ impl AsyncAuthorizeRequest<Body> for MyAuth {
     }
 }
 
-#[test]
-fn x() {}
+fn require_mutable(
+    mutability: ScriptMutability,
+) -> Result<(), (StatusCode, Json<serde_json::Value>)> {
+    match mutability {
+        ScriptMutability::Mutable => Ok(()),
+        ScriptMutability::Immutable => Err((
+            StatusCode::FORBIDDEN,
+            json!({"ok": false, "message": "this operation requires a mutable token"}).into(),
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mutable_operations_require_mutable_authorization() {
+        assert!(require_mutable(ScriptMutability::Mutable).is_ok());
+
+        let (status, _) = require_mutable(ScriptMutability::Immutable).unwrap_err();
+        assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+}
 
 pub(crate) async fn server_main(args: ServerArgs) {
     let db = DbInstance::new(&args.engine, &args.path, &args.config).unwrap();
@@ -437,9 +459,14 @@ async fn export_relations(
 }
 
 async fn import_relations(
+    Extension(mutability): Extension<ScriptMutability>,
     State(st): State<DbState>,
     Json(payload): Json<serde_json::Value>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if let Err(response) = require_mutable(mutability) {
+        return response;
+    }
+
     let payload = match payload.as_object() {
         None => {
             return (
@@ -482,9 +509,14 @@ struct BackupPayload {
 }
 
 async fn backup(
+    Extension(mutability): Extension<ScriptMutability>,
     State(st): State<DbState>,
     Json(payload): Json<BackupPayload>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if let Err(response) = require_mutable(mutability) {
+        return response;
+    }
+
     let result = spawn_blocking(move || st.db.backup_db(payload.path)).await;
 
     match result {
@@ -507,9 +539,14 @@ struct BackupImportPayload {
 }
 
 async fn import_from_backup(
+    Extension(mutability): Extension<ScriptMutability>,
     State(st): State<DbState>,
     Json(payload): Json<BackupImportPayload>,
 ) -> (StatusCode, Json<serde_json::Value>) {
+    if let Err(response) = require_mutable(mutability) {
+        return response;
+    }
+
     let result =
         spawn_blocking(move || st.db.import_from_backup(&payload.path, &payload.relations)).await;
 


### PR DESCRIPTION
### Motivation
- Close an authorization bypass where bearer tokens mapped to `ScriptMutability::Immutable` were still allowed to perform mutating operations via `/import`, `/backup`, and `/import-from-backup` endpoints.
- Ensure the mutability decision computed by the token-table auth path is enforced consistently across all handlers that perform database or filesystem-affecting work.

### Description
- Add a shared guard function `require_mutable` that returns HTTP `403 Forbidden` for `ScriptMutability::Immutable` and allows `ScriptMutability::Mutable` to proceed.
- Update the `/import`, `/backup`, and `/import-from-backup` handlers to accept `Extension(mutability): Extension<ScriptMutability>` and call `require_mutable` before performing any imports or backups in `cozo-bin/src/server.rs`.
- Add a unit test `mutable_operations_require_mutable_authorization` validating that mutable tokens are allowed and immutable tokens are rejected.

### Testing
- Ran `rustfmt --edition 2021 --check cozo-bin/src/server.rs` which passed for the modified file.
- Ran `cargo test -p cozo-bin mutable_operations_require_mutable_authorization` which passed (the new unit test succeeded).
- Ran `git diff --check` which reported no whitespace errors in the changes introduced here.
- Observed `cargo fmt --all -- --check` reports pre-existing formatting differences in unrelated `cozo-core` files, which are not touched by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a2ebd6304832b83fadee582d39435)