### PR TITLE
Gate CozoScript data readers behind explicit opt-in

### DIFF
--- a/cozo-core/Cargo.toml
+++ b/cozo-core/Cargo.toml
@@ -46,6 +46,10 @@ storage-rocksdb = ["dep:cozorocks"]
 storage-new-rocksdb = ["dep:rocksdb"]
 ## Enables the graph algorithms.
 graph-algo = ["graph", "rayon"]
+## Registers CsvReader and JsonReader, which allow queries to read arbitrary
+## process-readable files. With `requests`, they may also make outbound requests.
+## Only enable this for trusted CozoScript callers.
+data-import = []
 ## Allows the utilities to make web requests to fetch data.
 requests = ["dep:minreq"]
 ## Uses jemalloc as the global allocator, can make a difference in performance.

--- a/cozo-core/src/fixed_rule/mod.rs
+++ b/cozo-core/src/fixed_rule/mod.rs
@@ -1114,10 +1114,12 @@ lazy_static! {
                 "MMR".to_string(),
                 Arc::<Box<dyn FixedRule>>::new(Box::new(MaximalMarginalRelevance)),
             ),
+            #[cfg(feature = "data-import")]
             (
                 "JsonReader".to_string(),
                 Arc::<Box<dyn FixedRule>>::new(Box::new(JsonReader)),
             ),
+            #[cfg(feature = "data-import")]
             (
                 "CsvReader".to_string(),
                 Arc::<Box<dyn FixedRule>>::new(Box::new(CsvReader)),

--- a/cozo-core/src/fixed_rule/utilities/mod.rs
+++ b/cozo-core/src/fixed_rule/utilities/mod.rs
@@ -7,14 +7,18 @@
  */
 
 pub(crate) mod constant;
+#[cfg(feature = "data-import")]
 pub(crate) mod csv;
+#[cfg(feature = "data-import")]
 pub(crate) mod jlines;
 pub(crate) mod mmr;
 pub(crate) mod reorder_sort;
 pub(crate) mod rrf;
 
+#[cfg(feature = "data-import")]
 pub(crate) use self::csv::CsvReader;
 pub(crate) use constant::Constant;
+#[cfg(feature = "data-import")]
 pub(crate) use jlines::JsonReader;
 pub(crate) use mmr::MaximalMarginalRelevance;
 pub(crate) use reorder_sort::ReorderSort;

--- a/cozo-core/tests/air_routes.rs
+++ b/cozo-core/tests/air_routes.rs
@@ -5,7 +5,7 @@
  * If a copy of the MPL was not distributed with this file,
  * You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-#![cfg(feature = "graph-algo")]
+#![cfg(all(feature = "graph-algo", feature = "data-import"))]
 // Inherited fixture style; the release gate compiles this target but does not modernize it.
 #![allow(clippy::get_first, clippy::unnecessary_operation)]
 

--- a/cozo-core/tests/data_import_security.rs
+++ b/cozo-core/tests/data_import_security.rs
@@ -1,0 +1,16 @@
+use cozo::DbInstance;
+
+#[test]
+fn data_readers_require_explicit_opt_in() {
+    let db = DbInstance::new("mem", "", Default::default()).unwrap();
+    let rules = db.get_fixed_rules();
+
+    assert_eq!(
+        rules.contains_key("CsvReader"),
+        cfg!(feature = "data-import")
+    );
+    assert_eq!(
+        rules.contains_key("JsonReader"),
+        cfg!(feature = "data-import")
+    );
+}


### PR DESCRIPTION
### Motivation

- The `CsvReader` and `JsonReader` utilities accept a script-controlled `url` that can read `file://` paths or perform outbound HTTP(S) GETs, creating a local-file disclosure and SSRF risk when reachable from CozoScript. 
- The change aims to avoid exposing filesystem/network access to untrusted script callers by making these readers opt-in for trusted deployments. 

### Description

- Add a non-default `data-import` feature in `cozo-core/Cargo.toml` to opt in to filesystem- and network-capable readers via `data-import`. 
- Gate the `csv` and `jlines` modules and their public exports behind `#[cfg(feature = "data-import")]` in `cozo-core/src/fixed_rule/utilities/mod.rs`. 
- Wrap the `CsvReader`/`JsonReader` fixed-rule registrations with `#[cfg(feature = "data-import")]` in `cozo-core/src/fixed_rule/mod.rs` so they are not registered by default. 
- Restrict the `air_routes` test fixture to require `data-import` and add a regression test `cozo-core/tests/data_import_security.rs` that asserts the readers are absent by default and present when `data-import` is enabled. 

### Testing

- `cargo test -p mnestic --test data_import_security` succeeded (regression test passes with default features). 
- `cargo test -p mnestic --test data_import_security --features data-import` succeeded (regression test passes when `data-import` is enabled). 
- `cargo check -p mnestic` succeeded. 
- `rustfmt --edition 2021 --check` on the modified files succeeded. 
- `cargo fmt --all -- --check` reported pre-existing unrelated formatting differences (warning) and `cargo check -p mnestic --all-features` was started but manually stopped while compiling optional storage backends (warning).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a7175c198832b825d7eaae5fa1f35)