### PR TITLE
Block indirect reads from hidden relations

### DIFF
--- a/cozo-core/src/fixed_rule/mod.rs
+++ b/cozo-core/src/fixed_rule/mod.rs
@@ -40,6 +40,7 @@ use crate::runtime::graph_projection::{
     graph_source, GraphSource, GraphVariant, ProjectionNegativeWeightError,
     ProjectionNodesInputConflict, ProjectionVariant, VariantSpec,
 };
+use crate::runtime::relation::{AccessLevel, InsufficientAccessLevel};
 use crate::runtime::temp_store::{EpochStore, RegularTempStore};
 use crate::runtime::transact::SessionTx;
 use crate::NamedRows;
@@ -103,6 +104,13 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
                 ..
             } => {
                 let relation = self.tx.get_relation(name, false)?;
+                if relation.access_level < AccessLevel::ReadOnly {
+                    bail!(InsufficientAccessLevel(
+                        relation.name.to_string(),
+                        "reading rows".to_string(),
+                        relation.access_level
+                    ));
+                }
                 if let Some(tt) = tx_valid_at {
                     // bitemporal input (mnestic fork, 4b): two-level scan
                     Box::new(relation.bitemporal_scan_all(self.tx, *valid_at, *tt))
@@ -131,6 +139,13 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
                 ..
             } => {
                 let relation = self.tx.get_relation(name, false)?;
+                if relation.access_level < AccessLevel::ReadOnly {
+                    bail!(InsufficientAccessLevel(
+                        relation.name.to_string(),
+                        "reading rows".to_string(),
+                        relation.access_level
+                    ));
+                }
                 let t = vec![prefix.clone()];
                 if let Some(tt) = tx_valid_at {
                     // bitemporal input (mnestic fork, 4b): two-level scan

--- a/cozo-core/src/query/compile.rs
+++ b/cozo-core/src/query/compile.rs
@@ -458,6 +458,13 @@ impl<'a> SessionTx<'a> {
                 }
                 MagicAtom::NegatedRelation(rel_app) => {
                     let store = self.get_relation(&rel_app.name, false)?;
+                    if store.access_level < AccessLevel::ReadOnly {
+                        bail!(InsufficientAccessLevel(
+                            store.name.to_string(),
+                            "reading rows".to_string(),
+                            store.access_level
+                        ));
+                    }
                     ensure!(
                         store.arity() == rel_app.args.len(),
                         ArityMismatch(

--- a/cozo-core/src/runtime/tests.rs
+++ b/cozo-core/src/runtime/tests.rs
@@ -51,6 +51,33 @@ fn test_limit_offset() {
 }
 
 #[test]
+fn hidden_relations_cannot_be_read_indirectly() {
+    let db = DbInstance::default();
+    db.run_default(":create secret {id => value}").unwrap();
+    db.run_default("?[id, value] <- [[1, 'classified']] :put secret {id => value}")
+        .unwrap();
+    db.run_default("::access_level hidden secret").unwrap();
+
+    let negated = db
+        .run_default("candidates[id] <- [[1], [2]] ?[id] := candidates[id], not *secret{id}")
+        .expect_err("negation must not reveal membership in a hidden relation");
+    assert!(
+        format!("{negated:?}").contains("Insufficient access level"),
+        "{negated:?}"
+    );
+
+    let fixed_rule = db
+        .run_default(
+            "?[rank, id, value] <~ ReorderSort(*secret[id, value], out: [id, value], sort_by: id)",
+        )
+        .expect_err("fixed rules must not scan a hidden relation");
+    assert!(
+        format!("{fixed_rule:?}").contains("Insufficient access level"),
+        "{fixed_rule:?}"
+    );
+}
+
+#[test]
 fn test_normal_aggr_empty() {
     let db = DbInstance::default();
     let res = db.run_default("?[count(a)] := a in []").unwrap().rows;


### PR DESCRIPTION
### Motivation
- The `hidden` access level was documented to disallow any data access, but negated stored-relation atoms and fixed-rule relation inputs were not enforcing this, enabling membership inference and algorithmic exfiltration.
- The change closes these unchecked read paths so `hidden` relations cannot be read indirectly by queries or fixed-rule algorithms.

### Description
- Add an access-level check to `MagicAtom::NegatedRelation` in `cozo-core/src/query/compile.rs` to reject negated stored-relation atoms when the relation is below `ReadOnly`.
- Enforce the same row-read checks in fixed-rule relation inputs by importing `AccessLevel`/`InsufficientAccessLevel` and verifying `relation.access_level >= ReadOnly` before calling `scan_all`, `scan_prefix`, `skip_scan_*`, or `bitemporal_scan_*` in `cozo-core/src/fixed_rule/mod.rs`.
- Add a regression test `hidden_relations_cannot_be_read_indirectly` in `cozo-core/src/runtime/tests.rs` that asserts `Insufficient access level` errors for both a negation-based query and a `ReorderSort` fixed-rule invocation against a `hidden` relation.
- Keep unrelated workspace changes (e.g. Node.js lockfiles) untouched and only modify the core Rust files and tests needed to close the bypass.

### Testing
- Ran `cargo test -p mnestic --lib hidden_relations_cannot_be_read_indirectly` and the test passed.
- Ran `rustfmt --edition 2021 --check` on the modified files and the formatting check passed.
- Ran `git diff --check` and there were no whitespace or patch problems reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a7e9d36f4832bb50466d47e381490)