### PR TITLE
Enforce read-only multi-transaction semantics

### DIFF
--- a/cozo-core/src/runtime/db.rs
+++ b/cozo-core/src/runtime/db.rs
@@ -51,9 +51,9 @@ use crate::query::ra::{
 use crate::runtime::callback::{
     CallbackCollector, CallbackDeclaration, CallbackOp, EventCallbackRegistry,
 };
+use crate::runtime::diagnostics::QueryWarning;
 use crate::runtime::graph_projection;
 use crate::runtime::graph_projection::ProjectionCache;
-use crate::runtime::diagnostics::QueryWarning;
 use crate::runtime::relation::{
     try_extend_tuple_from_v, AccessLevel, InsufficientAccessLevel, RelationHandle, RelationId,
 };
@@ -518,7 +518,20 @@ impl<'s, S: Storage<'s>> Db<S> {
                             }
                         }
                     };
-                    if let Some(write_lock_name) = p.needs_write_lock() {
+                    let write_lock_name = p.needs_write_lock();
+                    if !is_write && write_lock_name.is_some() {
+                        if results
+                            .send(Err(miette!(
+                                "write lock required for read-only transaction"
+                            )))
+                            .is_err()
+                        {
+                            break;
+                        } else {
+                            continue;
+                        }
+                    }
+                    if let Some(write_lock_name) = write_lock_name {
                         match write_locks.entry(write_lock_name) {
                             Entry::Vacant(e) => {
                                 let lock = self

--- a/cozo-core/src/runtime/tests.rs
+++ b/cozo-core/src/runtime/tests.rs
@@ -668,6 +668,31 @@ fn test_multi_tx() {
 }
 
 #[test]
+fn read_only_multi_tx_rejects_writes() {
+    let db = DbInstance::default();
+    db.run_default(":create a {a}").unwrap();
+    db.run_default("?[a] <- [[1]] :put a {a}").unwrap();
+
+    let tx = db.multi_transaction(false);
+    let err = tx
+        .run_script("?[a] <- [[2]] :put a {a}", Default::default())
+        .expect_err("a read-only multi-transaction must reject writes");
+    assert!(format!("{err:?}").contains("read-only transaction"));
+    assert_eq!(
+        tx.run_script("?[a] := *a[a]", Default::default())
+            .unwrap()
+            .into_json()["rows"],
+        json!([[1]])
+    );
+    tx.abort().unwrap();
+
+    assert_eq!(
+        db.run_default("?[a] := *a[a]").unwrap().into_json()["rows"],
+        json!([[1]])
+    );
+}
+
+#[test]
 fn durable_writes_not_honored_off_rocksdb() {
     // The knob's contract: backends that don't wire it up return false (the
     // default trait impl). `mem` has nothing to sync; sqlite is already


### PR DESCRIPTION
### Motivation
- Prevent scripts that require a write lock from being executed when a multi-transaction was opened with `write = false`, which allowed backend-specific write or autocommit bypasses.
- Close an authorization/semantics gap exposed by language bindings that present `multi_transact(false)` as a read-only handle while the core execution path could still perform mutations.

### Description
- In `cozo-core/src/runtime/db.rs`, update the `run_multi_transaction` loop to check `p.needs_write_lock()` and, when `is_write == false`, reject programs that require a write lock by sending an error through the transaction `results` channel and skipping execution instead of running the program.
- Preserve the existing write-lock acquisition path for transactions that are allowed to write by keeping the `write_locks` logic unchanged when `is_write` is true.
- Add a regression test `read_only_multi_tx_rejects_writes` in `cozo-core/src/runtime/tests.rs` that asserts a read-only `multi_transaction(false)` rejects a mutating `:put` script, remains usable for subsequent reads, and that an `abort()` does not change persisted rows.
- Apply minor formatting/imports adjustments required by the change (no behavioral changes beyond the read-only enforcement).

### Testing
- Ran `cargo test -p mnestic --lib read_only_multi_tx_rejects_writes`, and the new test passed.
- Ran `rustfmt --edition 2021 --check cozo-core/src/runtime/db.rs cozo-core/src/runtime/tests.rs`, which succeeded.
- Ran repository checks (`git diff --check`) with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a4a22a4d0832ba93d3433c2019c8d)