### PR TITLE
fix(server): disable CORS for unauthenticated loopback API

### DIFF
--- a/cozo-bin/src/server.rs
+++ b/cozo-bin/src/server.rs
@@ -234,14 +234,22 @@ pub(crate) async fn server_main(args: ServerArgs) {
         tx_counter: Default::default(),
         txs: Default::default(),
     };
-    let cors = CorsLayer::new()
-        .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
-        .allow_origin(Any)
-        .allow_headers([
-            header::CONTENT_TYPE,
-            header::AUTHORIZATION,
-            HeaderName::from_static("x-cozo-auth"),
-        ]);
+    // Do not opt the unauthenticated loopback server into CORS. Otherwise an
+    // arbitrary website can preflight JSON requests and execute CozoScript in
+    // the visitor's local database. Authenticated servers may remain usable by
+    // cross-origin clients because their requests still require credentials.
+    let cors = if skip_auth {
+        CorsLayer::new()
+    } else {
+        CorsLayer::new()
+            .allow_methods([Method::GET, Method::POST, Method::PUT, Method::DELETE])
+            .allow_origin(Any)
+            .allow_headers([
+                header::CONTENT_TYPE,
+                header::AUTHORIZATION,
+                HeaderName::from_static("x-cozo-auth"),
+            ])
+    };
 
     let app = Router::new()
         .route("/text-query", post(text_query))


### PR DESCRIPTION
### Motivation

- The server previously enabled permissive CORS (including `Content-Type` and `x-cozo-auth`) while skipping authentication when bound to the default loopback address, which allows arbitrary websites to preflight JSON requests and execute CozoScript against the local database. 
- The change aims to eliminate that remote attack vector for the unauthenticated loopback service while preserving cross-origin support for deployments that require authentication.

### Description

- Change `cozo-bin/src/server.rs` to construct the `CorsLayer` conditionally: when `skip_auth` is true (loopback/unauthenticated) the server now uses a default `CorsLayer::new()` with no `allow_origin`/`allow_headers` opt-in, otherwise it retains the previous permissive configuration including `Content-Type`, `Authorization`, and `x-cozo-auth` headers. 
- Add a short comment explaining the security rationale and that authenticated servers still get the permissive CORS behavior.
- The patch is intentionally minimal and localized to the `CorsLayer` construction so as to preserve existing routing and authorization logic.

### Testing

- Ran `rustfmt --edition 2021 --check cozo-bin/src/server.rs`, which passed for the modified file. 
- Ran `cargo test -p cozo-bin`, which completed successfully with the package test suite (1 test) passing. 
- Ran `git diff --check` to validate no whitespace/format issues were introduced by the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a3583c0e0832bb0c4fa60b101d769)