### PR TITLE
Enforce relation access controls for imperative returns

### DIFF
--- a/cozo-core/src/runtime/imperative.rs
+++ b/cozo-core/src/runtime/imperative.rs
@@ -22,7 +22,7 @@ use crate::data::symb::Symbol;
 use crate::parse::{ImperativeCondition, ImperativeProgram, ImperativeStmt, SourceSpan};
 use crate::runtime::callback::CallbackCollector;
 use crate::runtime::db::{seconds_since_the_epoch, RunningQueryCleanup, RunningQueryHandle};
-use crate::runtime::relation::InputRelationHandle;
+use crate::runtime::relation::{AccessLevel, InputRelationHandle, InsufficientAccessLevel};
 use crate::runtime::transact::SessionTx;
 use crate::{DataValue, Db, NamedRows, Poison, Storage, ValidityTs};
 
@@ -102,6 +102,13 @@ impl<'s, S: Storage<'s>> Db<S> {
                             )?,
                             Right(rel) => {
                                 let relation = tx.get_relation(rel, false)?;
+                                if relation.access_level < AccessLevel::ReadOnly {
+                                    bail!(InsufficientAccessLevel(
+                                        relation.name.to_string(),
+                                        "reading rows".to_string(),
+                                        relation.access_level
+                                    ));
+                                }
                                 relation.as_named_rows(tx)?
                             }
                         };

--- a/cozo-core/src/runtime/tests.rs
+++ b/cozo-core/src/runtime/tests.rs
@@ -4172,3 +4172,19 @@ fn reconcile_validation() {
         .into_json();
     assert_eq!(res["rows"], serde_json::json!([[1, 99]]), "{res:?}");
 }
+
+#[test]
+fn imperative_return_respects_relation_access_level() {
+    let db = DbInstance::new("mem", "", "").unwrap();
+    db.run_default("?[k, v] <- [[1, 'secret']] :create secret {k => v}")
+        .unwrap();
+    db.run_default("::access_level hidden secret").unwrap();
+
+    let err = db
+        .run_default("%return secret")
+        .expect_err("imperative return must not expose a hidden relation");
+    assert!(
+        format!("{err:?}").contains("Insufficient access level"),
+        "{err:?}"
+    );
+}


### PR DESCRIPTION
### Motivation

- The imperative `%return <ident>` path could resolve and serialize persistent relations without enforcing `AccessLevel`, allowing hidden/read-protected stored relations to be exposed.
- Normal query compilation enforces `AccessLevel::ReadOnly` for stored-relation reads, so the imperative return path constituted a confidentiality bypass.

### Description

- Added an access-level guard in the imperative executor: when a `%return` serializes a named relation the code now checks `relation.access_level >= AccessLevel::ReadOnly` and returns an `InsufficientAccessLevel` error if not. The check is implemented in `cozo-core/src/runtime/imperative.rs` inside the `Return` handling branch before calling `relation.as_named_rows(tx)`.
- Imported `AccessLevel` and `InsufficientAccessLevel` into the imperative runtime module to perform and report the check. (`use crate::runtime::relation::{AccessLevel, InputRelationHandle, InsufficientAccessLevel};`)
- Added a regression test `imperative_return_respects_relation_access_level` in `cozo-core/src/runtime/tests.rs` which creates a stored relation, marks it `hidden`, and verifies that `%return secret` fails with `Insufficient access level`.

### Testing

- Ran `cargo fmt --check` which succeeded. 
- Ran the new unit test with `cargo test -p mnestic imperative_return_respects_relation_access_level --lib`, which passed.
- Performed `git diff --check` to ensure no whitespace/git issues; the check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a527b814c832b948f7503f4ab5dd1)