### PR TITLE
Per-query memory budget on materialization

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -5,7 +5,36 @@ provenance and licensing.
 
 ## Unreleased
 
-Nothing yet.
+- **A per-query memory budget** (spec
+  [`docs/specs/memory-budget.md`](docs/specs/memory-budget.md), signed
+  2026-08-16): the temp stores that hold every intermediate of semi-naive
+  evaluation previously had zero accounting, so a mis-authored join — a
+  cartesian intermediate is the canonical case — would OOM-kill the **host
+  process**. Now every store charges an estimated byte cost per allocation
+  event (real insertions, merge key-clones, bounded/dominance
+  re-materializations; moves are accounting-neutral, evictions and duplicate
+  drops are debited, and each store releases exactly what it charged on
+  drop), the sort and final-result staging copies are charged too, and a
+  budget trip aborts the query with the new
+  **`eval::mem_budget_exceeded`** diagnostic — before the memory is spent and
+  before any commit, so a tripped mutable script leaves no partial writes and
+  the Db keeps serving. The knob is a triple, min-composed exactly like the
+  wall-clock budget: a per-block **`:mem_limit <bytes>`** option, a per-call
+  `ScriptRunOptions::with_mem_limit`, and a Db-wide
+  `set_default_query_mem_limit` — **script text can only tighten the budget a
+  host set, never raise it** (scripts are increasingly LLM-authored). The
+  figures are logical estimates of engine-held bytes, not process RSS, and are
+  not stable across releases. The engine default stays **unset** (a library
+  must not change behavior under its hosts), but `cozo-bin` — an application —
+  ships with a 4 GiB default budget (`--default-query-mem-limit`, `0` for
+  unlimited), and its HTTP query payload accepts a per-request `mem_limit`.
+  Determinism posture, per the signed spec: a query comfortably over budget
+  always errors and one comfortably under always succeeds; at the margin,
+  trip-vs-succeed and the rule named in the error may vary with parallel
+  scheduling. No embedded Datalog engine ships a per-query memory bound
+  (Soufflé has none; Datomic queries can OOM the host JVM; RDFox's
+  `max-memory` is whole-server) — this is the "safe substrate inside your
+  process" story made concrete.
 
 ## 0.14.0 — 2026-08-08
 

--- a/cozo-bin/src/server.rs
+++ b/cozo-bin/src/server.rs
@@ -87,6 +87,14 @@ pub(crate) struct ServerArgs {
     /// per-request `timeout` or an in-script `:timeout` can only tighten it.
     #[clap(long)]
     default_query_timeout: Option<f64>,
+
+    /// Db-wide default per-query memory budget in estimated bytes (mnestic
+    /// fork, query memory budget; spec `docs/specs/memory-budget.md`).
+    /// cozo-bin is an application, not a library, so it ARMS a budget out of
+    /// the box (4 GiB); pass `0` for unlimited. A per-request `mem_limit` or
+    /// an in-script `:mem_limit` can only tighten it.
+    #[clap(long, default_value_t = 4 * 1024 * 1024 * 1024)]
+    default_query_mem_limit: u64,
 }
 
 #[derive(Clone)]
@@ -425,6 +433,9 @@ pub(crate) async fn server_main(args: ServerArgs) {
     std::fs::create_dir_all(&args.backup_dir).expect("Cannot create HTTP backup directory");
     let backup_dir =
         std::fs::canonicalize(&args.backup_dir).expect("Cannot resolve HTTP backup directory");
+    if args.default_query_mem_limit > 0 {
+        db.set_default_query_mem_limit(Some(args.default_query_mem_limit as usize));
+    }
     if let Some(secs) = args.default_query_timeout {
         db.set_default_query_timeout(Some(secs));
     }
@@ -737,6 +748,10 @@ struct QueryPayload {
     /// Optional; combined via `min` with any in-script `:timeout` and the
     /// server's `--default-query-timeout`. Ignored on the `/transact/:id` path.
     timeout: Option<f64>,
+    /// Per-call memory budget in estimated bytes (mnestic fork, query memory
+    /// budget). Optional; combined via `min` with any in-script `:mem_limit`
+    /// and the server's `--default-query-mem-limit`.
+    mem_limit: Option<usize>,
 }
 
 async fn text_query(
@@ -755,6 +770,7 @@ async fn text_query(
     };
     let options = ScriptRunOptions {
         timeout: payload.timeout,
+        mem_limit: payload.mem_limit,
     };
     let result = spawn_blocking(move || {
         st.db.run_script_fold_err_with_options(

--- a/cozo-core/src/cozoscript.pest
+++ b/cozo-core/src/cozoscript.pest
@@ -148,7 +148,7 @@ object_pair = {expr ~ ":" ~ expr}
 list = { "[" ~ (expr ~ ",")* ~ expr? ~ "]" }
 grouping = { "(" ~ expr ~ ")" }
 
-option = _{(limit_option|offset_option|sort_option|relation_option|timeout_option|as_of_option|sleep_option|returning_option|
+option = _{(limit_option|offset_option|sort_option|relation_option|timeout_option|mem_limit_option|as_of_option|sleep_option|returning_option|
             assert_none_option|assert_some_option|disable_magic_rewrite_option|reorder_option) ~ ";"?}
 out_arg = @{var ~ ("(" ~ var ~ ")")?}
 disable_magic_rewrite_option = {":disable_magic_rewrite" ~ expr}
@@ -169,6 +169,7 @@ relation_rm = {":rm"}
 relation_ensure = {":ensure"}
 relation_ensure_not = {":ensure_not"}
 timeout_option = {":timeout" ~ expr }
+mem_limit_option = {":mem_limit" ~ expr }
 reorder_option = {":reorder" ~ ident }
 as_of_option = {":as_of" ~ expr }
 sleep_option = {":sleep" ~ expr }

--- a/cozo-core/src/data/memsize.rs
+++ b/cozo-core/src/data/memsize.rs
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026, Shan Rizvi (mnestic fork).
+ * Copyright 2022, The Cozo Project Authors.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Shared estimated-heap-size vocabulary (mnestic fork, query memory budget;
+//! spec `docs/specs/memory-budget.md`). These estimators were born inside the
+//! `graph-algo`-gated projection cache; the query memory budget needs them on
+//! every build, so they live here un-gated and the projection cache imports
+//! them. The figures are deliberately *estimates* of engine-held bytes — they
+//! undercount allocator overhead by a roughly constant factor and are not
+//! stable across releases; tests pin brackets, never exact bytes.
+
+use crate::data::value::{DataValue, Vector};
+
+/// Charged per `BTreeMap`/`BTreeSet` entry when estimating a store's size.
+/// B-trees allocate in nodes, not per entry; this is the amortised share.
+pub(crate) const BTREE_ENTRY_OVERHEAD: usize = 48;
+
+/// Flat charge for the part of a value we cannot see into: a compiled
+/// regex's program. Its pattern text is counted exactly; the compiled
+/// automaton is opaque, and the estimate only needs the right order of
+/// magnitude for a value type this pathological.
+pub(crate) const OPAQUE_KEY_ESTIMATE: usize = 64;
+
+/// Heap bytes owned by a value, beyond its inline `DataValue`.
+pub(crate) fn value_heap_bytes(v: &DataValue) -> usize {
+    match v {
+        DataValue::Str(s) => {
+            if s.is_inline() {
+                0
+            } else {
+                s.len()
+            }
+        }
+        DataValue::Bytes(b) => b.len(),
+        DataValue::List(l) => {
+            l.len() * std::mem::size_of::<DataValue>()
+                + l.iter().map(value_heap_bytes).sum::<usize>()
+        }
+        DataValue::Set(s) => s
+            .iter()
+            .map(|v| std::mem::size_of::<DataValue>() + BTREE_ENTRY_OVERHEAD + value_heap_bytes(v))
+            .sum(),
+        DataValue::Vec(Vector::F32(a)) => a.len() * 4,
+        DataValue::Vec(Vector::F64(a)) => a.len() * 8,
+        // Json must be walked, not flat-charged: a single blob can be
+        // megabytes (projection-cache Phase 3/4 review, 2026-07-10).
+        DataValue::Json(j) => json_heap_bytes(&j.0),
+        DataValue::Regex(r) => r.0.as_str().len() + OPAQUE_KEY_ESTIMATE,
+        _ => 0,
+    }
+}
+
+/// Heap bytes owned by a JSON value, beyond one inline `serde_json::Value`.
+pub(crate) fn json_heap_bytes(v: &serde_json::Value) -> usize {
+    let node = std::mem::size_of::<serde_json::Value>();
+    match v {
+        serde_json::Value::String(s) => s.len(),
+        serde_json::Value::Array(a) => {
+            a.len() * node + a.iter().map(json_heap_bytes).sum::<usize>()
+        }
+        serde_json::Value::Object(m) => m
+            .iter()
+            .map(|(k, x)| k.len() + node + BTREE_ENTRY_OVERHEAD + json_heap_bytes(x))
+            .sum(),
+        _ => 0,
+    }
+}
+
+/// Estimated owned bytes of one tuple: the `Vec` header, one inline
+/// `DataValue` per column, and each value's heap. Does NOT include the
+/// per-entry `BTREE_ENTRY_OVERHEAD` — the charge site adds that, because a
+/// tuple used as a map *value* inside an existing entry carries no own entry.
+pub(crate) fn est_tuple_bytes(t: &[DataValue]) -> usize {
+    std::mem::size_of::<Vec<DataValue>>()
+        + t.len() * std::mem::size_of::<DataValue>()
+        + t.iter().map(value_heap_bytes).sum::<usize>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn narrow_tuple_lands_in_the_measured_bracket() {
+        // The audit measured ~168.4 B/row for the narrowest 2-col tuple
+        // including B-tree overhead; the estimate must land in that
+        // neighborhood (bracket, not exact bytes — the estimate is
+        // documented as unstable across releases).
+        let t = vec![DataValue::from(1i64), DataValue::from(2i64)];
+        let est = est_tuple_bytes(&t) + BTREE_ENTRY_OVERHEAD;
+        assert!(
+            (120..=240).contains(&est),
+            "2-col int tuple estimated at {est} B; expected the ~168 B bracket"
+        );
+    }
+
+    #[test]
+    fn vector_tuple_charges_its_heap() {
+        let v = DataValue::Vec(Vector::F32(ndarray::Array1::zeros(1536)));
+        let t = vec![DataValue::from(1i64), v];
+        let est = est_tuple_bytes(&t);
+        assert!(
+            est >= 1536 * 4,
+            "a 1536-dim f32 vector tuple must charge at least its heap ({est} B)"
+        );
+    }
+
+    #[test]
+    fn string_heap_only_when_not_inline() {
+        let long = DataValue::Str("a-string-well-past-inline-capacity-for-sure".into());
+        let t = vec![long];
+        assert!(est_tuple_bytes(&t) > est_tuple_bytes(&[DataValue::from(1i64)]));
+    }
+}

--- a/cozo-core/src/data/mod.rs
+++ b/cozo-core/src/data/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod expr;
 pub mod functions;
 pub(crate) mod json;
 pub(crate) mod memcmp;
+pub(crate) mod memsize;
 pub mod program;
 pub(crate) mod relation;
 pub mod symb;

--- a/cozo-core/src/data/program.rs
+++ b/cozo-core/src/data/program.rs
@@ -63,6 +63,11 @@ pub struct QueryOutOptions {
     pub offset: Option<usize>,
     /// Terminate query with an error if it exceeds this many seconds.
     pub timeout: Option<f64>,
+    /// Terminate query with an error if its materialization exceeds this many
+    /// estimated bytes (mnestic fork, query memory budget; spec
+    /// `docs/specs/memory-budget.md`). Combined via `min` with the per-call
+    /// and Db-default limits — a block can only tighten the budget.
+    pub mem_limit: Option<usize>,
     /// Join-reorder policy (mnestic fork, 0.10.5). Default `Greedy`; `:reorder
     /// written` opts out. A `:limit` without `:sort` also forces `Written` at
     /// normalization time to keep the returned row subset stable.
@@ -92,6 +97,9 @@ impl Display for QueryOutOptions {
         }
         if let Some(l) = self.offset {
             writeln!(f, ":offset {l};")?;
+        }
+        if let Some(l) = self.mem_limit {
+            writeln!(f, ":mem_limit {l};")?;
         }
         if let Some(l) = self.timeout {
             writeln!(f, ":timeout {l};")?;

--- a/cozo-core/src/lib.rs
+++ b/cozo-core/src/lib.rs
@@ -410,6 +410,26 @@ impl DbInstance {
             DbInstance::TiKv(db) => db.set_default_query_timeout(secs),
         }
     }
+
+    /// Set (or clear) the Db-wide default per-query memory budget in estimated
+    /// bytes (mnestic fork, query memory budget; spec
+    /// `docs/specs/memory-budget.md`). See
+    /// [`crate::Db::set_default_query_mem_limit`].
+    pub fn set_default_query_mem_limit(&self, bytes: Option<usize>) {
+        match self {
+            DbInstance::Mem(db) => db.set_default_query_mem_limit(bytes),
+            #[cfg(feature = "storage-sqlite")]
+            DbInstance::Sqlite(db) => db.set_default_query_mem_limit(bytes),
+            #[cfg(feature = "storage-rocksdb")]
+            DbInstance::RocksDb(db) => db.set_default_query_mem_limit(bytes),
+            #[cfg(feature = "storage-new-rocksdb")]
+            DbInstance::NewRocksDb(db) => db.set_default_query_mem_limit(bytes),
+            #[cfg(feature = "storage-sled")]
+            DbInstance::Sled(db) => db.set_default_query_mem_limit(bytes),
+            #[cfg(feature = "storage-tikv")]
+            DbInstance::TiKv(db) => db.set_default_query_mem_limit(bytes),
+        }
+    }
     /// Test-only dispatcher. See [`crate::Db::fail_next_commit_for_tests`].
     #[cfg(feature = "test-hooks")]
     #[doc(hidden)]

--- a/cozo-core/src/parse/query.rs
+++ b/cozo-core/src/parse/query.rs
@@ -284,6 +284,23 @@ pub(crate) fn parse_query(
                     out_opts.timeout = None;
                 }
             }
+            Rule::mem_limit_option => {
+                // mnestic fork, query memory budget (spec
+                // `docs/specs/memory-budget.md`): estimated-bytes ceiling on
+                // this block's materialization; `0` clears it.
+                let pair = pair.into_inner().next().unwrap();
+                let span = pair.extract_span();
+                let bytes = build_expr(pair, param_pool)?
+                    .eval_to_const()
+                    .map_err(|err| OptionNotConstantError("mem_limit", span, [err]))?
+                    .get_int()
+                    .ok_or(OptionNotNonNegIntError("mem_limit", span))?;
+                if bytes > 0 {
+                    out_opts.mem_limit = Some(bytes as usize);
+                } else {
+                    out_opts.mem_limit = None;
+                }
+            }
             Rule::sleep_option => {
                 #[cfg(target_arch = "wasm32")]
                 bail!(":sleep is not supported under WASM");

--- a/cozo-core/src/query/eval.rs
+++ b/cozo-core/src/query/eval.rs
@@ -29,7 +29,7 @@ use crate::parse::SourceSpan;
 use crate::query::compile::{
     AggrKind, CompiledProgram, CompiledRule, CompiledRuleSet, ContainedRuleMultiplicity,
 };
-use crate::runtime::db::Poison;
+use crate::runtime::db::{MemBudgetExceeded, Poison};
 use crate::runtime::temp_store::{EpochStore, MeetAggrStore, RegularTempStore, TempStore};
 use crate::runtime::transact::SessionTx;
 
@@ -69,6 +69,26 @@ impl QueryLimiter {
     }
 }
 
+/// Attach rule + epoch context to a memory-budget trip, and only to that
+/// (mnestic fork; spec `docs/specs/memory-budget.md` §7): other errors pass
+/// through untouched so their messages (and the tests pinned to them) never
+/// change.
+fn annotate_mem_budget(e: miette::Report, rule: &MagicSymbol, epoch: u32) -> miette::Report {
+    match e.downcast_ref::<MemBudgetExceeded>() {
+        // Rebuild the diagnostic with context rather than `wrap_err`-ing it,
+        // so the `eval::mem_budget_exceeded` code survives error-to-JSON
+        // folding (the wrapper would replace the outermost diagnostic).
+        Some(orig) => miette::Report::new(MemBudgetExceeded {
+            used: orig.used,
+            attempted: orig.attempted,
+            limit: orig.limit,
+            knob: orig.knob,
+            at: format!(", while evaluating rule {rule:?} (epoch {epoch})"),
+        }),
+        None => e,
+    }
+}
+
 impl<'a> SessionTx<'a> {
     pub(crate) fn stratified_magic_evaluate(
         &self,
@@ -91,20 +111,22 @@ impl<'a> SessionTx<'a> {
             }
             for (rule_name, rule_set) in cur_prog {
                 let store = match rule_set.aggr_kind()? {
-                    AggrKind::None | AggrKind::Normal => EpochStore::new_normal(rule_set.arity()),
+                    AggrKind::None | AggrKind::Normal => {
+                        EpochStore::new_normal(rule_set.arity(), poison.mem.clone())
+                    }
                     AggrKind::Meet => {
                         let rs = match rule_set {
                             CompiledRuleSet::Rules(rs) => rs,
                             _ => unreachable!(),
                         };
-                        EpochStore::new_meet(&rs[0].aggr)?
+                        EpochStore::new_meet(&rs[0].aggr, poison.mem.clone())?
                     }
                     AggrKind::BoundedMeet => {
                         let rs = match rule_set {
                             CompiledRuleSet::Rules(rs) => rs,
                             _ => unreachable!(),
                         };
-                        EpochStore::new_bounded_meet(&rs[0].aggr)?
+                        EpochStore::new_bounded_meet(&rs[0].aggr, poison.mem.clone())?
                     }
                 };
                 stores.insert(rule_name.clone(), store);
@@ -176,7 +198,10 @@ impl<'a> SessionTx<'a> {
             if epoch == 0 {
                 #[allow(clippy::needless_borrow)]
                 let execution = |(k, compiled_ruleset): (_, &CompiledRuleSet)| -> Result<_> {
-                    let new_store = match compiled_ruleset {
+                    // memory budget (mnestic fork): the inner closure lets a
+                    // budget trip pick up rule/epoch context on the way out.
+                    let compute = || -> Result<TempStore> {
+                        Ok(match compiled_ruleset {
                         CompiledRuleSet::Rules(ruleset) => match compiled_ruleset.aggr_kind()? {
                             AggrKind::None => {
                                 let res = self.initial_rule_non_aggr_eval(
@@ -218,16 +243,24 @@ impl<'a> SessionTx<'a> {
                         },
                         CompiledRuleSet::Fixed(fixed) => {
                             let fixed_impl = fixed.fixed_impl.as_ref();
-                            let mut out = RegularTempStore::default();
+                            // memory budget (mnestic fork): the out store holds
+                            // the handle, so a fixed rule's own `put` calls are
+                            // charged; the post-run check catches a trip even
+                            // for implementations that never consult poison.
+                            let mut out = RegularTempStore::with_budget(poison.mem.clone());
                             let payload = FixedRulePayload {
                                 manifest: &fixed,
                                 stores: borrowed_stores,
                                 tx: self,
                             };
                             fixed_impl.run(payload, &mut out, poison.clone())?;
+                            poison.check()?;
                             out.wrap()
                         }
+                        })
                     };
+                    let new_store =
+                        compute().map_err(|e| annotate_mem_budget(e, k, epoch))?;
                     Ok((k, new_store))
                 };
                 #[cfg(not(target_arch = "wasm32"))]
@@ -272,7 +305,9 @@ impl<'a> SessionTx<'a> {
                 // Follow up epoch > 0
                 #[allow(clippy::needless_borrow)]
                 let execution = |(k, compiled_ruleset): (_, &CompiledRuleSet)| -> Result<_> {
-                    let new_store = match compiled_ruleset {
+                    // memory budget (mnestic fork): see the epoch-0 twin.
+                    let compute = || -> Result<TempStore> {
+                        Ok(match compiled_ruleset {
                         CompiledRuleSet::Rules(ruleset) => {
                             match compiled_ruleset.aggr_kind()? {
                                 AggrKind::None => {
@@ -313,7 +348,10 @@ impl<'a> SessionTx<'a> {
                             // no need to do anything, algos are only calculated once
                             RegularTempStore::default().wrap()
                         }
+                        })
                     };
+                    let new_store =
+                        compute().map_err(|e| annotate_mem_budget(e, k, epoch))?;
                     Ok((k, new_store))
                 };
                 #[cfg(not(target_arch = "wasm32"))]
@@ -395,7 +433,7 @@ impl<'a> SessionTx<'a> {
         limiter: &QueryLimiter,
         poison: Poison,
     ) -> Result<(bool, RegularTempStore)> {
-        let mut out_store = RegularTempStore::default();
+        let mut out_store = RegularTempStore::with_budget(poison.mem.clone());
         let should_check_limit = limiter.total.is_some() && rule_symb.is_prog_entry();
 
         for (rule_n, rule) in ruleset.iter().enumerate() {
@@ -434,7 +472,8 @@ impl<'a> SessionTx<'a> {
         stores: &BTreeMap<MagicSymbol, EpochStore>,
         poison: Poison,
     ) -> Result<TempStore> {
-        let mut out_store = TempStore::new_bounded(ruleset[0].aggr.clone())?;
+        let mut out_store =
+            TempStore::new_bounded(ruleset[0].aggr.clone(), poison.mem.clone())?;
         for (rule_n, rule) in ruleset.iter().enumerate() {
             debug!("initial calculation for rule {:?}.{}", rule_symb, rule_n);
             for item_res in rule.relation.iter(self, None, stores, poison.clone())? {
@@ -455,7 +494,8 @@ impl<'a> SessionTx<'a> {
         stores: &BTreeMap<MagicSymbol, EpochStore>,
         poison: Poison,
     ) -> Result<TempStore> {
-        let mut out_store = TempStore::new_bounded(ruleset[0].aggr.clone())?;
+        let mut out_store =
+            TempStore::new_bounded(ruleset[0].aggr.clone(), poison.mem.clone())?;
         for (rule_n, rule) in ruleset.iter().enumerate() {
             let mut need_complete_run = false;
             let mut dependencies_changed = false;
@@ -509,6 +549,7 @@ impl<'a> SessionTx<'a> {
         poison: Poison,
     ) -> Result<MeetAggrStore> {
         let mut out_store = MeetAggrStore::new(ruleset[0].aggr.clone())?;
+        out_store.set_budget(poison.mem.clone());
 
         for (rule_n, rule) in ruleset.iter().enumerate() {
             debug!("initial calculation for rule {:?}.{}", rule_symb, rule_n);
@@ -548,7 +589,7 @@ impl<'a> SessionTx<'a> {
         limiter: &QueryLimiter,
         poison: Poison,
     ) -> Result<(bool, RegularTempStore)> {
-        let mut out_store = RegularTempStore::default();
+        let mut out_store = RegularTempStore::with_budget(poison.mem.clone());
         let should_check_limit = limiter.total.is_some() && rule_symb.is_prog_entry();
         let mut aggr_work: BTreeMap<Vec<DataValue>, Vec<Aggregation>> = BTreeMap::new();
 
@@ -676,7 +717,7 @@ impl<'a> SessionTx<'a> {
         poison: Poison,
     ) -> Result<(bool, RegularTempStore)> {
         let prev_store = stores.get(rule_symb).unwrap();
-        let mut out_store = RegularTempStore::default();
+        let mut out_store = RegularTempStore::with_budget(poison.mem.clone());
         let should_check_limit = limiter.total.is_some() && rule_symb.is_prog_entry();
         for (rule_n, rule) in ruleset.iter().enumerate() {
             let mut need_complete_run = false;
@@ -785,6 +826,7 @@ impl<'a> SessionTx<'a> {
         poison: Poison,
     ) -> Result<MeetAggrStore> {
         let mut out_store = MeetAggrStore::new(ruleset[0].aggr.clone())?;
+        out_store.set_budget(poison.mem.clone());
         for (rule_n, rule) in ruleset.iter().enumerate() {
             let mut need_complete_run = false;
             let mut dependencies_changed = false;

--- a/cozo-core/src/query/sort.rs
+++ b/cozo-core/src/query/sort.rs
@@ -12,9 +12,11 @@ use std::collections::BTreeMap;
 use itertools::Itertools;
 use miette::Result;
 
+use crate::data::memsize::est_tuple_bytes;
 use crate::data::program::SortDir;
 use crate::data::symb::Symbol;
 use crate::data::tuple::Tuple;
+use crate::runtime::db::MemBudget;
 use crate::runtime::temp_store::EpochStore;
 use crate::runtime::transact::SessionTx;
 
@@ -24,6 +26,7 @@ impl<'a> SessionTx<'a> {
         original: EpochStore,
         sorters: &[(Symbol, SortDir)],
         head: &[Symbol],
+        mem: Option<&MemBudget>,
     ) -> Result<Vec<Tuple>> {
         let head_indices: BTreeMap<_, _> = head.iter().enumerate().map(|(i, k)| (k, i)).collect();
         let idx_sorters = sorters
@@ -31,7 +34,28 @@ impl<'a> SessionTx<'a> {
             .map(|(k, dir)| (head_indices[k], *dir))
             .collect_vec();
 
-        let mut all_data: Vec<_> = original.all_iter().map(|v| v.into_tuple()).collect_vec();
+        // memory budget (mnestic fork; spec `docs/specs/memory-budget.md`):
+        // sorting copies the whole store into a Vec — the copy that doubles
+        // peak memory on exactly the largest results — so it is charged, and
+        // this is a fallible context, so it can error directly.
+        let mut all_data: Vec<Tuple>;
+        match mem {
+            Some(m) => {
+                all_data = Vec::new();
+                for (i, v) in original.all_iter().enumerate() {
+                    let t = v.into_tuple();
+                    m.charge(est_tuple_bytes(&t));
+                    if i & 4095 == 0 {
+                        m.error_if_tripped()?;
+                    }
+                    all_data.push(t);
+                }
+                m.error_if_tripped()?;
+            }
+            None => {
+                all_data = original.all_iter().map(|v| v.into_tuple()).collect_vec();
+            }
+        }
         all_data.sort_by(|a, b| {
             for (idx, dir) in &idx_sorters {
                 match a[*idx].cmp(&b[*idx]) {

--- a/cozo-core/src/runtime/db.rs
+++ b/cozo-core/src/runtime/db.rs
@@ -13,7 +13,7 @@ use std::fmt::{Debug, Formatter};
 use std::iter;
 use std::path::Path;
 #[allow(unused_imports)]
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 #[allow(unused_imports)]
 use std::thread;
@@ -34,6 +34,7 @@ use thiserror::Error;
 
 use crate::data::functions::current_validity;
 use crate::data::json::JsonValue;
+use crate::data::memsize::est_tuple_bytes;
 use crate::data::program::{InputProgram, QueryAssertion, RelationOp, ReturnMutation};
 use crate::data::relation::ColumnDef;
 use crate::data::tuple::{Tuple, TupleT};
@@ -109,6 +110,13 @@ pub struct ScriptRunOptions {
     /// budget, never extend past this guard. It is a single whole-script
     /// deadline: a multi-statement script does not get it afresh per statement.
     pub timeout: Option<f64>,
+    /// Per-call memory budget in estimated bytes (mnestic fork; spec
+    /// `docs/specs/memory-budget.md`). `None` (the default) imposes no
+    /// per-call budget. The effective limit for each block is the minimum of
+    /// this, any per-block `:mem_limit`, and the Db default
+    /// ([`Db::set_default_query_mem_limit`]) — a block can only tighten the
+    /// budget, never extend past this guard.
+    pub mem_limit: Option<usize>,
 }
 
 impl ScriptRunOptions {
@@ -120,6 +128,13 @@ impl ScriptRunOptions {
     /// Set the per-call wall-clock budget in seconds (builder style).
     pub fn with_timeout(mut self, secs: f64) -> Self {
         self.timeout = Some(secs);
+        self
+    }
+
+    /// Set the per-call memory budget in estimated bytes (builder style;
+    /// mnestic fork, query memory budget).
+    pub fn with_mem_limit(mut self, bytes: usize) -> Self {
+        self.mem_limit = Some(bytes);
         self
     }
 }
@@ -178,6 +193,12 @@ pub struct Db<S> {
     /// `:timeout`. Anchored at script start, so it bounds the whole
     /// `run_script` call rather than each statement.
     default_query_timeout_ms: Arc<AtomicU64>,
+    /// Db-wide default per-query memory budget in estimated bytes (mnestic
+    /// fork, query memory budget; spec `docs/specs/memory-budget.md`). `0` =
+    /// unset. Set via [`Db::set_default_query_mem_limit`]; folded (via `min`)
+    /// into every block's effective limit alongside any per-call limit and
+    /// per-block `:mem_limit`.
+    default_query_mem_limit: Arc<AtomicU64>,
     /// Kill switch for the automatic factorized-count rewrite (mnestic fork,
     /// query factorization; `query/factorize.rs`). When `true`, an eligible
     /// single-clause `count()`-over-a-positive-join query is rewritten to
@@ -401,6 +422,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             index_builds_in_progress: Default::default(),
             fts_doc_stats_cache: Default::default(),
             default_query_timeout_ms: Default::default(),
+            default_query_mem_limit: Default::default(),
             // DEFAULT for the automatic factorized-count rewrite: ON as of
             // 0.13.1, after the nightly planner-guard soak. Flip this one line
             // to `AtomicBool::new(false)` to make the rewrite opt-in again.
@@ -620,6 +642,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             cur_vld,
             mutability,
             options.timeout,
+            options.mem_limit,
         )
     }
 
@@ -657,7 +680,7 @@ impl<'s, S: Storage<'s>> Db<S> {
         cur_vld: ValidityTs,
         mutability: ScriptMutability,
     ) -> Result<NamedRows> {
-        self.run_script_ast_inner(payload, cur_vld, mutability, None)
+        self.run_script_ast_inner(payload, cur_vld, mutability, None, None)
     }
 
     /// Dispatch a parsed script, computing the whole-script wall-clock deadline
@@ -670,13 +693,17 @@ impl<'s, S: Storage<'s>> Db<S> {
         cur_vld: ValidityTs,
         mutability: ScriptMutability,
         call_timeout: Option<f64>,
+        call_mem_limit: Option<usize>,
     ) -> Result<NamedRows> {
         let read_only = mutability == ScriptMutability::Immutable;
         let outer_deadline = self.effective_outer_deadline(call_timeout);
+        let outer_mem_limit = self.effective_outer_mem_limit(call_mem_limit);
         let res = match payload {
-            CozoScript::Single(p) => self.execute_single(cur_vld, p, read_only, outer_deadline),
+            CozoScript::Single(p) => {
+                self.execute_single(cur_vld, p, read_only, outer_deadline, outer_mem_limit)
+            }
             CozoScript::Imperative(ps) => {
-                self.execute_imperative(cur_vld, &ps, read_only, outer_deadline)
+                self.execute_imperative(cur_vld, &ps, read_only, outer_deadline, outer_mem_limit)
             }
             CozoScript::Sys(op) => self.run_sys_op(op, read_only),
         };
@@ -732,6 +759,24 @@ impl<'s, S: Storage<'s>> Db<S> {
         deadline
     }
 
+    /// The whole-script memory budget from the per-call option and the Db
+    /// default (mnestic fork, query memory budget): the minimum of whichever
+    /// are set, `None` if neither is.
+    fn effective_outer_mem_limit(&self, call_limit: Option<usize>) -> Option<usize> {
+        let default = {
+            let v = self.default_query_mem_limit.load(Ordering::Relaxed);
+            if v == 0 {
+                None
+            } else {
+                Some(v as usize)
+            }
+        };
+        match (call_limit, default) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (a, b) => a.or(b),
+        }
+    }
+
     /// Commit a multi-transaction. Wraps `SessionTx::commit_tx` so the
     /// `test-hooks` failure switch has one place to live (mnestic fork, 0.12.1;
     /// see [`Db::fail_next_commit_for_tests`]). The injected failure returns
@@ -775,6 +820,16 @@ impl<'s, S: Storage<'s>> Db<S> {
         self.default_query_timeout_ms.store(ms, Ordering::Relaxed);
     }
 
+    /// Set (or clear, with `None`/`Some(0)`) the Db-wide default per-query
+    /// memory budget in estimated bytes (mnestic fork, query memory budget;
+    /// spec `docs/specs/memory-budget.md`). Folded via `min` into every
+    /// block's effective limit; a block's `:mem_limit` or a per-call option
+    /// can only tighten it further.
+    pub fn set_default_query_mem_limit(&self, bytes: Option<usize>) {
+        let v = bytes.unwrap_or(0) as u64;
+        self.default_query_mem_limit.store(v, Ordering::Relaxed);
+    }
+
     /// Enable or disable the automatic factorized-count rewrite (mnestic fork,
     /// query factorization; `query/factorize.rs`). The kill switch is a Db-wide
     /// toggle, **default ON since 0.13.1**. When on, an eligible single-clause
@@ -811,6 +866,17 @@ impl<'s, S: Storage<'s>> Db<S> {
             None
         } else {
             Some(ms as f64 / 1000.0)
+        }
+    }
+
+    /// The Db-wide default per-query memory budget in estimated bytes, or
+    /// `None` if unset (mnestic fork, query memory budget).
+    pub fn default_query_mem_limit(&self) -> Option<usize> {
+        let v = self.default_query_mem_limit.load(Ordering::Relaxed);
+        if v == 0 {
+            None
+        } else {
+            Some(v as usize)
         }
     }
 
@@ -1570,6 +1636,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             tt_hwm_dirty: false,
             reconciled_tt_relations: Default::default(),
             script_deadline: None,
+            script_mem_limit: None,
             projections: self.graph_projections.clone(),
             watermark,
             dirty_relations: Default::default(),
@@ -1593,6 +1660,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             tt_hwm_dirty: false,
             reconciled_tt_relations: Default::default(),
             script_deadline: None,
+            script_mem_limit: None,
             projections: self.graph_projections.clone(),
             watermark,
             dirty_relations: Default::default(),
@@ -1628,6 +1696,7 @@ impl<'s, S: Storage<'s>> Db<S> {
         p: InputProgram,
         read_only: bool,
         outer_deadline: Option<Instant>,
+        outer_mem_limit: Option<usize>,
     ) -> Result<NamedRows, Report> {
         let mut callback_collector = BTreeMap::new();
         let write_lock_names = p.needs_write_lock();
@@ -1654,9 +1723,11 @@ impl<'s, S: Storage<'s>> Db<S> {
             } else {
                 self.transact()?
             };
-            // Carry the whole-script wall-clock budget on the tx so run_query
-            // (and any triggers it fires) honour it (mnestic fork, query budget).
+            // Carry the whole-script wall-clock + memory budgets on the tx so
+            // run_query (and any triggers it fires) honour them (mnestic fork,
+            // query budget + memory budget).
             tx.script_deadline = outer_deadline;
+            tx.script_mem_limit = outer_mem_limit;
 
             res = self.execute_single_program(
                 p,
@@ -3057,7 +3128,25 @@ impl<'s, S: Storage<'s>> Db<S> {
             }
             deadline
         };
-        let poison = Poison::with_deadline(effective_deadline);
+        // memory budget (mnestic fork; spec `docs/specs/memory-budget.md`):
+        // the block's effective limit is the minimum of the whole-script limit
+        // carried on the transaction (per-call option + Db default) and this
+        // block's own `:mem_limit` — a block can only tighten the budget.
+        let mem_budget = {
+            let script = tx.script_mem_limit;
+            let block = out_opts.mem_limit;
+            match (script, block) {
+                (None, None) => None,
+                (Some(a), None) => Some(MemBudget::new(a, "the per-call run option or Db default")),
+                (None, Some(b)) => Some(MemBudget::new(b, "the block's `:mem_limit` option")),
+                (Some(a), Some(b)) => Some(if b < a {
+                    MemBudget::new(b, "the block's `:mem_limit` option")
+                } else {
+                    MemBudget::new(a, "the per-call run option or Db default")
+                }),
+            }
+        };
+        let poison = Poison::with_limits(effective_deadline, mem_budget.clone());
         // give the query an ID and store it so that it can be queried and cancelled
         let id = self.queries_count.fetch_add(1, Ordering::AcqRel);
 
@@ -3126,7 +3215,12 @@ impl<'s, S: Storage<'s>> Db<S> {
         if !out_opts.sorters.is_empty() {
             // sort outputs if required
             let sorted_result =
-                tx.sort_and_collect(result_store, &out_opts.sorters, &entry_head_or_default)?;
+                tx.sort_and_collect(
+                result_store,
+                &out_opts.sorters,
+                &entry_head_or_default,
+                mem_budget.as_ref(),
+            )?;
             let sorted_iter = if let Some(offset) = out_opts.offset {
                 Left(sorted_result.into_iter().skip(offset))
             } else {
@@ -3218,7 +3312,23 @@ impl<'s, S: Storage<'s>> Db<S> {
 
                 Ok((returned_rows, clean_ups))
             } else {
-                let rows: Vec<Tuple> = scan.collect_vec();
+                // memory budget (mnestic fork): the final result Vec is a
+                // second copy of the store's rows — charged, fallible here.
+                let rows: Vec<Tuple> = match &mem_budget {
+                    Some(m) => {
+                        let mut rows = Vec::new();
+                        for (i, t) in scan.enumerate() {
+                            m.charge(est_tuple_bytes(&t));
+                            if i & 4095 == 0 {
+                                m.error_if_tripped()?;
+                            }
+                            rows.push(t);
+                        }
+                        m.error_if_tripped()?;
+                        rows
+                    }
+                    None => scan.collect_vec(),
+                };
 
                 Ok((
                     NamedRows::new(
@@ -3484,10 +3594,126 @@ fn _get_variables(src: &str, params: &BTreeMap<String, DataValue>) -> Result<BTr
 /// into fixed rules and the RA enumeration pipeline. The carried deadline
 /// replaces the old detached timer thread: no per-query thread leak, and
 /// `:timeout` no longer depends on spawning a thread.
+/// The query memory budget's trip diagnostic (mnestic fork; spec
+/// `docs/specs/memory-budget.md`). Figures are logical estimates of
+/// engine-held bytes, not process RSS. Retriable: the aborted query holds
+/// nothing after the abort, and the Db and concurrent queries are unaffected.
+#[derive(Debug, Error, Diagnostic)]
+#[error(
+    "Query exceeded its memory budget: estimated {used} bytes held (attempted charge \
+     of {attempted} more) against a limit of {limit} bytes set by {knob}{at}"
+)]
+#[diagnostic(code(eval::mem_budget_exceeded))]
+#[diagnostic(help(
+    "The budget is the minimum of the per-block `:mem_limit` option, the per-call \
+     run option, and the Db default (`set_default_query_mem_limit`) — a block can \
+     only tighten it. Raise the governing knob, or narrow the query (check \
+     `::explain` for full scans and unfactorized counts). The figures are \
+     estimates of engine-held bytes, not process RSS."
+))]
+pub(crate) struct MemBudgetExceeded {
+    pub(crate) used: usize,
+    pub(crate) attempted: usize,
+    pub(crate) limit: usize,
+    pub(crate) knob: &'static str,
+    /// Rule/epoch context, filled in by the evaluator when the trip surfaces
+    /// inside a rule's evaluation (empty otherwise). A field rather than a
+    /// `wrap_err` so the diagnostic code survives `format_error_as_json`.
+    pub(crate) at: String,
+}
+
+/// Shared per-block estimated-bytes accounting for the query memory budget
+/// (mnestic fork; spec `docs/specs/memory-budget.md`). Cheap to clone — one
+/// `Arc`. Charging is infallible (the temp stores' write methods stay
+/// non-`Result`); crossing the limit arms `tripped`, and every shipped check
+/// cadence — the poisoned RA iterators, the per-rule `poison.check()`s —
+/// converts it into the `eval::mem_budget_exceeded` error. The debit path
+/// never trips and never underflows ("free should never throw").
+#[derive(Debug, Clone)]
+pub(crate) struct MemBudget {
+    inner: Arc<MemBudgetInner>,
+}
+
+#[derive(Debug)]
+struct MemBudgetInner {
+    /// Live estimated bytes charged by this block's stores + staging.
+    counter: AtomicUsize,
+    /// Effective limit in bytes (min-composed from the knob triple).
+    limit: usize,
+    /// Which knob produced the effective limit, for the error message.
+    knob: &'static str,
+    tripped: AtomicBool,
+    trip_used: AtomicUsize,
+    trip_attempted: AtomicUsize,
+}
+
+impl MemBudget {
+    pub(crate) fn new(limit: usize, knob: &'static str) -> Self {
+        Self {
+            inner: Arc::new(MemBudgetInner {
+                counter: AtomicUsize::new(0),
+                limit,
+                knob,
+                tripped: AtomicBool::new(false),
+                trip_used: AtomicUsize::new(0),
+                trip_attempted: AtomicUsize::new(0),
+            }),
+        }
+    }
+    /// Infallible charge: add estimated bytes; arm the trip if over limit.
+    #[inline]
+    pub(crate) fn charge(&self, n: usize) {
+        let old = self.inner.counter.fetch_add(n, Ordering::Relaxed);
+        if old.saturating_add(n) > self.inner.limit && !self.inner.tripped.swap(true, Ordering::Relaxed)
+        {
+            self.inner.trip_used.store(old, Ordering::Relaxed);
+            self.inner.trip_attempted.store(n, Ordering::Relaxed);
+        }
+    }
+    /// Infallible debit; never underflows, never trips, never un-trips.
+    #[inline]
+    pub(crate) fn debit(&self, n: usize) {
+        // saturating at zero via fetch_update would cost a CAS loop; a plain
+        // sub is safe because every debit releases a prior charge of the same
+        // estimate (the stores' `charged` fields enforce the pairing).
+        self.inner.counter.fetch_sub(n, Ordering::Relaxed);
+    }
+    /// Fallible charge for staging contexts (sort/result collection), which
+    /// can error directly instead of waiting for a check cadence.
+    #[inline]
+    pub(crate) fn charge_checked(&self, n: usize) -> Result<()> {
+        self.charge(n);
+        self.error_if_tripped()
+    }
+    /// The check-cadence half: raise the trip as its diagnostic.
+    #[inline]
+    pub(crate) fn error_if_tripped(&self) -> Result<()> {
+        if self.inner.tripped.load(Ordering::Relaxed) {
+            bail!(MemBudgetExceeded {
+                used: self.inner.trip_used.load(Ordering::Relaxed),
+                attempted: self.inner.trip_attempted.load(Ordering::Relaxed),
+                limit: self.inner.limit,
+                knob: self.inner.knob,
+                at: String::new(),
+            });
+        }
+        Ok(())
+    }
+    /// Current live estimated bytes (observability; consumed by tests today
+    /// and by the planned `::running` bytes column later).
+    #[allow(dead_code)]
+    pub(crate) fn used(&self) -> usize {
+        self.inner.counter.load(Ordering::Relaxed)
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct Poison {
     pub(crate) flag: Arc<AtomicBool>,
     pub(crate) deadline: Option<Instant>,
+    /// Query memory budget (mnestic fork); `None` = unlimited. Rides the
+    /// poison so every shipped check cadence also checks the budget trip.
+    pub(crate) mem: Option<MemBudget>,
 }
 
 /// A monotonic clock reading for a wall-clock query budget, or `None` where no
@@ -3581,6 +3807,12 @@ impl Poison {
             bail!(ProcessKilled)
         }
 
+        // memory budget (mnestic fork): a charge that crossed the limit
+        // armed the trip; every check cadence surfaces it as its own error.
+        if let Some(mem) = &self.mem {
+            mem.error_if_tripped()?;
+        }
+
         if let Some(deadline) = self.deadline {
             if Instant::now() >= deadline {
                 #[derive(Debug, Error, Diagnostic)]
@@ -3611,6 +3843,17 @@ impl Poison {
         Poison {
             flag: Arc::new(AtomicBool::new(false)),
             deadline,
+            mem: None,
+        }
+    }
+    /// Construct a poison carrying an optional wall-clock deadline AND an
+    /// optional memory budget (mnestic fork; spec
+    /// `docs/specs/memory-budget.md`).
+    pub(crate) fn with_limits(deadline: Option<Instant>, mem: Option<MemBudget>) -> Self {
+        Poison {
+            flag: Arc::new(AtomicBool::new(false)),
+            deadline,
+            mem,
         }
     }
 }

--- a/cozo-core/src/runtime/graph_projection.rs
+++ b/cozo-core/src/runtime/graph_projection.rs
@@ -117,7 +117,7 @@ use thiserror::Error;
 #[cfg(feature = "graph-algo")]
 use crate::data::tuple::TupleIter;
 #[cfg(feature = "graph-algo")]
-use crate::data::value::{DataValue, Vector};
+use crate::data::value::{DataValue};
 #[cfg(feature = "graph-algo")]
 use crate::fixed_rule::{build_unweighted_csr, build_weighted_csr};
 #[cfg(feature = "graph-algo")]
@@ -441,17 +441,11 @@ impl ProjectionCache {
 #[cfg(feature = "graph-algo")]
 pub(crate) const DEFAULT_PROJECTION_CAPACITY: usize = 512 * 1024 * 1024;
 
-/// Charged per `BTreeMap`/`BTreeSet` entry when estimating an id map's size.
-/// B-trees allocate in nodes, not per entry; this is the amortised share.
+// The per-entry/opaque-key estimators moved to `data/memsize.rs` (mnestic
+// fork, query memory budget) so every build has them; this module imports
+// them below.
 #[cfg(feature = "graph-algo")]
-const BTREE_ENTRY_OVERHEAD: usize = 48;
-
-/// Flat charge for the part of a vertex key we cannot see into: a compiled
-/// regex's program. Its pattern text is counted exactly; the compiled
-/// automaton is opaque, and the ceiling only needs the right order of
-/// magnitude for a key type this pathological.
-#[cfg(feature = "graph-algo")]
-const OPAQUE_KEY_ESTIMATE: usize = 64;
+use crate::data::memsize::{value_heap_bytes, BTREE_ENTRY_OVERHEAD};
 
 /// Which concrete CSR a projection has materialised. A projection names its
 /// sources; the variants are built lazily, one per `(direction, weighted)`
@@ -1320,56 +1314,6 @@ fn estimate_bytes(
         .saturating_add(idx)
         .saturating_add(inv)
         .min(usize::MAX as u64) as usize
-}
-
-/// Heap bytes owned by a vertex value, beyond its inline `DataValue`.
-#[cfg(feature = "graph-algo")]
-fn value_heap_bytes(v: &DataValue) -> usize {
-    match v {
-        DataValue::Str(s) => {
-            if s.is_inline() {
-                0
-            } else {
-                s.len()
-            }
-        }
-        DataValue::Bytes(b) => b.len(),
-        DataValue::List(l) => {
-            l.len() * std::mem::size_of::<DataValue>()
-                + l.iter().map(value_heap_bytes).sum::<usize>()
-        }
-        DataValue::Set(s) => s
-            .iter()
-            .map(|v| std::mem::size_of::<DataValue>() + BTREE_ENTRY_OVERHEAD + value_heap_bytes(v))
-            .sum(),
-        DataValue::Vec(Vector::F32(a)) => a.len() * 4,
-        DataValue::Vec(Vector::F64(a)) => a.len() * 8,
-        // Json must be walked, not flat-charged: it is a storable key type, a
-        // single blob vertex can be megabytes, and the build interns every
-        // vertex as two owned deep clones. A flat 64-byte charge let the real
-        // footprint exceed the ceiling without bound while `::graph list`
-        // reported a near-empty cache (Phase 3/4 review, 2026-07-10).
-        DataValue::Json(j) => json_heap_bytes(&j.0),
-        DataValue::Regex(r) => r.0.as_str().len() + OPAQUE_KEY_ESTIMATE,
-        _ => 0,
-    }
-}
-
-/// Heap bytes owned by a JSON value, beyond one inline `serde_json::Value`.
-#[cfg(feature = "graph-algo")]
-fn json_heap_bytes(v: &serde_json::Value) -> usize {
-    let node = std::mem::size_of::<serde_json::Value>();
-    match v {
-        serde_json::Value::String(s) => s.len(),
-        serde_json::Value::Array(a) => {
-            a.len() * node + a.iter().map(json_heap_bytes).sum::<usize>()
-        }
-        serde_json::Value::Object(m) => m
-            .iter()
-            .map(|(k, x)| k.len() + node + BTREE_ENTRY_OVERHEAD + json_heap_bytes(x))
-            .sum(),
-        _ => 0,
-    }
 }
 
 /// `::graph create G {edges: …, nodes: …}`. Validates loudly and immediately;

--- a/cozo-core/src/runtime/imperative.rs
+++ b/cozo-core/src/runtime/imperative.rs
@@ -259,6 +259,7 @@ impl<'s, S: Storage<'s>> Db<S> {
         ps: &ImperativeProgram,
         readonly: bool,
         outer_deadline: Option<Instant>,
+        outer_mem_limit: Option<usize>,
     ) -> Result<NamedRows, Report> {
         let mut callback_collector = BTreeMap::new();
         let mut write_lock_names = BTreeSet::new();
@@ -289,6 +290,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             // program (one tx), so carry it on the tx and arm the shared poison
             // with the same deadline (mnestic fork, query budget).
             tx.script_deadline = outer_deadline;
+            tx.script_mem_limit = outer_mem_limit;
 
             let poison = Poison::with_deadline(outer_deadline);
             let qid = self.queries_count.fetch_add(1, Ordering::AcqRel);

--- a/cozo-core/src/runtime/temp_store.rs
+++ b/cozo-core/src/runtime/temp_store.rs
@@ -18,14 +18,34 @@ use itertools::Itertools;
 use miette::{bail, ensure, Result};
 
 use crate::data::aggr::Aggregation;
+use crate::data::memsize::{est_tuple_bytes, BTREE_ENTRY_OVERHEAD};
 use crate::data::tuple::Tuple;
 use crate::data::value::DataValue;
+use crate::runtime::db::MemBudget;
 
 /// A store holding temp data during evaluation of queries.
 /// The public interface is used in custom implementations of algorithms/utilities.
 #[derive(Default, Debug)]
 pub struct RegularTempStore {
     inner: BTreeMap<Tuple, bool>,
+    /// Query memory budget handle (mnestic fork; spec
+    /// `docs/specs/memory-budget.md`). `None` = accounting disabled: every
+    /// charge site is then a single `Option` check. The stores hold the
+    /// handle (rather than threading it through the write methods) so
+    /// `pub fn put`'s signature is unchanged for FixedRule implementations
+    /// and their output writes are charged for free.
+    budget: Option<MemBudget>,
+    /// This store's own live charged bytes; debited wholesale on drop so a
+    /// tripped/aborted query releases exactly what it charged.
+    charged: usize,
+}
+
+impl Drop for RegularTempStore {
+    fn drop(&mut self) {
+        if let Some(b) = &self.budget {
+            b.debit(self.charged);
+        }
+    }
 }
 
 const EMPTY_TUPLE_REF: &Tuple = &vec![];
@@ -55,35 +75,104 @@ impl RegularTempStore {
             .range((lower_bound, upper_bound))
             .map(|(t, skip)| TupleInIter(t, EMPTY_TUPLE_REF, *skip))
     }
+    /// Construct with the query memory-budget handle attached (mnestic fork).
+    pub(crate) fn with_budget(budget: Option<MemBudget>) -> Self {
+        Self {
+            inner: Default::default(),
+            budget,
+            charged: 0,
+        }
+    }
+    pub(crate) fn set_budget(&mut self, budget: Option<MemBudget>) {
+        debug_assert_eq!(self.charged, 0, "budget attached to a non-empty store");
+        self.budget = budget;
+    }
+    #[inline]
+    fn charge(&mut self, n: usize) {
+        self.charged += n;
+        if let Some(b) = &self.budget {
+            b.charge(n);
+        }
+    }
+    #[inline]
+    fn debit(&mut self, n: usize) {
+        self.charged = self.charged.saturating_sub(n);
+        if let Some(b) = &self.budget {
+            b.debit(n);
+        }
+    }
+    #[inline]
+    fn reset_charges(&mut self) {
+        let n = self.charged;
+        self.charged = 0;
+        if let Some(b) = &self.budget {
+            b.debit(n);
+        }
+    }
     /// Add a tuple to the store
     pub fn put(&mut self, tuple: Tuple) {
-        self.inner.insert(tuple, false);
+        self.insert_impl(tuple, false);
     }
     pub(crate) fn put_with_skip(&mut self, tuple: Tuple) {
-        self.inner.insert(tuple, true);
+        self.insert_impl(tuple, true);
+    }
+    #[inline]
+    fn insert_impl(&mut self, tuple: Tuple, skip: bool) {
+        // Charge only an insertion that actually inserts: a duplicate-key
+        // insert keeps the old key and drops the incoming tuple — net ~zero.
+        if self.budget.is_some() {
+            let n = est_tuple_bytes(&tuple) + BTREE_ENTRY_OVERHEAD;
+            if self.inner.insert(tuple, skip).is_none() {
+                self.charge(n);
+            }
+        } else {
+            self.inner.insert(tuple, skip);
+        }
     }
     // returns true if prev is guaranteed to be the same as self after this function call,
     // false if we are not sure.
     pub(crate) fn merge_in(&mut self, prev: &mut Self, mut new: Self) -> bool {
+        prev.reset_charges();
         prev.inner.clear();
         if new.inner.is_empty() {
             return false;
         }
         if self.inner.is_empty() {
+            // A whole-struct swap: contents AND accounting travel together,
+            // so this arm is accounting-neutral (a move, not a copy).
             mem::swap(&mut new, self);
             return true;
         }
-        for (k, v) in new.inner {
+        // Transfer new's charges locally (the global counter already holds
+        // them); entries below either move into self or are debited.
+        self.charged += mem::take(&mut new.charged);
+        let moved = mem::take(&mut new.inner);
+        let active = self.budget.is_some();
+        let mut dropped = 0usize;
+        for (k, v) in moved {
+            let n = if active {
+                est_tuple_bytes(&k) + BTREE_ENTRY_OVERHEAD
+            } else {
+                0
+            };
             match self.inner.entry(k) {
                 Entry::Vacant(ent) => {
+                    // The moved entry stays charged in self; prev gains a
+                    // genuine key clone.
+                    if active {
+                        prev.charge(n);
+                    }
                     prev.inner.insert(ent.key().clone(), v);
                     ent.insert(v);
                 }
                 Entry::Occupied(mut ent) => {
+                    // The incoming duplicate key drops here.
+                    dropped += n;
                     ent.insert(v);
                 }
             }
         }
+        self.debit(dropped);
         false
     }
 }
@@ -93,6 +182,17 @@ pub(crate) struct MeetAggrStore {
     inner: BTreeMap<Tuple, Tuple>,
     aggregations: Vec<(Aggregation, Vec<DataValue>)>,
     grouping_len: usize,
+    /// Query memory budget (mnestic fork) — see `RegularTempStore::budget`.
+    budget: Option<MemBudget>,
+    charged: usize,
+}
+
+impl Drop for MeetAggrStore {
+    fn drop(&mut self) {
+        if let Some(b) = &self.budget {
+            b.debit(self.charged);
+        }
+    }
 }
 
 impl MeetAggrStore {
@@ -117,7 +217,35 @@ impl MeetAggrStore {
             inner: Default::default(),
             aggregations,
             grouping_len,
+            budget: None,
+            charged: 0,
         })
+    }
+    pub(crate) fn set_budget(&mut self, budget: Option<MemBudget>) {
+        debug_assert_eq!(self.charged, 0, "budget attached to a non-empty store");
+        self.budget = budget;
+    }
+    #[inline]
+    fn charge(&mut self, n: usize) {
+        self.charged += n;
+        if let Some(b) = &self.budget {
+            b.charge(n);
+        }
+    }
+    #[inline]
+    fn debit(&mut self, n: usize) {
+        self.charged = self.charged.saturating_sub(n);
+        if let Some(b) = &self.budget {
+            b.debit(n);
+        }
+    }
+    #[inline]
+    fn reset_charges(&mut self) {
+        let n = self.charged;
+        self.charged = 0;
+        if let Some(b) = &self.budget {
+            b.debit(n);
+        }
     }
     // also need to check if value exists beforehand! use the idempotency!
     // need to think this through more carefully.
@@ -138,6 +266,12 @@ impl MeetAggrStore {
                 Ok(changed)
             }
             None => {
+                if self.budget.is_some() {
+                    let n = est_tuple_bytes(key_part)
+                        + est_tuple_bytes(val_part)
+                        + BTREE_ENTRY_OVERHEAD;
+                    self.charge(n);
+                }
                 self.inner.insert(key_part.to_vec(), val_part.to_vec());
                 Ok(true)
             }
@@ -185,17 +319,33 @@ impl MeetAggrStore {
     /// returns true if prev is guaranteed to be the same as self after this function call,
     /// false if we are not sure.
     pub(crate) fn merge_in(&mut self, prev: &mut Self, mut new: Self) -> Result<bool> {
+        prev.reset_charges();
         prev.inner.clear();
         if new.inner.is_empty() {
             return Ok(false);
         }
         if self.inner.is_empty() {
+            // Whole-struct swap: contents and accounting travel together.
             mem::swap(self, &mut new);
             return Ok(true);
         }
-        for (k, v) in new.inner {
+        self.charged += mem::take(&mut new.charged);
+        let moved = mem::take(&mut new.inner);
+        let active = self.budget.is_some();
+        let mut dropped = 0usize;
+        for (k, v) in moved {
+            let n = if active {
+                est_tuple_bytes(&k) + est_tuple_bytes(&v) + BTREE_ENTRY_OVERHEAD
+            } else {
+                0
+            };
             match self.inner.entry(k) {
                 Entry::Vacant(ent) => {
+                    // prev gains genuine key+value clones; the moved entry
+                    // stays charged in self.
+                    if active {
+                        prev.charge(n);
+                    }
                     prev.inner.insert(ent.key().clone(), v.clone());
                     ent.insert(v);
                 }
@@ -213,12 +363,21 @@ impl MeetAggrStore {
                             changed |= this_changed;
                         }
                     }
+                    // The incoming duplicate entry drops here.
+                    dropped += n;
                     if changed {
+                        if active {
+                            let pn = est_tuple_bytes(ent.key())
+                                + est_tuple_bytes(ent.get())
+                                + BTREE_ENTRY_OVERHEAD;
+                            prev.charge(pn);
+                        }
                         prev.inner.insert(ent.key().clone(), ent.get().clone());
                     }
                 }
             }
         }
+        self.debit(dropped);
         Ok(false)
     }
 }
@@ -245,6 +404,17 @@ pub(crate) struct BoundedMeetStore {
     /// unbounded twin is belt-and-braces for the delta contract, not a
     /// load-bearing path.)
     unbounded: bool,
+    /// Query memory budget (mnestic fork) — see `RegularTempStore::budget`.
+    budget: Option<MemBudget>,
+    charged: usize,
+}
+
+impl Drop for BoundedMeetStore {
+    fn drop(&mut self) {
+        if let Some(b) = &self.budget {
+            b.debit(self.charged);
+        }
+    }
 }
 
 impl std::fmt::Debug for BoundedMeetStore {
@@ -274,6 +444,8 @@ impl BoundedMeetStore {
             k,
             grouping_len: total_key_len - 1,
             unbounded: false,
+            budget: None,
+            charged: 0,
         })
     }
     /// An empty twin for the delta slot: same contract, no truncation.
@@ -284,6 +456,34 @@ impl BoundedMeetStore {
             k: self.k,
             grouping_len: self.grouping_len,
             unbounded: true,
+            budget: self.budget.clone(),
+            charged: 0,
+        }
+    }
+    pub(crate) fn set_budget(&mut self, budget: Option<MemBudget>) {
+        debug_assert_eq!(self.charged, 0, "budget attached to a non-empty store");
+        self.budget = budget;
+    }
+    #[inline]
+    fn charge(&mut self, n: usize) {
+        self.charged += n;
+        if let Some(b) = &self.budget {
+            b.charge(n);
+        }
+    }
+    #[inline]
+    fn debit(&mut self, n: usize) {
+        self.charged = self.charged.saturating_sub(n);
+        if let Some(b) = &self.budget {
+            b.debit(n);
+        }
+    }
+    #[inline]
+    fn reset_charges(&mut self) {
+        let n = self.charged;
+        self.charged = 0;
+        if let Some(b) = &self.budget {
+            b.debit(n);
         }
     }
     pub(crate) fn exists(&self, key: &Tuple) -> bool {
@@ -300,22 +500,48 @@ impl BoundedMeetStore {
         self.op.validate(&val_part[0])?;
         let op = self.op.clone();
         let (k, unbounded) = (self.k, self.unbounded);
-        let entry = self.inner.entry(key_part.to_vec()).or_default();
-        match entry.binary_search_by(|held| op.cmp_candidates(&held[0], &val_part[0])) {
-            // Equal under the aggregate's order = duplicate under its ○=
-            Ok(_) => Ok(false),
-            Err(pos) => {
-                if !unbounded && pos >= k {
-                    // worse than the group's k-th best: not a change
-                    return Ok(false);
+        let active = self.budget.is_some();
+        // memory budget (mnestic fork): a brand-new group charges its key
+        // tuple + group-Vec header + entry overhead alongside the candidate.
+        let new_group = active && !self.inner.contains_key(key_part);
+        let mut delta_charge = 0usize;
+        let mut delta_debit = 0usize;
+        let changed = {
+            let entry = self.inner.entry(key_part.to_vec()).or_default();
+            match entry.binary_search_by(|held| op.cmp_candidates(&held[0], &val_part[0])) {
+                // Equal under the aggregate's order = duplicate under its ○=
+                Ok(_) => false,
+                Err(pos) => {
+                    if !unbounded && pos >= k {
+                        // worse than the group's k-th best: not a change
+                        false
+                    } else {
+                        if active {
+                            delta_charge += est_tuple_bytes(val_part);
+                        }
+                        entry.insert(pos, val_part.to_vec());
+                        if !unbounded && entry.len() > k {
+                            if active {
+                                if let Some(worst) = entry.last() {
+                                    // the displaced worst candidate drops
+                                    delta_debit += est_tuple_bytes(worst);
+                                }
+                            }
+                            entry.pop();
+                        }
+                        true
+                    }
                 }
-                entry.insert(pos, val_part.to_vec());
-                if !unbounded && entry.len() > k {
-                    entry.pop();
-                }
-                Ok(true)
             }
+        };
+        if changed && new_group {
+            delta_charge += est_tuple_bytes(key_part)
+                + std::mem::size_of::<Vec<Tuple>>()
+                + BTREE_ENTRY_OVERHEAD;
         }
+        self.charge(delta_charge);
+        self.debit(delta_debit);
+        Ok(changed)
     }
     fn range_iter(
         &self,
@@ -353,6 +579,7 @@ impl BoundedMeetStore {
     /// function call, false if we are not sure. `prev` collects the
     /// candidates that CHANGED a k-set — the delta for the next epoch.
     pub(crate) fn merge_in(&mut self, prev: &mut Self, mut new: Self) -> Result<bool> {
+        prev.reset_charges();
         prev.inner.clear();
         prev.unbounded = true;
         if new.inner.is_empty() {
@@ -360,9 +587,18 @@ impl BoundedMeetStore {
         }
         if self.inner.is_empty() {
             mem::swap(&mut self.inner, &mut new.inner);
+            // inner swapped without the accounting fields: carry them along.
+            mem::swap(&mut self.charged, &mut new.charged);
             return Ok(true);
         }
-        for (k, vs) in new.inner {
+        // The rows below are re-materialized through meet_put, which charges
+        // precisely; release new's own charges first (its entries all drop).
+        let moved = mem::take(&mut new.inner);
+        let released = mem::take(&mut new.charged);
+        if let Some(b) = &self.budget {
+            b.debit(released);
+        }
+        for (k, vs) in moved {
             for v in vs {
                 let mut row = k.clone();
                 row.extend(v.iter().cloned());
@@ -413,6 +649,17 @@ pub(crate) struct DominanceMeetStore {
     /// API is unchanged. `dominates` returns `bool` and cannot report a
     /// malformed operand; this does, loudly.
     validate: Option<fn(&DataValue) -> Result<()>>,
+    /// Query memory budget (mnestic fork) — see `RegularTempStore::budget`.
+    budget: Option<MemBudget>,
+    charged: usize,
+}
+
+impl Drop for DominanceMeetStore {
+    fn drop(&mut self) {
+        if let Some(b) = &self.budget {
+            b.debit(self.charged);
+        }
+    }
 }
 
 impl std::fmt::Debug for DominanceMeetStore {
@@ -450,6 +697,8 @@ impl DominanceMeetStore {
             grouping_len: total_key_len - 1,
             dedup_only: false,
             validate: crate::data::aggr::builtin_skyline_validator(aggr.name),
+            budget: None,
+            charged: 0,
         })
     }
     /// An empty twin for the delta slot: equality-dedup only.
@@ -461,6 +710,34 @@ impl DominanceMeetStore {
             grouping_len: self.grouping_len,
             dedup_only: true,
             validate: self.validate,
+            budget: self.budget.clone(),
+            charged: 0,
+        }
+    }
+    pub(crate) fn set_budget(&mut self, budget: Option<MemBudget>) {
+        debug_assert_eq!(self.charged, 0, "budget attached to a non-empty store");
+        self.budget = budget;
+    }
+    #[inline]
+    fn charge(&mut self, n: usize) {
+        self.charged += n;
+        if let Some(b) = &self.budget {
+            b.charge(n);
+        }
+    }
+    #[inline]
+    fn debit(&mut self, n: usize) {
+        self.charged = self.charged.saturating_sub(n);
+        if let Some(b) = &self.budget {
+            b.debit(n);
+        }
+    }
+    #[inline]
+    fn reset_charges(&mut self) {
+        let n = self.charged;
+        self.charged = 0;
+        if let Some(b) = &self.budget {
+            b.debit(n);
         }
     }
     pub(crate) fn exists(&self, key: &Tuple) -> bool {
@@ -484,51 +761,93 @@ impl DominanceMeetStore {
         if let Some(validate) = self.validate {
             validate(c)?;
         }
+        // memory budget (mnestic fork): charge/debit deltas accumulate in
+        // locals while `entry` borrows the map, and apply after — including
+        // before the max_survivors bail, so the accounting stays consistent
+        // on the error path (the drop debit releases exactly what was
+        // charged).
+        let active = self.budget.is_some();
+        let new_group = active && !self.inner.contains_key(key_part);
+        let mut delta_charge = 0usize;
+        let mut delta_debit = 0usize;
+        let mut overflow = false;
         let entry = self.inner.entry(key_part.to_vec()).or_default();
         // memcmp-order binary search: structural-equality dedup + insertion pos
         let pos = match entry.binary_search_by(|held| held[0].cmp(c)) {
             Ok(_) => return Ok(false),
             Err(pos) => pos,
         };
-        if self.dedup_only {
-            entry.insert(pos, val_part.to_vec());
-            return Ok(true);
-        }
-        let dom = &self.reg.dominates;
-        #[cfg(debug_assertions)]
-        if dom(c, c) {
-            bail!(
-                "dominance for bounded-meet aggregate '{}' violates irreflexivity: dominates(x, x) is true",
-                self.aggr_name
-            );
-        }
-        for held in entry.iter() {
-            if dom(&held[0], c) {
-                #[cfg(debug_assertions)]
-                if dom(c, &held[0]) {
-                    bail!(
-                        "dominance for bounded-meet aggregate '{}' violates asymmetry: dominates(a, b) and dominates(b, a) both hold",
-                        self.aggr_name
-                    );
-                }
-                // a survivor dominates the newcomer: by transitivity the
-                // newcomer cannot dominate any survivor — reject, unchanged
-                return Ok(false);
+        let changed = if self.dedup_only {
+            if active {
+                delta_charge += est_tuple_bytes(val_part);
             }
+            entry.insert(pos, val_part.to_vec());
+            true
+        } else {
+            let dom = &self.reg.dominates;
+            #[cfg(debug_assertions)]
+            if dom(c, c) {
+                bail!(
+                    "dominance for bounded-meet aggregate '{}' violates irreflexivity: dominates(x, x) is true",
+                    self.aggr_name
+                );
+            }
+            let mut rejected = false;
+            for held in entry.iter() {
+                if dom(&held[0], c) {
+                    #[cfg(debug_assertions)]
+                    if dom(c, &held[0]) {
+                        bail!(
+                            "dominance for bounded-meet aggregate '{}' violates asymmetry: dominates(a, b) and dominates(b, a) both hold",
+                            self.aggr_name
+                        );
+                    }
+                    // a survivor dominates the newcomer: by transitivity the
+                    // newcomer cannot dominate any survivor — reject, unchanged
+                    rejected = true;
+                    break;
+                }
+            }
+            if rejected {
+                false
+            } else {
+                if active {
+                    for held in entry.iter() {
+                        if dom(c, &held[0]) {
+                            // this survivor is about to be evicted
+                            delta_debit += est_tuple_bytes(held);
+                        }
+                    }
+                }
+                entry.retain(|held| !dom(c, &held[0]));
+                let pos = entry
+                    .binary_search_by(|held| held[0].cmp(c))
+                    .expect_err("deduped candidate reappeared after retain");
+                if active {
+                    delta_charge += est_tuple_bytes(val_part);
+                }
+                entry.insert(pos, val_part.to_vec());
+                if entry.len() > self.reg.max_survivors {
+                    overflow = true;
+                }
+                true
+            }
+        };
+        if changed && new_group {
+            delta_charge += est_tuple_bytes(key_part)
+                + std::mem::size_of::<Vec<Tuple>>()
+                + BTREE_ENTRY_OVERHEAD;
         }
-        entry.retain(|held| !dom(c, &held[0]));
-        let pos = entry
-            .binary_search_by(|held| held[0].cmp(c))
-            .expect_err("deduped candidate reappeared after retain");
-        entry.insert(pos, val_part.to_vec());
-        if entry.len() > self.reg.max_survivors {
+        self.charge(delta_charge);
+        self.debit(delta_debit);
+        if overflow {
             bail!(
                 "bounded-meet aggregate '{}' exceeded max_survivors = {}: the group's non-dominated set does not fit the registered resource guard (raise it, strengthen the dominance, or aggregate a coarser candidate)",
                 self.aggr_name,
                 self.reg.max_survivors
             );
         }
-        Ok(true)
+        Ok(changed)
     }
     fn range_iter(
         &self,
@@ -566,6 +885,7 @@ impl DominanceMeetStore {
     /// function call, false if we are not sure. `prev` collects the
     /// candidates that CHANGED a survivor set — the delta for the next epoch.
     pub(crate) fn merge_in(&mut self, prev: &mut Self, mut new: Self) -> Result<bool> {
+        prev.reset_charges();
         prev.inner.clear();
         prev.dedup_only = true;
         if new.inner.is_empty() {
@@ -573,9 +893,18 @@ impl DominanceMeetStore {
         }
         if self.inner.is_empty() && new.dedup_only == self.dedup_only {
             mem::swap(&mut self.inner, &mut new.inner);
+            // inner swapped without the accounting fields: carry them along.
+            mem::swap(&mut self.charged, &mut new.charged);
             return Ok(true);
         }
-        for (k, vs) in new.inner {
+        // Rows re-materialize through meet_put (which charges precisely);
+        // release new's own charges first — its entries all drop below.
+        let moved = mem::take(&mut new.inner);
+        let released = mem::take(&mut new.charged);
+        if let Some(b) = &self.budget {
+            b.debit(released);
+        }
+        for (k, vs) in moved {
             for v in vs {
                 let mut row = k.clone();
                 row.extend(v.iter().cloned());
@@ -602,15 +931,22 @@ impl TempStore {
     /// Build the epoch-output store for a bounded-meet rule: a
     /// `DominanceMeetStore` for a registered dominance aggregate, else the
     /// builtin `BoundedMeetStore` (mnestic fork, antichain-bounded-meet spec).
-    pub(crate) fn new_bounded(aggrs: Vec<Option<(Aggregation, Vec<DataValue>)>>) -> Result<Self> {
+    pub(crate) fn new_bounded(
+        aggrs: Vec<Option<(Aggregation, Vec<DataValue>)>>,
+        budget: Option<MemBudget>,
+    ) -> Result<Self> {
         let is_dominance = aggrs
             .iter()
             .flatten()
             .any(|(a, _)| a.bounded_dominance.is_some());
         Ok(if is_dominance {
-            TempStore::DominanceMeet(DominanceMeetStore::new(aggrs)?)
+            let mut st = DominanceMeetStore::new(aggrs)?;
+            st.set_budget(budget);
+            TempStore::DominanceMeet(st)
         } else {
-            TempStore::BoundedMeet(BoundedMeetStore::new(aggrs)?)
+            let mut st = BoundedMeetStore::new(aggrs)?;
+            st.set_budget(budget);
+            TempStore::BoundedMeet(st)
         })
     }
     /// Merge one candidate into a bounded-meet-category store.
@@ -668,18 +1004,25 @@ impl EpochStore {
     pub(crate) fn exists(&self, key: &Tuple) -> bool {
         self.total.exists(key)
     }
-    pub(crate) fn new_normal(arity: usize) -> Self {
+    pub(crate) fn new_normal(arity: usize, budget: Option<MemBudget>) -> Self {
         Self {
-            total: TempStore::Normal(RegularTempStore::default()),
-            delta: TempStore::Normal(RegularTempStore::default()),
+            total: TempStore::Normal(RegularTempStore::with_budget(budget.clone())),
+            delta: TempStore::Normal(RegularTempStore::with_budget(budget)),
             use_total_for_delta: true,
             arity,
         }
     }
-    pub(crate) fn new_meet(aggrs: &[Option<(Aggregation, Vec<DataValue>)>]) -> Result<Self> {
+    pub(crate) fn new_meet(
+        aggrs: &[Option<(Aggregation, Vec<DataValue>)>],
+        budget: Option<MemBudget>,
+    ) -> Result<Self> {
+        let mut total = MeetAggrStore::new(aggrs.to_vec())?;
+        total.set_budget(budget.clone());
+        let mut delta = MeetAggrStore::new(aggrs.to_vec())?;
+        delta.set_budget(budget);
         Ok(Self {
-            total: TempStore::MeetAggr(MeetAggrStore::new(aggrs.to_vec())?),
-            delta: TempStore::MeetAggr(MeetAggrStore::new(aggrs.to_vec())?),
+            total: TempStore::MeetAggr(total),
+            delta: TempStore::MeetAggr(delta),
             use_total_for_delta: true,
             arity: aggrs.len(),
         })
@@ -688,6 +1031,7 @@ impl EpochStore {
     /// sorted/deduped but unbounded (one epoch may surface > k candidates).
     pub(crate) fn new_bounded_meet(
         aggrs: &[Option<(Aggregation, Vec<DataValue>)>],
+        budget: Option<MemBudget>,
     ) -> Result<Self> {
         // antichain-bounded-meet spec: a registered dominance aggregate gets
         // the antichain store; the builtin (min_cost_k) keeps the k-set store.
@@ -696,7 +1040,8 @@ impl EpochStore {
             .flatten()
             .any(|(a, _)| a.bounded_dominance.is_some());
         if is_dominance {
-            let total = DominanceMeetStore::new(aggrs.to_vec())?;
+            let mut total = DominanceMeetStore::new(aggrs.to_vec())?;
+            total.set_budget(budget);
             let delta = total.delta_twin();
             return Ok(Self {
                 total: TempStore::DominanceMeet(total),
@@ -705,7 +1050,8 @@ impl EpochStore {
                 arity: aggrs.len(),
             });
         }
-        let total = BoundedMeetStore::new(aggrs.to_vec())?;
+        let mut total = BoundedMeetStore::new(aggrs.to_vec())?;
+        total.set_budget(budget);
         let delta = total.delta_twin();
         Ok(Self {
             total: TempStore::BoundedMeet(total),
@@ -894,4 +1240,86 @@ fn probe_meet_idempotence(
          semilattice operation)"
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::db::MemBudget;
+
+    fn b() -> MemBudget {
+        MemBudget::new(usize::MAX, "test")
+    }
+
+    fn t(x: i64) -> Tuple {
+        vec![DataValue::from(x), DataValue::from(x + 1)]
+    }
+
+    /// Charge events, not write paths (spec §5): real insertions move the
+    /// counter; duplicate-key puts are net-neutral.
+    #[test]
+    fn put_charges_inserts_and_not_duplicates() {
+        let budget = b();
+        let mut st = RegularTempStore::with_budget(Some(budget.clone()));
+        st.put(t(1));
+        let after_first = budget.used();
+        assert!(after_first > 0, "a real insertion charges");
+        st.put(t(1));
+        assert_eq!(budget.used(), after_first, "a duplicate put is net-neutral");
+        st.put(t(2));
+        assert_eq!(budget.used(), 2 * after_first, "uniform tuples charge uniformly");
+    }
+
+    /// The merge swap fast path is a move: exactly zero counter movement.
+    #[test]
+    fn merge_swap_arm_is_accounting_neutral() {
+        let budget = b();
+        let mut total = RegularTempStore::with_budget(Some(budget.clone()));
+        let mut prev = RegularTempStore::with_budget(Some(budget.clone()));
+        let mut new = RegularTempStore::with_budget(Some(budget.clone()));
+        new.put(t(1));
+        new.put(t(2));
+        let before = budget.used();
+        total.merge_in(&mut prev, new);
+        assert_eq!(budget.used(), before, "the swap arm must move, not copy");
+    }
+
+    /// The merge entry arm: the moved entry stays charged in total, the prev
+    /// key-clone is a genuine new copy, and the incoming duplicate is debited.
+    #[test]
+    fn merge_entry_arm_charges_clones_and_debits_duplicates() {
+        let budget = b();
+        let mut total = RegularTempStore::with_budget(Some(budget.clone()));
+        let mut prev = RegularTempStore::with_budget(Some(budget.clone()));
+        total.put(t(1)); // total non-empty ⇒ entry arm, not swap
+        let per_entry = budget.used();
+
+        // one fresh key (charged in new, moves to total; prev clones it) +
+        // one duplicate of total's key (debited when it drops)
+        let mut new = RegularTempStore::with_budget(Some(budget.clone()));
+        new.put(t(1));
+        new.put(t(2));
+        assert_eq!(budget.used(), 3 * per_entry);
+        total.merge_in(&mut prev, new);
+        // total: entries {1, 2}; prev: clone of {2}; duplicate {1} debited.
+        assert_eq!(budget.used(), 3 * per_entry);
+        drop(prev);
+        assert_eq!(budget.used(), 2 * per_entry, "prev's clone debits on drop");
+        drop(total);
+        assert_eq!(budget.used(), 0, "all charges release at drop");
+    }
+
+    /// Drop reconciliation: whatever a store charged, its drop debits.
+    #[test]
+    fn drop_debits_exactly_what_was_charged() {
+        let budget = b();
+        {
+            let mut st = RegularTempStore::with_budget(Some(budget.clone()));
+            for i in 0..100 {
+                st.put(t(i));
+            }
+            assert!(budget.used() > 0);
+        }
+        assert_eq!(budget.used(), 0);
+    }
 }

--- a/cozo-core/src/runtime/transact.rs
+++ b/cozo-core/src/runtime/transact.rs
@@ -72,6 +72,12 @@ pub struct SessionTx<'a> {
     /// trigger) shares one tx, every statement it drives inherits the same
     /// budget — a multi-statement script is bounded as a whole, not per block.
     pub(crate) script_deadline: Option<Instant>,
+    /// Whole-script memory budget in estimated bytes (mnestic fork; spec
+    /// `docs/specs/memory-budget.md`): the minimum of any per-call limit
+    /// (`run_script_with_options`) and the Db default
+    /// (`set_default_query_mem_limit`). `None` = no whole-script budget.
+    /// `run_query` combines it (via `min`) with the block's own `:mem_limit`.
+    pub(crate) script_mem_limit: Option<usize>,
     /// Graph-projection freshness state, shared with the `Db` (mnestic fork;
     /// `runtime/graph_projection.rs`).
     pub(crate) projections: Arc<ProjectionCache>,

--- a/cozo-core/tests/memory_budget.rs
+++ b/cozo-core/tests/memory_budget.rs
@@ -1,0 +1,429 @@
+/*
+ * Copyright 2026, Shan Rizvi (mnestic fork).
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Per-query memory budget tests (mnestic fork; spec
+//! `docs/specs/memory-budget.md`).
+//!
+//! Pins the budget surface the spec's §11 matrix demands:
+//!
+//! * The refutation repro, inverted: an intermediate-rule cartesian blowup
+//!   under a small budget errors with the distinct `eval::mem_budget_exceeded`
+//!   *instead of* materializing (the 2026-07-13 containment attempt errored
+//!   only after the store had filled).
+//! * The knob triple — in-script `:mem_limit`, per-call
+//!   [`ScriptRunOptions::with_mem_limit`], Db default
+//!   ([`DbInstance::set_default_query_mem_limit`]) — min-composes: a block or
+//!   call can only tighten the budget, never raise a host-set guard.
+//! * A tripped mutable script leaves no partial writes; the Db keeps serving;
+//!   repeated trip/retry cycles leak nothing.
+//! * Every store family (regular, meet, bounded-meet k-set, dominance
+//!   skyline) and the sort/result staging copies are charged.
+//!
+//! Backend note (house rule): budget accounting lives in engine-level temp
+//! stores shared by all backends, but the sqlite backend exercises the real
+//! `stored_*` join path, so the load-bearing assertions run there; mem gets a
+//! parity smoke.
+
+use cozo::{DataValue, DbInstance, NamedRows, ScriptMutability, ScriptRunOptions};
+use std::collections::BTreeMap;
+use std::time::{Duration, Instant};
+
+/// Rows in the base relation; the blowup rule materializes N^2 tuples
+/// (~168 B/row measured), so 2,000 rows ⇒ ~4M tuples ≈ ~670 MB unbudgeted.
+/// The budgets under test are ≤ 8 MB, so a working budget aborts after a few
+/// thousand tuples and the test never pays the quadratic bill.
+const N: i64 = 2000;
+
+/// The refutation repro: an *intermediate* rule (not the entry, so the
+/// `:limit` early-return machinery never applies) whose store takes the
+/// cartesian square of `rel`.
+const BLOWUP_QUERY: &str = "tmp[a, b] := *rel[a], *rel[b]\n?[count(a)] := tmp[a, _]";
+
+/// Small enough to finish fast unbudgeted (~40k tuples), big enough that a
+/// tight budget still trips on it.
+const SMALL_N: i64 = 200;
+
+const ABORT_BOUND: Duration = Duration::from_secs(10);
+
+fn mutable(db: &DbInstance, script: &str) -> NamedRows {
+    db.run_script(script, BTreeMap::new(), ScriptMutability::Mutable)
+        .unwrap()
+}
+
+fn setup_db(engine: &str, path: &str, n: i64) -> DbInstance {
+    let db = DbInstance::new(engine, path, Default::default()).unwrap();
+    mutable(&db, ":create rel { a: Int }");
+    let rows: Vec<Vec<DataValue>> = (0..n).map(|a| vec![DataValue::from(a)]).collect();
+    let mut data = BTreeMap::new();
+    data.insert(
+        "rel".to_string(),
+        NamedRows::new(vec!["a".to_string()], rows),
+    );
+    db.import_relations(data).unwrap();
+    db
+}
+
+/// Run a script and, if it errors, extract the miette diagnostic `code` and
+/// the full rendered message (via the public JSON folding, so this test crate
+/// never names `miette::Report`).
+fn run_and_code(
+    db: &DbInstance,
+    script: &str,
+    mutability: ScriptMutability,
+    options: ScriptRunOptions,
+) -> (bool, String, String, Duration) {
+    let t0 = Instant::now();
+    let res = db.run_script_with_options(script, BTreeMap::new(), mutability, options);
+    let elapsed = t0.elapsed();
+    match res {
+        Ok(_) => (false, String::new(), String::new(), elapsed),
+        Err(err) => {
+            let j = cozo::format_error_as_json(err, None);
+            let code = j
+                .get("code")
+                .and_then(|c| c.as_str())
+                .unwrap_or("")
+                .to_string();
+            let msg = j
+                .get("display")
+                .and_then(|c| c.as_str())
+                .unwrap_or("")
+                .to_string();
+            (true, code, msg, elapsed)
+        }
+    }
+}
+
+fn assert_budget_trip(label: &str, is_err: bool, code: &str, elapsed: Duration) {
+    assert!(
+        is_err,
+        "[{label}] budgeted blowup query should error, got Ok"
+    );
+    assert_eq!(
+        code, "eval::mem_budget_exceeded",
+        "[{label}] budget trip must raise the distinct `eval::mem_budget_exceeded` \
+         (got {code:?})"
+    );
+    assert!(
+        elapsed < ABORT_BOUND,
+        "[{label}] aborted after {elapsed:?}; the budget is not tripping during \
+         materialization — it must error instead of the OOM, not after it"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 1. The refutation repro, inverted: in-script `:mem_limit`, sqlite + mem.
+// ---------------------------------------------------------------------------
+
+fn assert_in_script_limit(engine: &str, path: &str) {
+    let db = setup_db(engine, path, N);
+    let script = format!("{BLOWUP_QUERY} :mem_limit 4000000");
+    let (is_err, code, msg, elapsed) = run_and_code(
+        &db,
+        &script,
+        ScriptMutability::Immutable,
+        ScriptRunOptions::default(),
+    );
+    assert_budget_trip(&format!("{engine}/:mem_limit"), is_err, &code, elapsed);
+    assert!(
+        msg.contains("bytes") && msg.contains(":mem_limit"),
+        "[{engine}] the message names the figures and the knob that tripped: {msg}"
+    );
+}
+
+#[test]
+fn in_script_limit_sqlite() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().join("mb.db");
+    assert_in_script_limit("sqlite", path.to_str().unwrap());
+}
+
+#[test]
+fn in_script_limit_mem() {
+    assert_in_script_limit("mem", "");
+}
+
+// ---------------------------------------------------------------------------
+// 2. Per-call option trips the same way.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn per_call_limit_sqlite() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = setup_db("sqlite", tmp.path().join("mb.db").to_str().unwrap(), N);
+    let (is_err, code, _msg, elapsed) = run_and_code(
+        &db,
+        BLOWUP_QUERY,
+        ScriptMutability::Immutable,
+        ScriptRunOptions::default().with_mem_limit(4_000_000),
+    );
+    assert_budget_trip("sqlite/per-call", is_err, &code, elapsed);
+}
+
+// ---------------------------------------------------------------------------
+// 3. Db default arms bare queries; blocks/calls can only tighten it.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn db_default_arms_bare_query() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = setup_db("sqlite", tmp.path().join("mb.db").to_str().unwrap(), N);
+    db.set_default_query_mem_limit(Some(4_000_000));
+    let (is_err, code, _msg, elapsed) = run_and_code(
+        &db,
+        BLOWUP_QUERY,
+        ScriptMutability::Immutable,
+        ScriptRunOptions::default(),
+    );
+    assert_budget_trip("sqlite/db-default", is_err, &code, elapsed);
+
+    // Clearing the default restores unlimited: the small workload passes.
+    db.set_default_query_mem_limit(None);
+    let small = setup_db(
+        "sqlite",
+        tmp.path().join("mb_small.db").to_str().unwrap(),
+        SMALL_N,
+    );
+    let (is_err, _, _, _) = run_and_code(
+        &small,
+        BLOWUP_QUERY,
+        ScriptMutability::Immutable,
+        ScriptRunOptions::default(),
+    );
+    assert!(!is_err, "unbudgeted small blowup should complete");
+}
+
+#[test]
+fn block_limit_cannot_raise_db_default() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = setup_db("sqlite", tmp.path().join("mb.db").to_str().unwrap(), N);
+    db.set_default_query_mem_limit(Some(4_000_000));
+    // The block asks for 100 GB; the host-set default still governs (scripts
+    // are increasingly LLM-authored — tighten-only is the signed contract).
+    let script = format!("{BLOWUP_QUERY} :mem_limit 100000000000");
+    let (is_err, code, _msg, elapsed) = run_and_code(
+        &db,
+        &script,
+        ScriptMutability::Immutable,
+        ScriptRunOptions::default(),
+    );
+    assert_budget_trip("sqlite/tighten-only-block", is_err, &code, elapsed);
+}
+
+#[test]
+fn per_call_cannot_raise_db_default() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = setup_db("sqlite", tmp.path().join("mb.db").to_str().unwrap(), N);
+    db.set_default_query_mem_limit(Some(4_000_000));
+    let (is_err, code, _msg, elapsed) = run_and_code(
+        &db,
+        BLOWUP_QUERY,
+        ScriptMutability::Immutable,
+        ScriptRunOptions::default().with_mem_limit(100_000_000_000),
+    );
+    assert_budget_trip("sqlite/tighten-only-call", is_err, &code, elapsed);
+}
+
+// ---------------------------------------------------------------------------
+// 4. Comfortably-under queries succeed with results identical to unbudgeted
+//    runs; comfortably-over always errors (the signed determinism posture).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn under_budget_matches_unbudgeted_and_is_stable() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = setup_db(
+        "sqlite",
+        tmp.path().join("mb.db").to_str().unwrap(),
+        SMALL_N,
+    );
+    let unbudgeted = db
+        .run_script(BLOWUP_QUERY, BTreeMap::new(), ScriptMutability::Immutable)
+        .unwrap();
+    for round in 0..5 {
+        let budgeted = db
+            .run_script_with_options(
+                BLOWUP_QUERY,
+                BTreeMap::new(),
+                ScriptMutability::Immutable,
+                // ~40k tuples × ~168 B ≈ 7 MB total residency; 64 MB is
+                // comfortable headroom over stores + staging.
+                ScriptRunOptions::default().with_mem_limit(64_000_000),
+            )
+            .unwrap_or_else(|e| panic!("round {round}: under-budget run errored: {e:?}"));
+        assert_eq!(unbudgeted.rows, budgeted.rows, "round {round}");
+    }
+}
+
+#[test]
+fn over_budget_always_errors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = setup_db("sqlite", tmp.path().join("mb.db").to_str().unwrap(), N);
+    for round in 0..5 {
+        let (is_err, code, _msg, elapsed) = run_and_code(
+            &db,
+            BLOWUP_QUERY,
+            ScriptMutability::Immutable,
+            ScriptRunOptions::default().with_mem_limit(4_000_000),
+        );
+        assert_budget_trip(&format!("sqlite/round-{round}"), is_err, &code, elapsed);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Trip-path integrity: no partial writes, Db keeps serving, no residue.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn tripped_mutable_script_leaves_no_partial_writes() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = setup_db("sqlite", tmp.path().join("mb.db").to_str().unwrap(), N);
+    mutable(&db, ":create out { a: Int, b: Int }");
+    let script =
+        "tmp[a, b] := *rel[a], *rel[b]\n?[a, b] := tmp[a, b] :put out { a, b } :mem_limit 4000000";
+    let (is_err, code, _msg, elapsed) = run_and_code(
+        &db,
+        script,
+        ScriptMutability::Mutable,
+        ScriptRunOptions::default(),
+    );
+    assert_budget_trip("sqlite/mutable", is_err, &code, elapsed);
+    let count = db
+        .run_script(
+            "?[count(a)] := *out[a, _]",
+            BTreeMap::new(),
+            ScriptMutability::Immutable,
+        )
+        .unwrap();
+    assert_eq!(
+        count.rows[0][0],
+        DataValue::from(0i64),
+        "a tripped mutable script must leave no partial writes"
+    );
+}
+
+#[test]
+fn repeated_trips_leave_no_residue() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = setup_db("sqlite", tmp.path().join("mb.db").to_str().unwrap(), N);
+    for _ in 0..5 {
+        let (is_err, code, _msg, _t) = run_and_code(
+            &db,
+            BLOWUP_QUERY,
+            ScriptMutability::Immutable,
+            ScriptRunOptions::default().with_mem_limit(4_000_000),
+        );
+        assert!(is_err && code == "eval::mem_budget_exceeded");
+    }
+    // The Db is unharmed and an ordinary query still runs.
+    let ok = db
+        .run_script(
+            "?[count(a)] := *rel[a]",
+            BTreeMap::new(),
+            ScriptMutability::Immutable,
+        )
+        .unwrap();
+    assert_eq!(ok.rows[0][0], DataValue::from(N));
+}
+
+// ---------------------------------------------------------------------------
+// 6. Every store family charges: meet, bounded-meet (k-set), dominance
+//    (skyline). Each groups by (a, b), so the store itself must hold ~N^2
+//    groups — the budget bites in the aggregated store, not just the regular
+//    intermediate.
+// ---------------------------------------------------------------------------
+
+fn assert_family_trips(label: &str, script: &str) {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = setup_db("sqlite", tmp.path().join("mb.db").to_str().unwrap(), N);
+    let (is_err, code, _msg, elapsed) = run_and_code(
+        &db,
+        script,
+        ScriptMutability::Immutable,
+        ScriptRunOptions::default().with_mem_limit(4_000_000),
+    );
+    assert_budget_trip(label, is_err, &code, elapsed);
+}
+
+#[test]
+fn meet_store_trips() {
+    assert_family_trips(
+        "sqlite/meet",
+        "?[a, b, min(x)] := *rel[a], *rel[b], x = a + b :mem_limit 4000000",
+    );
+}
+
+#[test]
+fn bounded_meet_store_trips() {
+    assert_family_trips(
+        "sqlite/min_cost_k",
+        "?[a, b, min_cost_k(p, 3)] := *rel[a], *rel[b], p = [b, 1.0] :mem_limit 4000000",
+    );
+}
+
+#[test]
+fn dominance_store_trips() {
+    assert_family_trips(
+        "sqlite/pareto",
+        "?[a, b, pareto_min(v)] := *rel[a], *rel[b], v = [a, b] :mem_limit 4000000",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7. The sort staging copy is charged: a budget the evaluation fits but the
+//    sorted duplicate does not still trips.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sort_staging_copy_is_charged() {
+    let tmp = tempfile::tempdir().unwrap();
+    let n = 60_000i64;
+    let db = setup_db("sqlite", tmp.path().join("mb.db").to_str().unwrap(), n);
+    // One pass over rel (~60k single-int tuples ≈ ~7.7 MB charged in the
+    // entry store); `:order` copies all of it again into the sort Vec. A
+    // 9 MB budget clears evaluation but not evaluation + the sorted copy.
+    let script = "?[a] := *rel[a] :order a :mem_limit 9000000";
+    let (is_err, code, _msg, elapsed) = run_and_code(
+        &db,
+        script,
+        ScriptMutability::Immutable,
+        ScriptRunOptions::default(),
+    );
+    assert_budget_trip("sqlite/sort-staging", is_err, &code, elapsed);
+    // Control: the same query under a budget with room for both copies.
+    let (is_err, _, _, _) = run_and_code(
+        &db,
+        "?[a] := *rel[a] :order a :mem_limit 64000000",
+        ScriptMutability::Immutable,
+        ScriptRunOptions::default(),
+    );
+    assert!(!is_err, "sort within budget should complete");
+}
+
+// ---------------------------------------------------------------------------
+// 8. Zero clears a block limit (documented `0` semantics), matching
+//    `:timeout 0`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn zero_block_limit_is_unlimited() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = setup_db(
+        "sqlite",
+        tmp.path().join("mb.db").to_str().unwrap(),
+        SMALL_N,
+    );
+    let script = format!("{BLOWUP_QUERY} :mem_limit 0");
+    let (is_err, _, _, _) = run_and_code(
+        &db,
+        &script,
+        ScriptMutability::Immutable,
+        ScriptRunOptions::default(),
+    );
+    assert!(!is_err, ":mem_limit 0 must mean no block limit");
+}


### PR DESCRIPTION
Implements the signed [memory-budget spec](docs/specs/memory-budget.md) — the next minor's headline. A mis-authored join can no longer OOM-kill the host process: materialization is charged (estimated bytes, allocation-event semantics with enumerated debits and Drop reconciliation), and crossing the budget trips a clean, typed, retriable `eval::mem_budget_exceeded` before the memory is spent and before any commit.

- Knob triple min-composed, tighten-only from script text (`:mem_limit` / `with_mem_limit` / `set_default_query_mem_limit`).
- Engine default unset (never-silently-break-upstream); `cozo-bin` arms 4 GiB by default per the signed Q5.
- 15 integration tests (the 2026-07-13 refutation repro, inverted, is test 1) + charge-event unit tests; full suite green including the inherited upstream tests and the existing timeout suite over the shared `Poison`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)