### PR TITLE
fix: enforce base relation ACLs on indexes

### DIFF
--- a/cozo-core/src/query/compile.rs
+++ b/cozo-core/src/query/compile.rs
@@ -254,11 +254,12 @@ impl<'a> SessionTx<'a> {
                 }
                 MagicAtom::Relation(rel_app) => {
                     let store = self.get_relation(&rel_app.name, false)?;
-                    if store.access_level < AccessLevel::ReadOnly {
+                    let access_level = self.effective_read_access_level(&store)?;
+                    if access_level < AccessLevel::ReadOnly {
                         bail!(InsufficientAccessLevel(
                             store.name.to_string(),
                             "reading rows".to_string(),
-                            store.access_level
+                            access_level
                         ));
                     }
                     ensure!(

--- a/cozo-core/src/runtime/db.rs
+++ b/cozo-core/src/runtime/db.rs
@@ -815,11 +815,12 @@ impl<'s, S: Storage<'s>> Db<S> {
             let handle = tx.get_relation(rel.as_ref(), false)?;
             let size_hint = handle.metadata.keys.len() + handle.metadata.non_keys.len();
 
-            if handle.access_level < AccessLevel::ReadOnly {
+            let access_level = tx.effective_read_access_level(&handle)?;
+            if access_level < AccessLevel::ReadOnly {
                 bail!(InsufficientAccessLevel(
                     handle.name.to_string(),
                     "data export".to_string(),
-                    handle.access_level
+                    access_level
                 ));
             }
 

--- a/cozo-core/src/runtime/relation.rs
+++ b/cozo-core/src/runtime/relation.rs
@@ -121,6 +121,23 @@ impl RelationHandle {
     }
 }
 
+impl<'a> SessionTx<'a> {
+    /// Return the effective access level for a relation read. Ordinary
+    /// indexes are stored as independent `base:index` relations, but they
+    /// must never grant more access than their base relation.
+    pub(crate) fn effective_read_access_level(
+        &self,
+        handle: &RelationHandle,
+    ) -> Result<AccessLevel> {
+        if let Some((base_name, _)) = handle.name.split_once(':') {
+            let base = self.get_relation(base_name, false)?;
+            Ok(handle.access_level.min(base.access_level))
+        } else {
+            Ok(handle.access_level)
+        }
+    }
+}
+
 #[derive(
     Copy,
     Clone,
@@ -1824,6 +1841,13 @@ impl<'a> SessionTx<'a> {
     ) -> Result<()> {
         // Get relation handle
         let mut rel_handle = self.get_relation(rel_name, true)?;
+        if rel_handle.access_level < AccessLevel::Normal {
+            bail!(InsufficientAccessLevel(
+                rel_handle.name.to_string(),
+                "creating index".to_string(),
+                rel_handle.access_level
+            ));
+        }
         Self::reject_txtime_relation(&rel_handle, "::index create")?;
 
         // Check if index already exists

--- a/cozo-core/src/runtime/tests.rs
+++ b/cozo-core/src/runtime/tests.rs
@@ -515,6 +515,28 @@ fn test_index() {
 }
 
 #[test]
+fn index_respects_base_relation_access_level() {
+    let db = DbInstance::default();
+    db.run_default(":create secret {id: Int => value: String}")
+        .unwrap();
+    db.run_default("?[id, value] <- [[1, 'classified']] :put secret {id => value}")
+        .unwrap();
+    db.run_default("::index create secret:by_value {value}")
+        .unwrap();
+    db.run_default("::access_level hidden secret").unwrap();
+
+    assert!(db
+        .run_default("?[id, value] := *secret:by_value{value, id}")
+        .is_err());
+    assert!(db
+        .export_relations(["secret:by_value"].into_iter())
+        .is_err());
+    assert!(db
+        .run_default("::index create secret:another {value}")
+        .is_err());
+}
+
+#[test]
 fn test_json_objects() {
     let db = DbInstance::default();
     db.run_default("?[a] := a = {'a': 1}").unwrap();


### PR DESCRIPTION
### Motivation

- Index relations are materialized as standalone `base:index` relations and were directly queryable, allowing reads that bypass the base relation's access level. This change prevents indexed relations from granting broader access than their base relation.

### Description

- Add `SessionTx::effective_read_access_level` to compute an index relation's effective access as the minimum of the index handle and its base relation. (`cozo-core/src/runtime/relation.rs`)
- Use the effective access-level check for direct CozoScript relation reads so `*base:index` cannot be read when the base is restricted. (`cozo-core/src/query/compile.rs`)
- Use the effective access-level check for relation exports so index exports are blocked when the base relation denies reads. (`cozo-core/src/runtime/db.rs`)
- Reject `::index create` for ordinary indexes when the base relation's `access_level` is not `Normal`, preventing creation of covering indexes over restricted relations. (`cozo-core/src/runtime/relation.rs`)
- Add a regression test that asserts direct index queries, exporting, and subsequent index creation over a hidden base relation are rejected. (`cozo-core/src/runtime/tests.rs`)

### Testing

- Ran `cargo test --manifest-path cozo-core/Cargo.toml index_respects_base_relation_access_level --lib`, which passed. 
- Ran `cargo test --manifest-path cozo-core/Cargo.toml test_index --lib`, which passed. 
- Ran `git diff --check` to inspect the change; no code-check errors introduced by this patch. 
- Note: `cargo fmt --all -- --check` reports pre-existing formatting differences in unrelated files (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a511a6fd8832b96c43cc9f8b3cf53)