### PR TITLE
Constrain HTTP backup paths to a configured directory

### DIFF
--- a/cozo-bin/README.md
+++ b/cozo-bin/README.md
@@ -85,9 +85,11 @@ and a nicely-formatted diagnostic will be in `"display"` if available.
 * `GET /export/{relations: String}`, where `relations` is a comma-separated list of relations to export.
 * `PUT /import`, import data into the database. Data should be in `application/json` MIME type in the body,
   in the same format as returned in the `data` field in the `/export` API.
-* `POST /backup`, backup database, should supply a JSON body of the form `{"path": <PATH>}`
+* `POST /backup`, backup database, should supply a JSON body of the form `{"path": <PATH>}`.
+  The path is relative to the server's `--backup-dir` (default: `backups`) and cannot escape it.
 * `POST /import-from-backup`, import data into the database from a backup. Should supply a JSON body
-  of the form `{"path": <PATH>, "relations": <ARRAY OF RELATION NAMES>}`.
+  of the form `{"path": <PATH>, "relations": <ARRAY OF RELATION NAMES>}`. The same
+  `--backup-dir` restriction applies.
 * `GET /`, if you open this in your browser and open your developer tools, you will be able to use
   a very simple client to query this database.
 

--- a/cozo-bin/src/server.rs
+++ b/cozo-bin/src/server.rs
@@ -9,6 +9,7 @@
 use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::net::{Ipv6Addr, SocketAddr};
+use std::path::{Path as FsPath, PathBuf};
 use std::str::FromStr;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
@@ -50,6 +51,10 @@ pub(crate) struct ServerArgs {
     #[clap(short, long, default_value_t = String::from("cozo.db"))]
     path: String,
 
+    /// Directory containing files exposed by the HTTP backup APIs
+    #[clap(long, default_value_t = String::from("backups"))]
+    backup_dir: String,
+
     /// Restore from the specified backup before starting the server
     #[clap(long)]
     restore: Option<String>,
@@ -80,6 +85,7 @@ pub(crate) struct ServerArgs {
 #[derive(Clone)]
 struct DbState {
     db: DbInstance,
+    backup_dir: Arc<PathBuf>,
     rule_senders: Arc<Mutex<BTreeMap<u32, crossbeam::channel::Sender<miette::Result<NamedRows>>>>>,
     rule_counter: Arc<AtomicU32>,
     tx_counter: Arc<AtomicU32>,
@@ -186,6 +192,9 @@ fn x() {}
 
 pub(crate) async fn server_main(args: ServerArgs) {
     let db = DbInstance::new(&args.engine, &args.path, &args.config).unwrap();
+    std::fs::create_dir_all(&args.backup_dir).expect("Cannot create HTTP backup directory");
+    let backup_dir =
+        std::fs::canonicalize(&args.backup_dir).expect("Cannot resolve HTTP backup directory");
     if let Some(secs) = args.default_query_timeout {
         db.set_default_query_timeout(Some(secs));
     }
@@ -229,6 +238,7 @@ pub(crate) async fn server_main(args: ServerArgs) {
 
     let state = DbState {
         db,
+        backup_dir: Arc::new(backup_dir),
         rule_senders: Default::default(),
         rule_counter: Default::default(),
         tx_counter: Default::default(),
@@ -481,11 +491,86 @@ struct BackupPayload {
     path: String,
 }
 
+fn resolve_backup_path(backup_dir: &FsPath, requested: &str) -> miette::Result<PathBuf> {
+    let requested = FsPath::new(requested);
+    if requested.as_os_str().is_empty() || requested.is_absolute() {
+        return Err(miette!(
+            "backup path must be relative to the HTTP backup directory"
+        ));
+    }
+
+    let candidate = backup_dir.join(requested);
+    let parent = candidate
+        .parent()
+        .ok_or_else(|| miette!("backup path has no parent directory"))?;
+    let resolved_parent =
+        std::fs::canonicalize(parent).map_err(|_| miette!("backup path parent does not exist"))?;
+    if !resolved_parent.starts_with(backup_dir) {
+        return Err(miette!("backup path escapes the HTTP backup directory"));
+    }
+
+    // Canonicalize an existing file as well, so a symlink cannot point outside
+    // the configured directory. New files inherit the checked parent.
+    match std::fs::symlink_metadata(&candidate) {
+        Ok(_) => {
+            let resolved = std::fs::canonicalize(&candidate)
+                .map_err(|_| miette!("cannot resolve backup path"))?;
+            if !resolved.starts_with(backup_dir) {
+                return Err(miette!("backup path escapes the HTTP backup directory"));
+            }
+            Ok(resolved)
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            Ok(resolved_parent.join(candidate.file_name().unwrap()))
+        }
+        Err(_) => Err(miette!("cannot inspect backup path")),
+    }
+}
+
+#[cfg(test)]
+mod backup_path_tests {
+    use super::resolve_backup_path;
+    use std::fs;
+
+    #[test]
+    fn confines_http_backup_paths_to_configured_directory() {
+        let root = std::env::temp_dir().join(format!("cozo-backup-path-{}", std::process::id()));
+        let backups = root.join("backups");
+        fs::create_dir_all(backups.join("nested")).unwrap();
+        let backups = fs::canonicalize(backups).unwrap();
+
+        assert_eq!(
+            resolve_backup_path(&backups, "nested/safe.db").unwrap(),
+            backups.join("nested/safe.db")
+        );
+        assert!(resolve_backup_path(&backups, "/tmp/outside.db").is_err());
+        assert!(resolve_backup_path(&backups, "../outside.db").is_err());
+
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(root.join("missing-outside.db"), backups.join("link.db"))
+                .unwrap();
+            assert!(resolve_backup_path(&backups, "link.db").is_err());
+        }
+
+        fs::remove_dir_all(root).unwrap();
+    }
+}
+
 async fn backup(
     State(st): State<DbState>,
     Json(payload): Json<BackupPayload>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let result = spawn_blocking(move || st.db.backup_db(payload.path)).await;
+    let path = match resolve_backup_path(&st.backup_dir, &payload.path) {
+        Ok(path) => path,
+        Err(err) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                json!({"ok": false, "message": err.to_string()}).into(),
+            );
+        }
+    };
+    let result = spawn_blocking(move || st.db.backup_db(path)).await;
 
     match result {
         Ok(Ok(())) => {
@@ -510,8 +595,16 @@ async fn import_from_backup(
     State(st): State<DbState>,
     Json(payload): Json<BackupImportPayload>,
 ) -> (StatusCode, Json<serde_json::Value>) {
-    let result =
-        spawn_blocking(move || st.db.import_from_backup(&payload.path, &payload.relations)).await;
+    let path = match resolve_backup_path(&st.backup_dir, &payload.path) {
+        Ok(path) => path,
+        Err(err) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                json!({"ok": false, "message": err.to_string()}).into(),
+            );
+        }
+    };
+    let result = spawn_blocking(move || st.db.import_from_backup(path, &payload.relations)).await;
 
     match result {
         Ok(Ok(())) => {


### PR DESCRIPTION
### Motivation
- The HTTP `/backup` and `/import-from-backup` handlers previously accepted caller-controlled filesystem paths and forwarded them directly to the backup/restore APIs, allowing an authenticated client to create/overwrite or read arbitrary SQLite files on the server filesystem. 
- The change introduces a confined, canonicalized directory for files exposed via the HTTP backup APIs so network requests cannot escape the intended backup area.

### Description
- Add a new server option `--backup-dir` (default `backups`) and canonicalize it at startup, stored on `DbState` as `backup_dir` in `cozo-bin/src/server.rs`.
- Introduce `resolve_backup_path(backup_dir: &Path, requested: &str) -> miette::Result<PathBuf>` which rejects empty or absolute paths, parent-traversal, missing parent directories, and any path or symlink that would resolve outside `--backup-dir`.
- Apply `resolve_backup_path` to both `backup` and `import_from_backup` handlers so only validated `PathBuf` values reach `DbInstance::backup_db` / `import_from_backup`.
- Add unit tests (`backup_path_tests`) that cover nested-safe paths, absolute paths, `..` traversal, and dangling-symlink escapes, and document the `--backup-dir` behavior in `cozo-bin/README.md`.

### Testing
- Ran the focused unit test: `cargo test -p cozo-bin --no-default-features --features minimal --bin cozo-bin -- backup_path_tests`, which passed.
- Ran formatter and checks: `rustfmt --edition 2021 cozo-bin/src/server.rs` and `git diff --check` with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a6d9b1dd0832b8625367c89fa091b)