### PR TITLE
fix: centralize stored-relation read access control

### DIFF
--- a/cozo-core/src/fixed_rule/mod.rs
+++ b/cozo-core/src/fixed_rule/mod.rs
@@ -40,6 +40,7 @@ use crate::runtime::graph_projection::{
     graph_source, GraphSource, GraphVariant, ProjectionNegativeWeightError,
     ProjectionNodesInputConflict, ProjectionVariant, VariantSpec,
 };
+use crate::runtime::relation::{AccessLevel, InsufficientAccessLevel};
 use crate::runtime::temp_store::{EpochStore, RegularTempStore};
 use crate::runtime::transact::SessionTx;
 use crate::NamedRows;
@@ -103,6 +104,13 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
                 ..
             } => {
                 let relation = self.tx.get_relation(name, false)?;
+                if relation.access_level < AccessLevel::ReadOnly {
+                    bail!(InsufficientAccessLevel(
+                        relation.name.to_string(),
+                        "reading rows".to_string(),
+                        relation.access_level
+                    ));
+                }
                 if let Some(tt) = tx_valid_at {
                     // bitemporal input (mnestic fork, 4b): two-level scan
                     Box::new(relation.bitemporal_scan_all(self.tx, *valid_at, *tt))
@@ -131,6 +139,13 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
                 ..
             } => {
                 let relation = self.tx.get_relation(name, false)?;
+                if relation.access_level < AccessLevel::ReadOnly {
+                    bail!(InsufficientAccessLevel(
+                        relation.name.to_string(),
+                        "reading rows".to_string(),
+                        relation.access_level
+                    ));
+                }
                 let t = vec![prefix.clone()];
                 if let Some(tt) = tx_valid_at {
                     // bitemporal input (mnestic fork, 4b): two-level scan

--- a/cozo-core/src/fixed_rule/mod.rs
+++ b/cozo-core/src/fixed_rule/mod.rs
@@ -40,7 +40,6 @@ use crate::runtime::graph_projection::{
     graph_source, GraphSource, GraphVariant, ProjectionNegativeWeightError,
     ProjectionNodesInputConflict, ProjectionVariant, VariantSpec,
 };
-use crate::runtime::relation::{AccessLevel, InsufficientAccessLevel};
 use crate::runtime::temp_store::{EpochStore, RegularTempStore};
 use crate::runtime::transact::SessionTx;
 use crate::NamedRows;
@@ -103,14 +102,7 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
                 tx_valid_at,
                 ..
             } => {
-                let relation = self.tx.get_relation(name, false)?;
-                if relation.access_level < AccessLevel::ReadOnly {
-                    bail!(InsufficientAccessLevel(
-                        relation.name.to_string(),
-                        "reading rows".to_string(),
-                        relation.access_level
-                    ));
-                }
+                let relation = self.tx.get_relation_for_read(name, "reading rows")?;
                 if let Some(tt) = tx_valid_at {
                     // bitemporal input (mnestic fork, 4b): two-level scan
                     Box::new(relation.bitemporal_scan_all(self.tx, *valid_at, *tt))
@@ -138,14 +130,7 @@ impl<'a, 'b> FixedRuleInputRelation<'a, 'b> {
                 tx_valid_at,
                 ..
             } => {
-                let relation = self.tx.get_relation(name, false)?;
-                if relation.access_level < AccessLevel::ReadOnly {
-                    bail!(InsufficientAccessLevel(
-                        relation.name.to_string(),
-                        "reading rows".to_string(),
-                        relation.access_level
-                    ));
-                }
+                let relation = self.tx.get_relation_for_read(name, "reading rows")?;
                 let t = vec![prefix.clone()];
                 if let Some(tt) = tx_valid_at {
                     // bitemporal input (mnestic fork, 4b): two-level scan
@@ -1238,7 +1223,7 @@ impl MagicFixedRuleRuleArg {
                 store.arity
             }
             MagicFixedRuleRuleArg::Stored { name, .. } => {
-                let handle = tx.get_relation(name, false)?;
+                let handle = tx.get_relation_for_read(name, "reading rows")?;
                 handle.arity()
             }
         })

--- a/cozo-core/src/query/compile.rs
+++ b/cozo-core/src/query/compile.rs
@@ -254,11 +254,12 @@ impl<'a> SessionTx<'a> {
                 }
                 MagicAtom::Relation(rel_app) => {
                     let store = self.get_relation(&rel_app.name, false)?;
-                    if store.access_level < AccessLevel::ReadOnly {
+                    let access_level = self.effective_read_access_level(&store)?;
+                    if access_level < AccessLevel::ReadOnly {
                         bail!(InsufficientAccessLevel(
                             store.name.to_string(),
                             "reading rows".to_string(),
-                            store.access_level
+                            access_level
                         ));
                     }
                     ensure!(

--- a/cozo-core/src/query/compile.rs
+++ b/cozo-core/src/query/compile.rs
@@ -22,7 +22,6 @@ use crate::data::symb::Symbol;
 use crate::data::value::DataValue;
 use crate::parse::SourceSpan;
 use crate::query::ra::RelAlgebra;
-use crate::runtime::relation::{AccessLevel, InsufficientAccessLevel};
 use crate::runtime::transact::SessionTx;
 
 pub(crate) type CompiledProgram = BTreeMap<MagicSymbol, CompiledRuleSet>;
@@ -253,15 +252,7 @@ impl<'a> SessionTx<'a> {
                     ret = ret.join(right, prev_joiner_vars, right_joiner_vars, rule_app.span);
                 }
                 MagicAtom::Relation(rel_app) => {
-                    let store = self.get_relation(&rel_app.name, false)?;
-                    let access_level = self.effective_read_access_level(&store)?;
-                    if access_level < AccessLevel::ReadOnly {
-                        bail!(InsufficientAccessLevel(
-                            store.name.to_string(),
-                            "reading rows".to_string(),
-                            access_level
-                        ));
-                    }
+                    let store = self.get_relation_for_read(&rel_app.name, "reading rows")?;
                     ensure!(
                         store.arity() == rel_app.args.len(),
                         ArityMismatch(
@@ -458,14 +449,7 @@ impl<'a> SessionTx<'a> {
                     ret = ret.neg_join(right, prev_joiner_vars, right_joiner_vars, rule_app.span);
                 }
                 MagicAtom::NegatedRelation(rel_app) => {
-                    let store = self.get_relation(&rel_app.name, false)?;
-                    if store.access_level < AccessLevel::ReadOnly {
-                        bail!(InsufficientAccessLevel(
-                            store.name.to_string(),
-                            "reading rows".to_string(),
-                            store.access_level
-                        ));
-                    }
+                    let store = self.get_relation_for_read(&rel_app.name, "reading rows")?;
                     ensure!(
                         store.arity() == rel_app.args.len(),
                         ArityMismatch(

--- a/cozo-core/src/query/compile.rs
+++ b/cozo-core/src/query/compile.rs
@@ -458,6 +458,13 @@ impl<'a> SessionTx<'a> {
                 }
                 MagicAtom::NegatedRelation(rel_app) => {
                     let store = self.get_relation(&rel_app.name, false)?;
+                    if store.access_level < AccessLevel::ReadOnly {
+                        bail!(InsufficientAccessLevel(
+                            store.name.to_string(),
+                            "reading rows".to_string(),
+                            store.access_level
+                        ));
+                    }
                     ensure!(
                         store.arity() == rel_app.args.len(),
                         ArityMismatch(

--- a/cozo-core/src/runtime/db.rs
+++ b/cozo-core/src/runtime/db.rs
@@ -815,11 +815,12 @@ impl<'s, S: Storage<'s>> Db<S> {
             let handle = tx.get_relation(rel.as_ref(), false)?;
             let size_hint = handle.metadata.keys.len() + handle.metadata.non_keys.len();
 
-            if handle.access_level < AccessLevel::ReadOnly {
+            let access_level = tx.effective_read_access_level(&handle)?;
+            if access_level < AccessLevel::ReadOnly {
                 bail!(InsufficientAccessLevel(
                     handle.name.to_string(),
                     "data export".to_string(),
-                    handle.access_level
+                    access_level
                 ));
             }
 

--- a/cozo-core/src/runtime/db.rs
+++ b/cozo-core/src/runtime/db.rs
@@ -51,9 +51,9 @@ use crate::query::ra::{
 use crate::runtime::callback::{
     CallbackCollector, CallbackDeclaration, CallbackOp, EventCallbackRegistry,
 };
+use crate::runtime::diagnostics::QueryWarning;
 use crate::runtime::graph_projection;
 use crate::runtime::graph_projection::ProjectionCache;
-use crate::runtime::diagnostics::QueryWarning;
 use crate::runtime::relation::{
     try_extend_tuple_from_v, AccessLevel, InsufficientAccessLevel, RelationHandle, RelationId,
 };
@@ -812,17 +812,8 @@ impl<'s, S: Storage<'s>> Db<S> {
         let tx = self.transact()?;
         let mut ret: BTreeMap<String, NamedRows> = BTreeMap::new();
         for rel in relations {
-            let handle = tx.get_relation(rel.as_ref(), false)?;
+            let handle = tx.get_relation_for_read(rel.as_ref(), "data export")?;
             let size_hint = handle.metadata.keys.len() + handle.metadata.non_keys.len();
-
-            let access_level = tx.effective_read_access_level(&handle)?;
-            if access_level < AccessLevel::ReadOnly {
-                bail!(InsufficientAccessLevel(
-                    handle.name.to_string(),
-                    "data export".to_string(),
-                    access_level
-                ));
-            }
 
             let mut cols = handle
                 .metadata
@@ -2235,16 +2226,9 @@ impl<'s, S: Storage<'s>> Db<S> {
             SysOp::TtHistory(rel, keys, limit, offset) => {
                 // mnestic fork, bitemporality step 5: the introspection
                 // surface — every (vt, tt) record of the given keys.
-                let handle = tx.get_relation(rel, false)?;
+                let handle = tx.get_relation_for_read(rel, "history introspection")?;
                 if !handle.has_txtime() {
                     bail!("::history requires a TxTime relation, {} is not", rel);
-                }
-                if handle.access_level < AccessLevel::ReadOnly {
-                    bail!(InsufficientAccessLevel(
-                        handle.name.to_string(),
-                        "history introspection".to_string(),
-                        handle.access_level
-                    ))
                 }
                 let kpos = handle.metadata.keys.len() - 1;
                 let is_bitemporal = !handle.is_tt_only();

--- a/cozo-core/src/runtime/graph_projection.rs
+++ b/cozo-core/src/runtime/graph_projection.rs
@@ -1508,7 +1508,7 @@ fn resolve_source(tx: &SessionTx<'_>, name: &str) -> Result<RelationHandle> {
     if name.starts_with('_') {
         bail!(ProjectionTempSourceError(name.to_string()));
     }
-    let handle = tx.get_relation(name, false)?;
+    let handle = tx.get_relation_for_read(name, "reading graph projection source")?;
     // Belt and braces: `is_temp_store_name` is the only way in today, but the
     // id collision this guards against is silent and unrecoverable.
     if handle.is_temp {

--- a/cozo-core/src/runtime/imperative.rs
+++ b/cozo-core/src/runtime/imperative.rs
@@ -22,7 +22,7 @@ use crate::data::symb::Symbol;
 use crate::parse::{ImperativeCondition, ImperativeProgram, ImperativeStmt, SourceSpan};
 use crate::runtime::callback::CallbackCollector;
 use crate::runtime::db::{seconds_since_the_epoch, RunningQueryCleanup, RunningQueryHandle};
-use crate::runtime::relation::InputRelationHandle;
+use crate::runtime::relation::{AccessLevel, InputRelationHandle, InsufficientAccessLevel};
 use crate::runtime::transact::SessionTx;
 use crate::{DataValue, Db, NamedRows, Poison, Storage, ValidityTs};
 
@@ -102,6 +102,13 @@ impl<'s, S: Storage<'s>> Db<S> {
                             )?,
                             Right(rel) => {
                                 let relation = tx.get_relation(rel, false)?;
+                                if relation.access_level < AccessLevel::ReadOnly {
+                                    bail!(InsufficientAccessLevel(
+                                        relation.name.to_string(),
+                                        "reading rows".to_string(),
+                                        relation.access_level
+                                    ));
+                                }
                                 relation.as_named_rows(tx)?
                             }
                         };

--- a/cozo-core/src/runtime/imperative.rs
+++ b/cozo-core/src/runtime/imperative.rs
@@ -22,7 +22,7 @@ use crate::data::symb::Symbol;
 use crate::parse::{ImperativeCondition, ImperativeProgram, ImperativeStmt, SourceSpan};
 use crate::runtime::callback::CallbackCollector;
 use crate::runtime::db::{seconds_since_the_epoch, RunningQueryCleanup, RunningQueryHandle};
-use crate::runtime::relation::{AccessLevel, InputRelationHandle, InsufficientAccessLevel};
+use crate::runtime::relation::InputRelationHandle;
 use crate::runtime::transact::SessionTx;
 use crate::{DataValue, Db, NamedRows, Poison, Storage, ValidityTs};
 
@@ -44,7 +44,7 @@ impl<'s, S: Storage<'s>> Db<S> {
     ) -> Result<bool> {
         let res = match p {
             Left(rel) => {
-                let relation = tx.get_relation(rel, false)?;
+                let relation = tx.get_relation_for_read(rel, "reading rows")?;
                 relation.as_named_rows(tx)?
             }
             Right(p) => self.execute_single_program(
@@ -101,14 +101,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                                 callback_collector,
                             )?,
                             Right(rel) => {
-                                let relation = tx.get_relation(rel, false)?;
-                                if relation.access_level < AccessLevel::ReadOnly {
-                                    bail!(InsufficientAccessLevel(
-                                        relation.name.to_string(),
-                                        "reading rows".to_string(),
-                                        relation.access_level
-                                    ));
-                                }
+                                let relation = tx.get_relation_for_read(rel, "reading rows")?;
                                 relation.as_named_rows(tx)?
                             }
                         };
@@ -123,7 +116,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                     return Ok(Right(ControlCode::Termination(*current.unwrap())));
                 }
                 ImperativeStmt::TempDebug { temp, .. } => {
-                    let relation = tx.get_relation(temp, false)?;
+                    let relation = tx.get_relation_for_read(temp, "reading rows")?;
                     println!("{}: {:?}", temp, relation.as_named_rows(tx)?);
                     ret = NamedRows::default();
                 }

--- a/cozo-core/src/runtime/relation.rs
+++ b/cozo-core/src/runtime/relation.rs
@@ -121,6 +121,23 @@ impl RelationHandle {
     }
 }
 
+impl<'a> SessionTx<'a> {
+    /// Return the effective access level for a relation read. Ordinary
+    /// indexes are stored as independent `base:index` relations, but they
+    /// must never grant more access than their base relation.
+    pub(crate) fn effective_read_access_level(
+        &self,
+        handle: &RelationHandle,
+    ) -> Result<AccessLevel> {
+        if let Some((base_name, _)) = handle.name.split_once(':') {
+            let base = self.get_relation(base_name, false)?;
+            Ok(handle.access_level.min(base.access_level))
+        } else {
+            Ok(handle.access_level)
+        }
+    }
+}
+
 #[derive(
     Copy,
     Clone,
@@ -1824,6 +1841,13 @@ impl<'a> SessionTx<'a> {
     ) -> Result<()> {
         // Get relation handle
         let mut rel_handle = self.get_relation(rel_name, true)?;
+        if rel_handle.access_level < AccessLevel::Normal {
+            bail!(InsufficientAccessLevel(
+                rel_handle.name.to_string(),
+                "creating index".to_string(),
+                rel_handle.access_level
+            ));
+        }
         Self::reject_txtime_relation(&rel_handle, "::index create")?;
 
         // Check if index already exists

--- a/cozo-core/src/runtime/relation.rs
+++ b/cozo-core/src/runtime/relation.rs
@@ -136,6 +136,26 @@ impl<'a> SessionTx<'a> {
             Ok(handle.access_level)
         }
     }
+
+    /// Resolve a stored relation for a read and enforce its effective ACL.
+    /// Every read surface must use this method so an index can never expose a
+    /// base relation that is hidden.
+    pub(crate) fn get_relation_for_read(
+        &self,
+        name: &str,
+        operation: &str,
+    ) -> Result<RelationHandle> {
+        let handle = self.get_relation(name, false)?;
+        let access_level = self.effective_read_access_level(&handle)?;
+        if access_level < AccessLevel::ReadOnly {
+            bail!(InsufficientAccessLevel(
+                handle.name.to_string(),
+                operation.to_string(),
+                access_level
+            ));
+        }
+        Ok(handle)
+    }
 }
 
 #[derive(

--- a/cozo-core/src/runtime/tests.rs
+++ b/cozo-core/src/runtime/tests.rs
@@ -51,6 +51,33 @@ fn test_limit_offset() {
 }
 
 #[test]
+fn hidden_relations_cannot_be_read_indirectly() {
+    let db = DbInstance::default();
+    db.run_default(":create secret {id => value}").unwrap();
+    db.run_default("?[id, value] <- [[1, 'classified']] :put secret {id => value}")
+        .unwrap();
+    db.run_default("::access_level hidden secret").unwrap();
+
+    let negated = db
+        .run_default("candidates[id] <- [[1], [2]] ?[id] := candidates[id], not *secret{id}")
+        .expect_err("negation must not reveal membership in a hidden relation");
+    assert!(
+        format!("{negated:?}").contains("Insufficient access level"),
+        "{negated:?}"
+    );
+
+    let fixed_rule = db
+        .run_default(
+            "?[rank, id, value] <~ ReorderSort(*secret[id, value], out: [id, value], sort_by: id)",
+        )
+        .expect_err("fixed rules must not scan a hidden relation");
+    assert!(
+        format!("{fixed_rule:?}").contains("Insufficient access level"),
+        "{fixed_rule:?}"
+    );
+}
+
+#[test]
 fn test_normal_aggr_empty() {
     let db = DbInstance::default();
     let res = db.run_default("?[count(a)] := a in []").unwrap().rows;

--- a/cozo-core/src/runtime/tests.rs
+++ b/cozo-core/src/runtime/tests.rs
@@ -4221,3 +4221,19 @@ fn reconcile_validation() {
         .into_json();
     assert_eq!(res["rows"], serde_json::json!([[1, 99]]), "{res:?}");
 }
+
+#[test]
+fn imperative_return_respects_relation_access_level() {
+    let db = DbInstance::new("mem", "", "").unwrap();
+    db.run_default("?[k, v] <- [[1, 'secret']] :create secret {k => v}")
+        .unwrap();
+    db.run_default("::access_level hidden secret").unwrap();
+
+    let err = db
+        .run_default("%return secret")
+        .expect_err("imperative return must not expose a hidden relation");
+    assert!(
+        format!("{err:?}").contains("Insufficient access level"),
+        "{err:?}"
+    );
+}

--- a/cozo-core/src/runtime/tests.rs
+++ b/cozo-core/src/runtime/tests.rs
@@ -542,6 +542,28 @@ fn test_index() {
 }
 
 #[test]
+fn index_respects_base_relation_access_level() {
+    let db = DbInstance::default();
+    db.run_default(":create secret {id: Int => value: String}")
+        .unwrap();
+    db.run_default("?[id, value] <- [[1, 'classified']] :put secret {id => value}")
+        .unwrap();
+    db.run_default("::index create secret:by_value {value}")
+        .unwrap();
+    db.run_default("::access_level hidden secret").unwrap();
+
+    assert!(db
+        .run_default("?[id, value] := *secret:by_value{value, id}")
+        .is_err());
+    assert!(db
+        .export_relations(["secret:by_value"].into_iter())
+        .is_err());
+    assert!(db
+        .run_default("::index create secret:another {value}")
+        .is_err());
+}
+
+#[test]
 fn test_json_objects() {
     let db = DbInstance::default();
     db.run_default("?[a] := a = {'a': 1}").unwrap();

--- a/cozo-core/src/runtime/tests.rs
+++ b/cozo-core/src/runtime/tests.rs
@@ -559,6 +559,19 @@ fn index_respects_base_relation_access_level() {
         .export_relations(["secret:by_value"].into_iter())
         .is_err());
     assert!(db
+        .run_default(
+            "candidates[value] <- [['classified'], ['public']] \
+             ?[value] := candidates[value], not *secret:by_value{value}"
+        )
+        .is_err());
+    assert!(db
+        .run_default(
+            "?[rank, value, id] <~ ReorderSort(*secret:by_value[value, id], \
+             out: [value, id], sort_by: value)"
+        )
+        .is_err());
+    assert!(db.run_default("%return secret:by_value").is_err());
+    assert!(db
         .run_default("::index create secret:another {value}")
         .is_err());
 }

--- a/cozo-core/tests/budgeted_traversal.rs
+++ b/cozo-core/tests/budgeted_traversal.rs
@@ -867,6 +867,25 @@ fn j1b_named_gate_binding_parses_and_binds_by_name() {
 }
 
 #[test]
+fn j1c_hidden_gate_is_not_readable_by_fixed_rule() {
+    let (_dir, db) = open_db();
+    run(&db, ":create secret_gate {uid: String => ok: Int}");
+    run(
+        &db,
+        "?[uid, ok] <- [['a',1],['b',1]] :put secret_gate {uid => ok}",
+    );
+    run(&db, "::access_level hidden secret_gate");
+
+    let m = err(
+        &db,
+        "e[f, t, w] <- [['a','b',1.0]]\ns[n] <- [['a']]\n\
+         ?[n, c, p, d] <~ BudgetedTraversal(e[f, t, w], s[n], \
+         *secret_gate{uid, ok}, max_nodes: 10, admit: ok == 1)",
+    );
+    assert!(m.contains("Insufficient access level hidden"), "{m}");
+}
+
+#[test]
 fn j2_gate_not_a_bridge() {
     let (_dir, db) = open_db();
     run(&db, ":create g {uid: String => ok: Int}");

--- a/cozo-core/tests/graph_projection.rs
+++ b/cozo-core/tests/graph_projection.rs
@@ -40,6 +40,11 @@ fn err(db: &DbInstance, script: &str) -> String {
     )
 }
 
+fn assert_access_denied(db: &DbInstance, script: &str) {
+    let msg = err(db, script);
+    assert!(msg.contains("Insufficient access level"), "{msg}");
+}
+
 fn rows(res: &NamedRows) -> Vec<Vec<DataValue>> {
     res.rows.clone()
 }
@@ -396,6 +401,53 @@ fn renaming_a_tt_relation_into_a_source_name_errors_at_use() {
     // Source kinds are re-checked at every use, not only at create.
     let msg = err(&db, "?[n, c] <~ ConnectedComponents(graph: 'g')");
     assert!(msg.contains("transaction-time relation"), "{msg}");
+}
+
+// -------------------------------------------------------- source read ACLs
+
+#[test]
+fn a_hidden_edge_source_is_rejected_when_the_projection_is_created() {
+    let db = graph_db();
+    run(&db, "::access_level hidden knows");
+    assert_access_denied(&db, "::graph create g {edges: knows}");
+}
+
+#[test]
+fn a_hidden_edge_source_is_rejected_before_a_cold_build() {
+    let db = graph_db();
+    run(&db, "::graph create g {edges: knows}");
+    run(&db, "::access_level hidden knows");
+    assert_access_denied(&db, "?[n, c] <~ ConnectedComponents(graph: 'g')");
+}
+
+#[test]
+fn a_hidden_edge_source_is_rejected_before_a_warm_cache_hit() {
+    let db = graph_db();
+    run(&db, "::graph create g {edges: knows}");
+    run(&db, "?[n, c] <~ ConnectedComponents(graph: 'g')");
+    assert_eq!(resident(&db), 1);
+
+    run(&db, "::access_level hidden knows");
+    assert_access_denied(&db, "?[n, c] <~ ConnectedComponents(graph: 'g')");
+}
+
+#[test]
+fn a_hidden_node_source_is_rejected_before_a_cold_build() {
+    let db = graph_db();
+    run(&db, "::graph create g {edges: knows, nodes: person}");
+    run(&db, "::access_level hidden person");
+    assert_access_denied(&db, "?[n, c] <~ ConnectedComponents(graph: 'g')");
+}
+
+#[test]
+fn a_hidden_node_source_is_rejected_before_a_warm_cache_hit() {
+    let db = graph_db();
+    run(&db, "::graph create g {edges: knows, nodes: person}");
+    run(&db, "?[n, c] <~ ConnectedComponents(graph: 'g')");
+    assert_eq!(resident(&db), 1);
+
+    run(&db, "::access_level hidden person");
+    assert_access_denied(&db, "?[n, c] <~ ConnectedComponents(graph: 'g')");
 }
 
 // --------------------------------------------------------- caching behaviour


### PR DESCRIPTION
## Summary

- resolve every stored relation read through one checked relation resolver
- inherit a base relation's access level for ordinary base:index relations
- enforce the same effective ACL for positive and negated atoms, fixed-rule inputs and arity checks, imperative reads, exports, and history reads
- route graph-projection node and edge sources through the same checked resolver
- retain the focused BudgetedTraversal hidden-gate regression from #21
- add index-specific and graph-projection regressions, including cold and warm cache reads after a source becomes Hidden

## Root cause

Relation read authorization was duplicated across execution paths. Several indirect readers checked the index relation's raw ACL or performed no check, allowing a hidden base relation to remain observable through an index, negation, a fixed rule, imperative return, export, or graph projection.

## Impact

A hidden base or graph source relation can no longer be exposed through alternate query, export, projection-build, or cached-projection surfaces, and future read paths have one authorization primitive to reuse.

## Supersedes

#21, #32, #33, and #38.

## Validation

- full graph_projection integration suite: 63 passed
- five new Hidden-source graph regressions passed across creation, cold build, and warm cache paths
- existing focused ACL and BudgetedTraversal regressions passed
- PR #40 hosted checks: 8/8 passed
- combined verification PR #41 at 7f7b07575f45e53f47139687a8b38e5d8bf12938: 8/8 passed
- MindGraph acceptance PR #47 pinned to that exact SHA: 10/10 passed, including full core and server suites on Ubuntu and macOS, RocksDB-backed tests, clippy, docs, and Rust 1.88
- git diff integrity, formatting, and Cargo metadata passed

## Merge order

Merge this PR first, then #39. The exact combined result was validated by #41.