### PR TITLE
Cross-instance RocksDB memory: shared cache envelope + WBM carve-out (mnestic-rocks additive)

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -5,7 +5,58 @@ provenance and licensing.
 
 ## Unreleased
 
-Nothing yet.
+### Cross-instance shared memory for the RocksDB backend
+
+One shared block cache + `WriteBufferManager` envelope for many embedded
+RocksDB instances in one process (spec:
+`docs/specs/cross-instance-memory.md`; the construction Kafka Streams, Flink,
+and TiKV each converged on). **Requires a mnestic-rocks release, which must
+publish before the mnestic crate that pins it.**
+
+- **The handle**: `RocksMemoryResources::new(RocksMemoryConfig { total_bytes,
+  memtable_fraction })` — one LRU cache of `total_bytes` (THE envelope;
+  `strict_capacity_limit=false`, default high-priority pool) plus one
+  `WriteBufferManager` of `total_bytes × memtable_fraction` charged INTO the
+  cache as dummy entries (cost-to-cache: the memtable share is a carve-out of
+  the envelope, not an addition beside it; `allow_stall=false`). Validation
+  is typed and total: nonzero total, fraction strictly in (0, 1). Immutable
+  after construction; clones are refcounted handles to the same live objects.
+- **Entry points**: `new_cozo_rocksdb_with_memory(path, &handle)` beside
+  `new_cozo_rocksdb` for Rust hosts; for bindings and string-configured
+  hosts, `DbInstance::new`'s previously-ignored `options` JSON gains
+  `{"shared_memory": {"total_bytes": …, "memtable_fraction": 0.25}}`
+  (fraction optional, default 0.25) — the first use fixes the process-default
+  config, an identical later config joins, a differing one is a typed
+  conflict error naming both configs. Non-RocksDB engines ignore the key.
+- **Override loudness**: with a handle present, the shared cache overrides
+  any `block_cache` the `<path>/options` file declares — and the open logs a
+  warning naming both capacities (the 0.13.0 lesson: never drop declared
+  options silently). Participating instances also get
+  `cache_index_and_filter_blocks_with_high_priority=true`.
+- **Property surface**: per-instance `rocksdb.block-cache-usage`,
+  `rocksdb.cur-size-all-mem-tables`, `rocksdb.estimate-table-readers-mem`
+  via `Db::rocksdb_memory_stats()` / `DbInstance::rocksdb_memory_stats()`
+  (a struct of `Option<u64>`; all `None` on non-RocksDB engines), plus
+  handle-level accessors (`memory_usage`, `mutable_memtable_memory_usage`,
+  `dummy_entries_in_cache_usage`, `buffer_size`, `cache_capacity`,
+  `cache_usage`). Charged into the envelope: data blocks, index/filter
+  blocks, memtable bytes. NOT charged: table readers outside the cache, WAL,
+  allocator retention — a soft envelope, disjoint from the query memory
+  budget.
+- **Bridge (`cozorocks`, all additive)**: opaque `RocksMemoryResources`
+  crossing cxx as a `SharedPtr` function argument,
+  `open_db_with_resources(...)` beside an untouched `open_db` (both now call
+  one shared install helper), `get_int_property` on `RocksDbBridge`, and a
+  `DbOpenReport` carrying the override facts to Rust for logging. Also fixes
+  the options-file cache-attach CF loop (`bridge/db.cpp`), which indexed
+  descriptor `[0]` on every iteration and dereferenced
+  `GetOptions<BlockBasedTableOptions>()` without the null check its sibling
+  0.13.0 fix block has — a non-block-based table factory in an options file
+  crashed the open (reachable only by direct bridge consumers passing a
+  cache).
+- Tests: `cozo-core/tests/cross_instance_memory.rs` (spec §8 matrix —
+  sharing-is-real, conflict semantics, validation, override loudness,
+  CF-loop regression, non-RocksDB `None`s, over-budget write storm).
 
 ## 0.14.0 — 2026-08-08
 

--- a/cozo-core/src/lib.rs
+++ b/cozo-core/src/lib.rs
@@ -98,7 +98,11 @@ pub use storage::mem::{new_cozo_mem, MemStorage};
 #[cfg(feature = "storage-new-rocksdb")]
 pub use storage::newrocks::{new_cozo_newrocksdb, NewRocksDbStorage};
 #[cfg(feature = "storage-rocksdb")]
-pub use storage::rocks::{new_cozo_rocksdb, RocksDbStorage};
+pub use storage::rocks::{
+    new_cozo_rocksdb, new_cozo_rocksdb_with_memory, process_default_rocks_memory,
+    RocksDbStorage, RocksMemoryConfig, RocksMemoryConfigError, RocksMemoryResources,
+    RocksMemoryStats, SharedMemoryConfigConflict,
+};
 #[cfg(feature = "storage-sled")]
 pub use storage::sled::{new_cozo_sled, SledStorage};
 #[cfg(feature = "storage-sqlite")]
@@ -189,7 +193,18 @@ impl DbInstance {
     /// some of the engines are available. The `mem` engine is always available.
     ///
     /// `path` is ignored for `mem` and `tikv` engines.
-    /// `options` is ignored for every engine except `tikv`.
+    /// `options` is ignored for every engine except `tikv` and `rocksdb`.
+    ///
+    /// For `rocksdb`, `options` may carry a `shared_memory` key —
+    /// `{"shared_memory": {"total_bytes": 268435456, "memtable_fraction": 0.25}}`
+    /// (`memtable_fraction` optional, default 0.25) — which joins the instance
+    /// to the PROCESS-DEFAULT shared memory envelope: one block cache plus one
+    /// write-buffer manager shared by every instance opened with the same
+    /// config (docs/specs/cross-instance-memory.md §4). The first use fixes
+    /// the canonical config; an identical later config joins, a differing one
+    /// is a typed conflict error naming both. Rust hosts wanting several
+    /// distinct envelopes should use `new_cozo_rocksdb_with_memory` with
+    /// explicit handles instead. Non-RocksDB engines ignore the key.
     #[allow(unused_variables)]
     pub fn new(engine: &str, path: impl AsRef<Path>, options: &str) -> Result<Self> {
         let options = if options.is_empty() { "{}" } else { options };
@@ -198,7 +213,34 @@ impl DbInstance {
             #[cfg(feature = "storage-sqlite")]
             "sqlite" => Self::Sqlite(new_cozo_sqlite(path)?),
             #[cfg(feature = "storage-rocksdb")]
-            "rocksdb" => Self::RocksDb(new_cozo_rocksdb(path)?),
+            "rocksdb" => {
+                fn default_memtable_fraction() -> f64 {
+                    RocksMemoryConfig::DEFAULT_MEMTABLE_FRACTION
+                }
+                #[derive(serde_derive::Deserialize)]
+                struct SharedMemoryOpts {
+                    total_bytes: usize,
+                    #[serde(default = "default_memtable_fraction")]
+                    memtable_fraction: f64,
+                }
+                #[derive(serde_derive::Deserialize)]
+                struct RocksDbOpts {
+                    #[serde(default)]
+                    shared_memory: Option<SharedMemoryOpts>,
+                }
+                let opts: RocksDbOpts = serde_json::from_str(options).into_diagnostic()?;
+                match opts.shared_memory {
+                    None => Self::RocksDb(new_cozo_rocksdb(path)?),
+                    Some(shared) => {
+                        let config = RocksMemoryConfig {
+                            total_bytes: shared.total_bytes,
+                            memtable_fraction: shared.memtable_fraction,
+                        };
+                        let handle = process_default_rocks_memory(config)?;
+                        Self::RocksDb(new_cozo_rocksdb_with_memory(path, &handle)?)
+                    }
+                }
+            }
             #[cfg(feature = "storage-new-rocksdb")]
             "newrocksdb" => Self::NewRocksDb(new_cozo_newrocksdb(path)?),
             #[cfg(feature = "storage-sled")]
@@ -226,6 +268,17 @@ impl DbInstance {
         options: &str,
     ) -> std::result::Result<Self, String> {
         Self::new(engine, path, options).map_err(|err| err.to_string())
+    }
+
+    /// Per-instance RocksDB memory property reads (mnestic fork,
+    /// docs/specs/cross-instance-memory.md §5). Returns a struct whose fields
+    /// are all `None` for every non-RocksDB engine — never an error.
+    #[cfg(feature = "storage-rocksdb")]
+    pub fn rocksdb_memory_stats(&self) -> RocksMemoryStats {
+        match self {
+            DbInstance::RocksDb(db) => db.rocksdb_memory_stats(),
+            _ => RocksMemoryStats::default(),
+        }
     }
 
     /// Dispatcher method.  See [crate::Db::set_durable_writes].

--- a/cozo-core/src/storage/rocks.rs
+++ b/cozo-core/src/storage/rocks.rs
@@ -9,12 +9,13 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
-use log::info;
+use log::{info, warn};
 use miette::{miette, IntoDiagnostic, Result, WrapErr};
 
 use cozorocks::{DbBuilder, DbIter, RocksDb, SnapReader, Tx};
+pub use cozorocks::{RocksMemoryConfig, RocksMemoryConfigError, RocksMemoryResources};
 
 use crate::data::tuple::{check_key_for_validity, Tuple};
 use crate::data::value::ValidityTs;
@@ -32,15 +33,59 @@ const CURRENT_STORAGE_VERSION: u64 = 3;
 /// sustain huge concurrency.
 /// Supports concurrent readers and writers.
 pub fn new_cozo_rocksdb(path: impl AsRef<Path>) -> Result<Db<RocksDbStorage>> {
-    let builder = DbBuilder::default().path(path.as_ref());
-    fs::create_dir_all(path.as_ref()).map_err(|err| {
+    let db_builder = prepare_db_builder(path.as_ref())?;
+    let db = db_builder.build()?;
+
+    let ret = Db::new(RocksDbStorage::new(db))?;
+    ret.initialize()?;
+    Ok(ret)
+}
+
+/// Creates a RocksDB database object participating in a shared cross-instance
+/// memory envelope (mnestic fork, docs/specs/cross-instance-memory.md §4).
+/// Build ONE [`RocksMemoryResources`] handle from a [`RocksMemoryConfig`] and
+/// open every participating instance with a clone of it: they then share one
+/// block cache (the envelope) and one WriteBufferManager charged into it.
+///
+/// The handle OVERRIDES any `block_cache` a `<path>/options` file declares (a
+/// live shared object cannot be expressed in an INI file); the override is
+/// logged loudly with both capacities, never applied silently. Everything
+/// else in the options file is honored as usual.
+pub fn new_cozo_rocksdb_with_memory(
+    path: impl AsRef<Path>,
+    memory: &RocksMemoryResources,
+) -> Result<Db<RocksDbStorage>> {
+    let db_builder = prepare_db_builder(path.as_ref())?;
+    let (db, report) = db_builder.build_with_memory(memory)?;
+    if report.overrode_options_file_cache {
+        warn!(
+            "shared memory envelope overrides the options-file block_cache for {}: \
+             options file declared a {}-byte cache, shared cache capacity is {} bytes",
+            path.as_ref().to_string_lossy(),
+            report.options_file_cache_capacity,
+            report.shared_cache_capacity
+        );
+    }
+
+    let ret = Db::new(RocksDbStorage::new(db))?;
+    ret.initialize()?;
+    Ok(ret)
+}
+
+/// Shared open-path setup for [`new_cozo_rocksdb`] and
+/// [`new_cozo_rocksdb_with_memory`]: directory + manifest handling, options
+/// file discovery, and the `DbBuilder` knobs. Extracted verbatim so the
+/// no-handle path stays bit-identical.
+fn prepare_db_builder(path: &Path) -> Result<DbBuilder> {
+    let builder = DbBuilder::default().path(path);
+    fs::create_dir_all(path).map_err(|err| {
         BadDbInit(format!(
             "cannot create directory {}: {}",
-            path.as_ref().to_string_lossy(),
+            path.to_string_lossy(),
             err
         ))
     })?;
-    let path_buf = PathBuf::from(path.as_ref());
+    let path_buf = PathBuf::from(path);
 
     let is_new = {
         let mut manifest_path = path_buf.clone();
@@ -98,18 +143,89 @@ pub fn new_cozo_rocksdb(path: impl AsRef<Path>) -> Result<Db<RocksDbStorage>> {
         ""
     };
 
-    let db_builder = builder
+    Ok(builder
         .create_if_missing(is_new)
         .use_capped_prefix_extractor(true, KEY_PREFIX_LEN)
         .use_bloom_filter(true, 9.9, true)
         .path(store_path)
-        .options_path(options_path);
+        .options_path(options_path))
+}
 
-    let db = db_builder.build()?;
+/// Typed conflict error for the process-default shared memory envelope
+/// (mnestic fork, docs/specs/cross-instance-memory.md §4): the process
+/// default is constructed once from the first config seen; a later differing
+/// request is refused, naming both configs — never first-writer-wins
+/// silently. An identical config joins the existing handle.
+#[derive(Debug, thiserror::Error, miette::Diagnostic)]
+#[error(
+    "conflicting `shared_memory` config for the process-default RocksDB memory envelope: \
+     already initialized with {existing:?}; this open requested {requested:?}"
+)]
+#[diagnostic(code(mnestic::rocks::shared_memory_config_conflict))]
+pub struct SharedMemoryConfigConflict {
+    /// The canonical config the process default was constructed from.
+    pub existing: RocksMemoryConfig,
+    /// The differing config this open requested.
+    pub requested: RocksMemoryConfig,
+}
 
-    let ret = Db::new(RocksDbStorage::new(db))?;
-    ret.initialize()?;
-    Ok(ret)
+/// The process-default shared memory envelope: the canonical config plus the
+/// live handle, fixed by the first use. Deliberately not a naked `once_flag`:
+/// config equality is checked on every later request.
+static PROCESS_DEFAULT_MEMORY: Mutex<Option<(RocksMemoryConfig, RocksMemoryResources)>> =
+    Mutex::new(None);
+
+/// Resolves the process-default shared memory handle for `config` (mnestic
+/// fork, docs/specs/cross-instance-memory.md §4 — the entry point reachable
+/// from string-configured hosts via `DbInstance::new`'s options JSON). First
+/// use constructs and stores the canonical (config, handle) pair; an
+/// identical later config joins; a differing one is a typed
+/// [`SharedMemoryConfigConflict`]. The explicit-handle path
+/// ([`new_cozo_rocksdb_with_memory`]) never consults this.
+pub fn process_default_rocks_memory(config: RocksMemoryConfig) -> Result<RocksMemoryResources> {
+    let mut guard = PROCESS_DEFAULT_MEMORY
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    match &*guard {
+        Some((existing, handle)) => {
+            if *existing == config {
+                Ok(handle.clone())
+            } else {
+                Err(SharedMemoryConfigConflict {
+                    existing: existing.clone(),
+                    requested: config,
+                }
+                .into())
+            }
+        }
+        None => {
+            let handle = RocksMemoryResources::new(config.clone()).into_diagnostic()?;
+            *guard = Some((config, handle.clone()));
+            Ok(handle)
+        }
+    }
+}
+
+/// Per-instance RocksDB memory property reads (mnestic fork,
+/// docs/specs/cross-instance-memory.md §5). Each field mirrors the RocksDB
+/// int property of the same name; `None` when the property is unavailable
+/// (and, via the `DbInstance`-level accessor, on non-RocksDB engines).
+///
+/// These measure RocksDB's storage-side memory only. They are disjoint from
+/// the query memory budget's evaluation-time estimate; neither counts the
+/// other's bytes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RocksMemoryStats {
+    /// `rocksdb.block-cache-usage` — with a shared envelope this is the
+    /// SHARED cache's usage (real blocks + WriteBufferManager dummy entries),
+    /// so every participating instance reports the same value.
+    pub block_cache_usage: Option<u64>,
+    /// `rocksdb.cur-size-all-mem-tables` — this instance's active and
+    /// unflushed immutable memtables (bytes).
+    pub cur_size_all_mem_tables: Option<u64>,
+    /// `rocksdb.estimate-table-readers-mem` — table-reader memory outside the
+    /// block cache; NOT charged into the shared envelope.
+    pub estimate_table_readers_mem: Option<u64>,
 }
 
 /// RocksDB storage engine
@@ -128,6 +244,25 @@ impl RocksDbStorage {
             db,
             sync_writes: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    /// Per-instance memory property reads (mnestic fork,
+    /// docs/specs/cross-instance-memory.md §5). Fields are `None` when
+    /// RocksDB cannot answer for this instance.
+    pub fn memory_stats(&self) -> RocksMemoryStats {
+        RocksMemoryStats {
+            block_cache_usage: self.db.block_cache_usage().ok(),
+            cur_size_all_mem_tables: self.db.cur_size_all_mem_tables().ok(),
+            estimate_table_readers_mem: self.db.estimate_table_readers_mem().ok(),
+        }
+    }
+}
+
+impl Db<RocksDbStorage> {
+    /// Per-instance RocksDB memory property reads (mnestic fork,
+    /// docs/specs/cross-instance-memory.md §5). See [`RocksMemoryStats`].
+    pub fn rocksdb_memory_stats(&self) -> RocksMemoryStats {
+        self.db.memory_stats()
     }
 }
 

--- a/cozo-core/tests/cross_instance_memory.rs
+++ b/cozo-core/tests/cross_instance_memory.rs
@@ -1,0 +1,473 @@
+/*
+ * Copyright 2026, Shan Rizvi (mnestic fork).
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Cross-instance shared memory tests (docs/specs/cross-instance-memory.md §8):
+//! one shared block cache + WriteBufferManager envelope across several
+//! embedded RocksDB instances in one process.
+
+#![cfg(feature = "storage-rocksdb")]
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, Once, OnceLock};
+
+use cozo::{
+    new_cozo_rocksdb, new_cozo_rocksdb_with_memory, DataValue, Db, DbInstance, NamedRows,
+    RocksDbStorage, RocksMemoryConfig, RocksMemoryConfigError, RocksMemoryResources,
+    ScriptMutability,
+};
+
+// ---------------------------------------------------------------------------
+// helpers
+
+fn run(db: &Db<RocksDbStorage>, script: &str) -> NamedRows {
+    db.run_script(script, Default::default(), ScriptMutability::Mutable)
+        .unwrap_or_else(|e| panic!("script failed: {e:?}\n--- script ---\n{script}"))
+}
+
+fn create_kv(db: &Db<RocksDbStorage>) {
+    run(db, ":create kv {k: Int => v: String}");
+}
+
+/// Import `n` rows of roughly `payload_len` bytes each into `kv`.
+fn import_rows(db: &Db<RocksDbStorage>, start: i64, n: i64, payload_len: usize) {
+    let payload = "x".repeat(payload_len);
+    let mut to_import = BTreeMap::new();
+    to_import.insert(
+        "kv".to_string(),
+        NamedRows {
+            headers: vec!["k".to_string(), "v".to_string()],
+            rows: (start..start + n)
+                .map(|i| vec![DataValue::from(i), DataValue::from(payload.as_str())])
+                .collect(),
+            next: None,
+        },
+    );
+    db.import_relations(to_import).unwrap();
+}
+
+fn count_kv(db: &Db<RocksDbStorage>) -> usize {
+    db.run_script(
+        "?[count(k)] := *kv[k, _]",
+        Default::default(),
+        ScriptMutability::Immutable,
+    )
+    .unwrap()
+    .rows[0][0]
+        .get_int()
+        .unwrap() as usize
+}
+
+/// Newest RocksDB-generated OPTIONS file in `<db>/data`.
+fn newest_options_file(db_dir: &Path) -> PathBuf {
+    let data_dir = db_dir.join("data");
+    let mut candidates: Vec<_> = fs::read_dir(&data_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .map(|n| n.to_string_lossy().starts_with("OPTIONS-"))
+                .unwrap_or(false)
+        })
+        .collect();
+    candidates.sort();
+    candidates.pop().expect("RocksDB wrote an OPTIONS file")
+}
+
+// ---------------------------------------------------------------------------
+// log capture (same pattern as tests/import_index_staleness.rs): the override
+// is surfaced as a `log` warning, asserted via a capturing logger.
+
+fn captured() -> &'static Mutex<Vec<String>> {
+    static CAPTURED: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+    CAPTURED.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+struct CaptureLogger;
+
+impl log::Log for CaptureLogger {
+    fn enabled(&self, _: &log::Metadata<'_>) -> bool {
+        true
+    }
+    fn log(&self, record: &log::Record<'_>) {
+        if record.level() <= log::Level::Warn {
+            captured().lock().unwrap().push(record.args().to_string());
+        }
+    }
+    fn flush(&self) {}
+}
+
+fn init_capture() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        log::set_logger(&CaptureLogger).expect("no other logger may be installed");
+        log::set_max_level(log::LevelFilter::Warn);
+    });
+}
+
+// ---------------------------------------------------------------------------
+// §8.1 — bit-parity default: no handle, plain open keeps working (the wider
+// suite pins full behavior; this is the smoke half).
+
+#[test]
+fn no_handle_smoke() {
+    let dir = tempfile::tempdir().unwrap();
+    let db = new_cozo_rocksdb(dir.path()).unwrap();
+    create_kv(&db);
+    import_rows(&db, 0, 100, 32);
+    assert_eq!(count_kv(&db), 100);
+    // Property reads work without a handle too (per-instance cache).
+    let stats = db.rocksdb_memory_stats();
+    assert!(stats.block_cache_usage.is_some());
+    assert!(stats.cur_size_all_mem_tables.is_some());
+    assert!(stats.estimate_table_readers_mem.is_some());
+}
+
+// ---------------------------------------------------------------------------
+// §8.2 — sharing is real: two instances, one handle; writes to A move the
+// handle-level WBM/cache metrics, and both instances see the same shared
+// cache through the per-instance property read.
+
+#[test]
+fn sharing_is_real() {
+    let handle = RocksMemoryResources::new(RocksMemoryConfig {
+        total_bytes: 64 << 20,
+        memtable_fraction: 0.25,
+    })
+    .unwrap();
+    assert_eq!(handle.cache_capacity(), 64 << 20);
+    assert_eq!(handle.buffer_size(), 16 << 20);
+
+    let dir_a = tempfile::tempdir().unwrap();
+    let dir_b = tempfile::tempdir().unwrap();
+    let db_a = new_cozo_rocksdb_with_memory(dir_a.path(), &handle).unwrap();
+    let db_b = new_cozo_rocksdb_with_memory(dir_b.path(), &handle).unwrap();
+    create_kv(&db_a);
+    create_kv(&db_b);
+
+    let base_wbm = handle.memory_usage();
+    let base_cache = handle.cache_usage();
+
+    // ~2 MB into A's memtables.
+    import_rows(&db_a, 0, 4000, 500);
+    assert_eq!(count_kv(&db_a), 4000);
+
+    // Handle-level: memtable bytes moved, and they were charged into the
+    // shared cache as dummy entries (cost-to-cache).
+    assert!(
+        handle.memory_usage() > base_wbm,
+        "WBM memory usage should grow with A's memtables: {} -> {}",
+        base_wbm,
+        handle.memory_usage()
+    );
+    assert!(handle.mutable_memtable_memory_usage() > 0);
+    assert!(
+        handle.dummy_entries_in_cache_usage() > 0,
+        "memtable bytes must be charged into the shared cache"
+    );
+    assert!(
+        handle.cache_usage() > base_cache,
+        "shared cache usage should grow with the WBM dummy entries: {} -> {}",
+        base_cache,
+        handle.cache_usage()
+    );
+
+    // Per-instance property reads are plausible and nonzero.
+    let stats_a = db_a.rocksdb_memory_stats();
+    assert!(stats_a.cur_size_all_mem_tables.unwrap() > 0);
+    assert!(stats_a.block_cache_usage.unwrap() > 0);
+    assert!(stats_a.estimate_table_readers_mem.is_some());
+
+    // B sees the SAME cache: its block-cache-usage read reports the shared
+    // object, matching both A's read and the handle's own view. (Background
+    // work may move the number between reads; allow a few retries.)
+    let mut ok = false;
+    for _ in 0..10 {
+        let a = db_a.rocksdb_memory_stats().block_cache_usage.unwrap();
+        let b = db_b.rocksdb_memory_stats().block_cache_usage.unwrap();
+        let h = handle.cache_usage();
+        if a == b && b == h {
+            ok = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(
+        ok,
+        "A, B, and the handle must report the same shared cache usage"
+    );
+
+    // B is a working instance of its own.
+    import_rows(&db_b, 0, 100, 32);
+    assert_eq!(count_kv(&db_b), 100);
+    assert_eq!(count_kv(&db_a), 4000);
+}
+
+// ---------------------------------------------------------------------------
+// §8.3 — process-default conflict semantics via the options JSON. One test
+// owns the process-wide default (it is per-process state).
+
+#[test]
+fn process_default_conflict_semantics() {
+    let opts = r#"{"shared_memory": {"total_bytes": 33554432, "memtable_fraction": 0.3}}"#;
+
+    let dir1 = tempfile::tempdir().unwrap();
+    let db1 = DbInstance::new("rocksdb", dir1.path(), opts).unwrap();
+    // First use fixes the canonical config; property reads flow through.
+    assert!(db1.rocksdb_memory_stats().block_cache_usage.is_some());
+
+    // Identical config joins.
+    let dir2 = tempfile::tempdir().unwrap();
+    let _db2 = DbInstance::new("rocksdb", dir2.path(), opts).unwrap();
+
+    // Differing total_bytes: typed conflict naming both configs.
+    let dir3 = tempfile::tempdir().unwrap();
+    let err = DbInstance::new(
+        "rocksdb",
+        dir3.path(),
+        r#"{"shared_memory": {"total_bytes": 16777216, "memtable_fraction": 0.3}}"#,
+    )
+    .err()
+    .expect("differing shared_memory config must conflict");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("conflicting"), "unexpected error: {msg}");
+    assert!(
+        msg.contains("33554432"),
+        "must name the existing config: {msg}"
+    );
+    assert!(
+        msg.contains("16777216"),
+        "must name the requested config: {msg}"
+    );
+
+    // Omitted memtable_fraction defaults to 0.25 — which differs from the
+    // canonical 0.3, so the conflict message proves the default applied.
+    let dir4 = tempfile::tempdir().unwrap();
+    let err = DbInstance::new(
+        "rocksdb",
+        dir4.path(),
+        r#"{"shared_memory": {"total_bytes": 33554432}}"#,
+    )
+    .err()
+    .expect("defaulted fraction differs from canonical, must conflict");
+    let msg = format!("{err:?}");
+    assert!(msg.contains("0.25"), "default fraction must be 0.25: {msg}");
+
+    // No shared_memory key: plain open, untouched by the process default.
+    let dir5 = tempfile::tempdir().unwrap();
+    let _db5 = DbInstance::new("rocksdb", dir5.path(), "").unwrap();
+
+    // Non-rocksdb engines ignore the key entirely.
+    let _mem = DbInstance::new("mem", "", opts).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// §8.4 — validation: incoherent configs are a typed error at handle
+// construction, never a silent clamp.
+
+#[test]
+fn validation_errors() {
+    let err = RocksMemoryResources::new(RocksMemoryConfig {
+        total_bytes: 0,
+        memtable_fraction: 0.25,
+    })
+    .unwrap_err();
+    assert_eq!(err, RocksMemoryConfigError::ZeroTotalBytes);
+
+    for bad in [0.0, 1.0, -0.5, 1.5, f64::NAN] {
+        let err = RocksMemoryResources::new(RocksMemoryConfig {
+            total_bytes: 1 << 20,
+            memtable_fraction: bad,
+        })
+        .unwrap_err();
+        assert!(
+            matches!(err, RocksMemoryConfigError::MemtableFractionOutOfRange(_)),
+            "fraction {bad} must be rejected, got {err:?}"
+        );
+    }
+
+    // Strictly inside (0,1) is fine, and the default helper validates.
+    RocksMemoryResources::new(RocksMemoryConfig {
+        total_bytes: 1 << 20,
+        memtable_fraction: 0.999,
+    })
+    .unwrap();
+    RocksMemoryResources::new(RocksMemoryConfig::with_total_bytes(1 << 20)).unwrap();
+}
+
+// ---------------------------------------------------------------------------
+// §8.5 + §8.6 — an options file declaring its own block_cache still opens
+// with a handle attached; the shared cache wins and the override is logged
+// loudly with both capacities.
+
+#[test]
+fn options_file_block_cache_override_is_loud() {
+    init_capture();
+
+    let dir = tempfile::tempdir().unwrap();
+    {
+        let db = new_cozo_rocksdb(dir.path()).unwrap();
+        create_kv(&db);
+        import_rows(&db, 0, 10, 32);
+    }
+
+    // RocksDB never serialises block_cache (kDontSerialize), so patch the
+    // generated OPTIONS file to declare one, the way a tuning user would.
+    let generated = fs::read_to_string(newest_options_file(dir.path())).unwrap();
+    let bbt_header = generated
+        .lines()
+        .find(|l| l.trim_start().starts_with("[TableOptions/BlockBasedTable"))
+        .expect("generated OPTIONS file has a BlockBasedTable section")
+        .to_string();
+    let patched = generated.replace(&bbt_header, &format!("{bbt_header}\n  block_cache=4194304"));
+    fs::write(dir.path().join("options"), patched).unwrap();
+
+    let handle = RocksMemoryResources::new(RocksMemoryConfig {
+        total_bytes: 32 << 20,
+        memtable_fraction: 0.25,
+    })
+    .unwrap();
+    let db = new_cozo_rocksdb_with_memory(dir.path(), &handle).unwrap();
+
+    // The override fired and named both capacities.
+    let warnings = captured().lock().unwrap().clone();
+    let hit = warnings.iter().find(|w| {
+        w.contains("overrides the options-file block_cache")
+            && w.contains("4194304")
+            && w.contains(&(32u64 << 20).to_string())
+    });
+    assert!(
+        hit.is_some(),
+        "expected a loud override warning naming both capacities, got: {warnings:?}"
+    );
+
+    // The instance is attached to the shared cache and fully functional.
+    assert_eq!(count_kv(&db), 10);
+    import_rows(&db, 10, 100, 32);
+    assert_eq!(count_kv(&db), 110);
+    let mut ok = false;
+    for _ in 0..10 {
+        if db.rocksdb_memory_stats().block_cache_usage.unwrap() == handle.cache_usage() {
+            ok = true;
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    assert!(ok, "instance must report the shared cache's usage");
+}
+
+// §8.6 — CF-loop regression: descriptors whose table factory is absent or
+// not block-based no longer dereference null when a cache is to be attached.
+// Two expressible cases: an UNKNOWN factory name in the TableOptions section
+// (the options parser resets `table_factory` to null and carries on —
+// "deserialization is optional"), and a PlainTable factory (non-null, but
+// `GetOptions<BlockBasedTableOptions>()` returns null). The old loop
+// dereferenced both; reaching the open at all is the regression assertion,
+// and the engine's unconditional bloom-filter rebuild then restores a
+// block-based factory, so the open also succeeds.
+
+#[test]
+fn options_file_non_block_based_factory_no_crash() {
+    for replacement_header in [
+        "[TableOptions/NoSuchTableFactory \"default\"]",
+        "[TableOptions/PlainTable \"default\"]",
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        {
+            let db = new_cozo_rocksdb(dir.path()).unwrap();
+            create_kv(&db);
+            import_rows(&db, 0, 10, 32);
+        }
+
+        let generated = fs::read_to_string(newest_options_file(dir.path())).unwrap();
+        // Swap the BlockBasedTable section for the replacement factory and
+        // drop the (now-mismatched) section body.
+        let mut patched = String::new();
+        let mut in_bbt_section = false;
+        for line in generated.lines() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with('[') {
+                in_bbt_section = trimmed.starts_with("[TableOptions/BlockBasedTable");
+                if in_bbt_section {
+                    patched.push_str(replacement_header);
+                    patched.push('\n');
+                }
+            }
+            if !in_bbt_section {
+                patched.push_str(line);
+                patched.push('\n');
+            }
+        }
+        fs::write(dir.path().join("options"), patched).unwrap();
+
+        let handle = RocksMemoryResources::new(RocksMemoryConfig {
+            total_bytes: 16 << 20,
+            memtable_fraction: 0.25,
+        })
+        .unwrap();
+        // Old code: null dereference inside the CF cache-attach loop. New
+        // code: the loop skips such descriptors; whether the open then
+        // succeeds depends only on ordinary options handling.
+        match new_cozo_rocksdb_with_memory(dir.path(), &handle) {
+            Ok(db) => {
+                assert_eq!(count_kv(&db), 10);
+            }
+            Err(e) => {
+                // A clean error is acceptable; crashing is not.
+                eprintln!("open with {replacement_header} options file errored cleanly: {e:?}");
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// §8.7 — property reads on non-rocksdb backends return None, never error.
+
+#[test]
+fn non_rocksdb_property_reads_return_none() {
+    let db = DbInstance::new("mem", "", "").unwrap();
+    let stats = db.rocksdb_memory_stats();
+    assert_eq!(stats.block_cache_usage, None);
+    assert_eq!(stats.cur_size_all_mem_tables, None);
+    assert_eq!(stats.estimate_table_readers_mem, None);
+}
+
+// ---------------------------------------------------------------------------
+// §8.8 — stall posture: allow_stall=false means the WBM never wedges writers;
+// a bounded write storm over budget on two instances keeps making progress
+// (WBM-forced flushes are fine, deadlock/stall is not).
+
+#[test]
+fn write_storm_over_budget_makes_progress() {
+    // Tiny envelope: 8 MB total, 4 MB WBM budget.
+    let handle = RocksMemoryResources::new(RocksMemoryConfig {
+        total_bytes: 8 << 20,
+        memtable_fraction: 0.5,
+    })
+    .unwrap();
+    let dir_a = tempfile::tempdir().unwrap();
+    let dir_b = tempfile::tempdir().unwrap();
+    let db_a = new_cozo_rocksdb_with_memory(dir_a.path(), &handle).unwrap();
+    let db_b = new_cozo_rocksdb_with_memory(dir_b.path(), &handle).unwrap();
+    create_kv(&db_a);
+    create_kv(&db_b);
+
+    // ~4 MB per instance in interleaved batches — crosses the WBM budget
+    // several times over the storm.
+    let batches = 20i64;
+    let rows_per_batch = 200i64;
+    for batch in 0..batches {
+        let start = batch * rows_per_batch;
+        import_rows(&db_a, start, rows_per_batch, 1024);
+        import_rows(&db_b, start, rows_per_batch, 1024);
+    }
+    assert_eq!(count_kv(&db_a), (batches * rows_per_batch) as usize);
+    assert_eq!(count_kv(&db_b), (batches * rows_per_batch) as usize);
+}

--- a/cozorocks/bridge/common.h
+++ b/cozorocks/bridge/common.h
@@ -23,6 +23,7 @@ using namespace std;
 
 struct RocksDbStatus;
 struct DbOpts;
+struct DbOpenReport;
 
 typedef Status::Code StatusCode;
 typedef Status::SubCode StatusSubCode;

--- a/cozorocks/bridge/db.cpp
+++ b/cozorocks/bridge/db.cpp
@@ -54,12 +54,28 @@ ColumnFamilyOptions default_cf_options() {
     return options;
 }
 
-shared_ptr <RocksDbBridge> open_db(const DbOpts &opts, RocksDbStatus &status) {
+// Shared body of `open_db` and `open_db_with_resources` (mnestic fork,
+// docs/specs/cross-instance-memory.md §4/§7). `memory` may be null (the plain
+// `open_db` path — behavior bit-identical to before the refactor); when
+// present, its cache and WriteBufferManager are installed in both cache
+// branches and any options-file `block_cache` is overridden, with the
+// override recorded in `report` for the Rust side to log.
+static shared_ptr<RocksDbBridge>
+open_db_impl(const DbOpts &opts, const shared_ptr<RocksMemoryResources> &memory,
+             RocksDbStatus &status, DbOpenReport &report) {
     auto options = default_db_options();
 
+    const bool use_shared = memory != nullptr;
     shared_ptr<Cache> cache = nullptr;
 
-    if (opts.block_cache_size > 0) {
+    if (use_shared) {
+        // The shared cache IS the envelope: it takes precedence over the
+        // programmatic `block_cache_size` path and over any `block_cache` an
+        // options file declares (override reported below).
+        cache = memory->cache;
+        report.used_shared_resources = true;
+        report.shared_cache_capacity = memory->cache->GetCapacity();
+    } else if (opts.block_cache_size > 0) {
         // Honour the size the caller asked for. This used to hardcode 1 GiB and ignore
         // `block_cache_size` entirely, so a caller requesting 64 MB silently got sixteen
         // times that.
@@ -77,13 +93,44 @@ shared_ptr <RocksDbBridge> open_db(const DbOpts &opts, RocksDbStatus &status) {
             write_status(s, status);
             return nullptr;
         }
+        if (loaded_cf_descs.empty()) {
+            // Same defect class as the loop fix below: descriptor [0] is
+            // consumed unconditionally, so an empty descriptor list must be a
+            // loud error, not undefined behavior.
+            write_status(Status::InvalidArgument("options file contains no column family"),
+                         status);
+            return nullptr;
+        }
 
         if (cache != nullptr) {
+            // (S13 fix) This loop used to index descriptor [0] on every
+            // iteration and dereference `GetOptions<BlockBasedTableOptions>()`
+            // without the null check its sibling fix block below has — a
+            // non-block-based table factory in the options file crashed the
+            // open. Only descriptor [0] survives into the single-CF
+            // `TransactionDB::Open` below, but attach to every descriptor
+            // honestly and skip the ones that cannot carry a cache.
             for (size_t i = 0; i < loaded_cf_descs.size(); ++i) {
-                auto* loaded_bbt_opt =
-                        loaded_cf_descs[0]
-                                .options.table_factory->GetOptions<BlockBasedTableOptions>();
+                auto &cf_options = loaded_cf_descs[i].options;
+                if (cf_options.table_factory == nullptr) {
+                    continue;
+                }
+                auto *loaded_bbt_opt =
+                        cf_options.table_factory->GetOptions<BlockBasedTableOptions>();
+                if (loaded_bbt_opt == nullptr) {
+                    continue;
+                }
+                if (use_shared && i == 0 && loaded_bbt_opt->block_cache != nullptr) {
+                    // The options file declared its own cache; the shared
+                    // envelope wins. Never silently: report both capacities.
+                    report.overrode_options_file_cache = true;
+                    report.options_file_cache_capacity =
+                            loaded_bbt_opt->block_cache->GetCapacity();
+                }
                 loaded_bbt_opt->block_cache = cache;
+                if (use_shared) {
+                    loaded_bbt_opt->cache_index_and_filter_blocks_with_high_priority = true;
+                }
             }
         }
 
@@ -143,6 +190,12 @@ shared_ptr <RocksDbBridge> open_db(const DbOpts &opts, RocksDbStatus &status) {
             // whenever no options file was supplied.
             table_options.block_cache = cache;
         }
+        if (use_shared) {
+            // Index/filter blocks of participating instances go through the
+            // shared cache's high-priority pool so full memtable pressure
+            // (WBM dummy entries) evicts data blocks before metadata.
+            table_options.cache_index_and_filter_blocks_with_high_priority = true;
+        }
         options.table_factory.reset(NewBlockBasedTableFactory(table_options));
     }
     if (opts.use_capped_prefix_extractor) {
@@ -150,6 +203,12 @@ shared_ptr <RocksDbBridge> open_db(const DbOpts &opts, RocksDbStatus &status) {
     }
     if (opts.use_fixed_prefix_extractor) {
         options.prefix_extractor.reset(NewFixedPrefixTransform(opts.fixed_prefix_extractor_len));
+    }
+    if (use_shared) {
+        // One WriteBufferManager across every participating instance; its
+        // budget is charged into the shared cache (cost-to-cache dummy
+        // entries). Must be on DBOptions before TransactionDB::Open.
+        options.write_buffer_manager = memory->write_buffer_manager;
     }
     options.create_missing_column_families = true;
 
@@ -166,6 +225,24 @@ shared_ptr <RocksDbBridge> open_db(const DbOpts &opts, RocksDbStatus &status) {
 
 
     return db;
+}
+
+shared_ptr <RocksDbBridge> open_db(const DbOpts &opts, RocksDbStatus &status) {
+    // No memory handle: bit-identical to the pre-refactor body (the report is
+    // written but discarded — nothing to override without a handle).
+    DbOpenReport report{};
+    return open_db_impl(opts, nullptr, status, report);
+}
+
+shared_ptr <RocksDbBridge>
+open_db_with_resources(const DbOpts &opts, shared_ptr<RocksMemoryResources> resources,
+                       RocksDbStatus &status, DbOpenReport &report) {
+    report = DbOpenReport{};
+    return open_db_impl(opts, resources, status, report);
+}
+
+shared_ptr <RocksMemoryResources> new_memory_resources(size_t total_bytes, double memtable_fraction) {
+    return make_shared<RocksMemoryResources>(total_bytes, memtable_fraction);
 }
 
 RocksDbBridge::~RocksDbBridge() {

--- a/cozorocks/bridge/db.h
+++ b/cozorocks/bridge/db.h
@@ -13,6 +13,60 @@
 #include "common.h"
 #include "tx.h"
 #include "slice.h"
+#include "rocksdb/cache.h"
+// rocksdb/cache.h only forward-declares `Cache` in 8.8; the full class (for
+// GetCapacity/GetUsage) lives in advanced_cache.h.
+#include "rocksdb/advanced_cache.h"
+#include "rocksdb/write_buffer_manager.h"
+
+// Shared cross-instance memory resources (mnestic fork,
+// docs/specs/cross-instance-memory.md): one LRU block cache — THE cache is the
+// byte envelope (`strict_capacity_limit=false`, default high-priority pool) —
+// plus one WriteBufferManager whose memtable budget is charged INTO the cache
+// as dummy entries (cost-to-cache), so the memtable share is a carve-out of
+// the envelope, never an addition beside it. The object is immutable after
+// construction; shared_ptr copies are refcounted handles to the same live
+// cache/WBM. Input validation (nonzero total, fraction strictly in (0,1))
+// happens on the Rust side before construction.
+struct RocksMemoryResources {
+    shared_ptr<Cache> cache;
+    shared_ptr<WriteBufferManager> write_buffer_manager;
+
+    RocksMemoryResources(size_t total_bytes, double memtable_fraction)
+            : cache(NewLRUCache(total_bytes, /*num_shard_bits*/ -1,
+                                /*strict_capacity_limit*/ false,
+                                /*high_pri_pool_ratio*/ 0.5)),
+              write_buffer_manager(make_shared<WriteBufferManager>(
+                      static_cast<size_t>(static_cast<double>(total_bytes) * memtable_fraction),
+                      cache,
+                      /*allow_stall*/ false)) {}
+
+    inline uint64_t wbm_memory_usage() const {
+        return write_buffer_manager->memory_usage();
+    }
+
+    inline uint64_t wbm_mutable_memtable_memory_usage() const {
+        return write_buffer_manager->mutable_memtable_memory_usage();
+    }
+
+    inline uint64_t wbm_dummy_entries_in_cache_usage() const {
+        return write_buffer_manager->dummy_entries_in_cache_usage();
+    }
+
+    inline uint64_t wbm_buffer_size() const {
+        return write_buffer_manager->buffer_size();
+    }
+
+    inline uint64_t cache_capacity() const {
+        return cache->GetCapacity();
+    }
+
+    inline uint64_t cache_usage() const {
+        return cache->GetUsage();
+    }
+};
+
+shared_ptr<RocksMemoryResources> new_memory_resources(size_t total_bytes, double memtable_fraction);
 
 struct SnapshotBridge {
     const Snapshot *snapshot;
@@ -191,10 +245,41 @@ struct RocksDbBridge {
         return db->GetBaseDB();
     }
 
+    // Int-property read on the base DB (mnestic fork,
+    // docs/specs/cross-instance-memory.md §5). Follows the status-out-param
+    // convention: kNotFound is written when RocksDB does not recognise the
+    // property (or has no value for it), kAborted when the DB handle is gone.
+    inline uint64_t get_int_property(rust::Str name, RocksDbStatus &status) const {
+        if (db == nullptr) {
+            write_status(Status::Aborted("database handle is closed"), status);
+            return 0;
+        }
+        uint64_t value = 0;
+        string name_(name);
+        if (get_base_db()->GetIntProperty(name_, &value)) {
+            write_status(Status::OK(), status);
+        } else {
+            write_status(Status::NotFound("unknown or unavailable int property", name_), status);
+        }
+        return value;
+    }
+
     ~RocksDbBridge();
 };
 
 shared_ptr<RocksDbBridge>
 open_db(const DbOpts &opts, RocksDbStatus &status);
+
+// Open with a shared cross-instance memory handle (mnestic fork,
+// docs/specs/cross-instance-memory.md §4): same body as `open_db` via a shared
+// install helper, but the handle's cache is installed as the block cache in
+// both cache branches — OVERRIDING any `block_cache` the options file declares
+// (reported via `report` so the Rust side can log it; a live shared object
+// cannot be expressed in an INI file, so overriding is correct — silence about
+// it is not) — and the handle's WriteBufferManager is installed on DBOptions
+// before `TransactionDB::Open`.
+shared_ptr<RocksDbBridge>
+open_db_with_resources(const DbOpts &opts, shared_ptr<RocksMemoryResources> resources,
+                       RocksDbStatus &status, DbOpenReport &report);
 
 #endif //COZOROCKS_DB_H

--- a/cozorocks/src/bridge/db.rs
+++ b/cozorocks/src/bridge/db.rs
@@ -132,7 +132,186 @@ impl DbBuilder {
             Err(status)
         }
     }
+
+    /// Open with a shared cross-instance memory handle (mnestic fork,
+    /// docs/specs/cross-instance-memory.md §4). The handle's cache and
+    /// WriteBufferManager are installed on this instance; any `block_cache`
+    /// the options file declares is overridden, which the returned
+    /// [`DbOpenReport`] records so the caller can log it loudly.
+    pub fn build_with_memory(
+        self,
+        memory: &RocksMemoryResources,
+    ) -> Result<(RocksDb, DbOpenReport), RocksDbStatus> {
+        let mut status = RocksDbStatus::default();
+        let mut report = DbOpenReport::default();
+
+        let result =
+            open_db_with_resources(&self.opts, memory.inner.clone(), &mut status, &mut report);
+        if status.is_ok() {
+            Ok((RocksDb { inner: result }, report))
+        } else {
+            Err(status)
+        }
+    }
 }
+
+/// Configuration for a shared cross-instance memory envelope (mnestic fork,
+/// docs/specs/cross-instance-memory.md §3). `total_bytes` is THE envelope: one
+/// LRU block cache of this capacity is shared by every participating
+/// instance, and the WriteBufferManager's budget
+/// (`total_bytes * memtable_fraction`) is charged INTO that cache as dummy
+/// entries (cost-to-cache) — a carve-out of the envelope, not an addition
+/// beside it. Under full memtable pressure, block/index capacity degrades
+/// toward `total_bytes * (1 - memtable_fraction)`.
+///
+/// Charged into the envelope: data blocks, index/filter blocks (high-priority
+/// pool), memtable bytes (as WBM dummy entries). NOT charged: table-reader
+/// memory outside the cache, WAL, allocator retention, iterators/pinned
+/// blocks beyond cache accounting, and everything non-RocksDB. This is a
+/// soft, RocksDB-managed envelope, not a whole-process memory limit.
+///
+/// Pinned in v1 (not configurable): `strict_capacity_limit=false`,
+/// `high_pri_pool_ratio` = RocksDB default (0.5),
+/// `cache_index_and_filter_blocks_with_high_priority=true` on participating
+/// instances, `allow_stall=false`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RocksMemoryConfig {
+    /// Total size of the envelope in bytes. Must be nonzero.
+    pub total_bytes: usize,
+    /// Fraction of the envelope carved out for memtables (the
+    /// WriteBufferManager's buffer size). Must lie strictly within (0, 1) —
+    /// strictly below 1 so block/index capacity survives full memtable
+    /// pressure. Default: [`Self::DEFAULT_MEMTABLE_FRACTION`].
+    pub memtable_fraction: f64,
+}
+
+impl RocksMemoryConfig {
+    /// Default memtable carve-out when only a total budget is given.
+    pub const DEFAULT_MEMTABLE_FRACTION: f64 = 0.25;
+
+    /// A config with the default memtable carve-out.
+    pub fn with_total_bytes(total_bytes: usize) -> Self {
+        Self {
+            total_bytes,
+            memtable_fraction: Self::DEFAULT_MEMTABLE_FRACTION,
+        }
+    }
+
+    /// Explicit and total validation: incoherent configs are a typed error at
+    /// handle construction, never a silent clamp.
+    pub fn validate(&self) -> Result<(), RocksMemoryConfigError> {
+        if self.total_bytes == 0 {
+            return Err(RocksMemoryConfigError::ZeroTotalBytes);
+        }
+        if !(self.memtable_fraction > 0.0 && self.memtable_fraction < 1.0) {
+            return Err(RocksMemoryConfigError::MemtableFractionOutOfRange(
+                self.memtable_fraction,
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Typed validation error for [`RocksMemoryConfig`].
+#[derive(Debug, Clone, PartialEq)]
+pub enum RocksMemoryConfigError {
+    /// `total_bytes` must be nonzero.
+    ZeroTotalBytes,
+    /// `memtable_fraction` must lie strictly within (0, 1); carries the
+    /// rejected value. (NaN is rejected by the same comparison.)
+    MemtableFractionOutOfRange(f64),
+}
+
+impl std::fmt::Display for RocksMemoryConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RocksMemoryConfigError::ZeroTotalBytes => {
+                write!(f, "shared memory config: total_bytes must be nonzero")
+            }
+            RocksMemoryConfigError::MemtableFractionOutOfRange(v) => write!(
+                f,
+                "shared memory config: memtable_fraction must lie strictly within (0, 1), got {v}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for RocksMemoryConfigError {}
+
+/// A live shared cross-instance memory handle (mnestic fork,
+/// docs/specs/cross-instance-memory.md §3): one LRU block cache + one
+/// WriteBufferManager charged into it, constructed once from a validated
+/// [`RocksMemoryConfig`]. Clones are refcounted handles to the same live
+/// objects; the handle is immutable after construction. Pass it to
+/// [`DbBuilder::build_with_memory`] for every instance that should share the
+/// envelope.
+#[derive(Clone)]
+pub struct RocksMemoryResources {
+    pub(crate) inner: SharedPtr<crate::bridge::ffi::RocksMemoryResources>,
+    config: RocksMemoryConfig,
+}
+
+impl RocksMemoryResources {
+    /// Validates `config` and constructs the shared cache + WriteBufferManager.
+    pub fn new(config: RocksMemoryConfig) -> Result<Self, RocksMemoryConfigError> {
+        config.validate()?;
+        let inner = new_memory_resources(config.total_bytes, config.memtable_fraction);
+        Ok(Self { inner, config })
+    }
+
+    /// The canonical config this handle was constructed from.
+    pub fn config(&self) -> &RocksMemoryConfig {
+        &self.config
+    }
+
+    /// Total memory used by memtables under this WriteBufferManager (bytes).
+    pub fn memory_usage(&self) -> u64 {
+        self.inner.wbm_memory_usage()
+    }
+
+    /// Memory used by active (mutable) memtables (bytes).
+    pub fn mutable_memtable_memory_usage(&self) -> u64 {
+        self.inner.wbm_mutable_memtable_memory_usage()
+    }
+
+    /// Bytes the WriteBufferManager has charged into the shared cache as
+    /// dummy entries (the cost-to-cache carve-out, visible inside
+    /// [`Self::cache_usage`]).
+    pub fn dummy_entries_in_cache_usage(&self) -> u64 {
+        self.inner.wbm_dummy_entries_in_cache_usage()
+    }
+
+    /// The WriteBufferManager's budget (`total_bytes * memtable_fraction`).
+    pub fn buffer_size(&self) -> u64 {
+        self.inner.wbm_buffer_size()
+    }
+
+    /// The shared cache's capacity — the envelope (`total_bytes`).
+    pub fn cache_capacity(&self) -> u64 {
+        self.inner.cache_capacity()
+    }
+
+    /// The shared cache's current usage (real blocks + WBM dummy entries).
+    pub fn cache_usage(&self) -> u64 {
+        self.inner.cache_usage()
+    }
+}
+
+impl std::fmt::Debug for RocksMemoryResources {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RocksMemoryResources")
+            .field("config", &self.config)
+            .finish_non_exhaustive()
+    }
+}
+
+// SAFETY: the handle only wraps `std::shared_ptr`s to RocksDB's `Cache` and
+// `WriteBufferManager`, both of which are internally synchronised and
+// explicitly designed to be shared across DB instances and threads; the
+// shared_ptr control block is thread-safe. Same discipline as `RocksDb`.
+unsafe impl Send for RocksMemoryResources {}
+
+unsafe impl Sync for RocksMemoryResources {}
 
 #[derive(Clone)]
 pub struct RocksDb {
@@ -204,6 +383,36 @@ impl RocksDb {
         } else {
             Err(status)
         }
+    }
+    /// Int-property read on the base DB (mnestic fork,
+    /// docs/specs/cross-instance-memory.md §5). Errors with `kNotFound` when
+    /// RocksDB does not recognise the property or has no value for it.
+    fn int_property(&self, name: &str) -> Result<u64, RocksDbStatus> {
+        let mut status = RocksDbStatus::default();
+        let value = self.inner.get_int_property(name, &mut status);
+        if status.is_ok() {
+            Ok(value)
+        } else {
+            Err(status)
+        }
+    }
+    /// `rocksdb.block-cache-usage`: memory size of the entries residing in
+    /// this instance's block cache (with a shared handle this is the SHARED
+    /// cache's usage, including the WriteBufferManager's dummy entries — every
+    /// participating instance reports the same value).
+    pub fn block_cache_usage(&self) -> Result<u64, RocksDbStatus> {
+        self.int_property("rocksdb.block-cache-usage")
+    }
+    /// `rocksdb.cur-size-all-mem-tables`: approximate size of this instance's
+    /// active and unflushed immutable memtables (bytes).
+    pub fn cur_size_all_mem_tables(&self) -> Result<u64, RocksDbStatus> {
+        self.int_property("rocksdb.cur-size-all-mem-tables")
+    }
+    /// `rocksdb.estimate-table-readers-mem`: estimated memory this instance
+    /// uses for reading SST tables, EXCLUDING block cache (this share is NOT
+    /// charged into the shared envelope).
+    pub fn estimate_table_readers_mem(&self) -> Result<u64, RocksDbStatus> {
+        self.int_property("rocksdb.estimate-table-readers-mem")
     }
 }
 

--- a/cozorocks/src/bridge/mod.rs
+++ b/cozorocks/src/bridge/mod.rs
@@ -51,6 +51,26 @@ pub(crate) mod ffi {
         pub message: String,
     }
 
+    /// What an open did with a shared memory handle (mnestic fork,
+    /// docs/specs/cross-instance-memory.md §4). Filled by
+    /// `open_db_with_resources`; the interesting bit is the loud override:
+    /// when the options file declared its own `block_cache`, the shared cache
+    /// wins and both capacities are reported so the caller can log them.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct DbOpenReport {
+        /// A shared memory handle was installed on this open.
+        pub used_shared_resources: bool,
+        /// The `<path>/options` file declared a `block_cache`, which the
+        /// shared cache overrode.
+        pub overrode_options_file_cache: bool,
+        /// Capacity (bytes) of the cache the options file declared; only
+        /// meaningful when `overrode_options_file_cache` is true.
+        pub options_file_cache_capacity: u64,
+        /// Capacity (bytes) of the shared cache that was installed; only
+        /// meaningful when `used_shared_resources` is true.
+        pub shared_cache_capacity: u64,
+    }
+
     #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     pub enum StatusCode {
         kOk = 0,
@@ -144,9 +164,37 @@ pub(crate) mod ffi {
             status: &mut RocksDbStatus,
         ) -> &'a [u8];
 
+        /// Shared cross-instance memory resources (mnestic fork,
+        /// docs/specs/cross-instance-memory.md): one LRU block cache (the
+        /// envelope) + one WriteBufferManager charged into it. Opaque;
+        /// crosses only as a `SharedPtr` function argument, never as a
+        /// `DbOpts` field.
+        type RocksMemoryResources;
+        fn new_memory_resources(
+            total_bytes: usize,
+            memtable_fraction: f64,
+        ) -> SharedPtr<RocksMemoryResources>;
+        fn wbm_memory_usage(self: &RocksMemoryResources) -> u64;
+        fn wbm_mutable_memtable_memory_usage(self: &RocksMemoryResources) -> u64;
+        fn wbm_dummy_entries_in_cache_usage(self: &RocksMemoryResources) -> u64;
+        fn wbm_buffer_size(self: &RocksMemoryResources) -> u64;
+        fn cache_capacity(self: &RocksMemoryResources) -> u64;
+        fn cache_usage(self: &RocksMemoryResources) -> u64;
+
         type RocksDbBridge;
         fn get_db_path(self: &RocksDbBridge) -> &CxxString;
         fn open_db(builder: &DbOpts, status: &mut RocksDbStatus) -> SharedPtr<RocksDbBridge>;
+        fn open_db_with_resources(
+            builder: &DbOpts,
+            resources: SharedPtr<RocksMemoryResources>,
+            status: &mut RocksDbStatus,
+            report: &mut DbOpenReport,
+        ) -> SharedPtr<RocksDbBridge>;
+        fn get_int_property(
+            self: &RocksDbBridge,
+            name: &str,
+            status: &mut RocksDbStatus,
+        ) -> u64;
         fn transact(self: &RocksDbBridge) -> UniquePtr<TxBridge>;
         fn snapshot_read(self: &RocksDbBridge) -> UniquePtr<SnapshotReadBridge>;
         fn del_range(self: &RocksDbBridge, lower: &[u8], upper: &[u8], status: &mut RocksDbStatus);
@@ -233,6 +281,18 @@ impl Default for ffi::RocksDbStatus {
             subcode: ffi::StatusSubCode::kNone,
             severity: ffi::StatusSeverity::kNoError,
             message: "".to_string(),
+        }
+    }
+}
+
+impl Default for ffi::DbOpenReport {
+    #[inline]
+    fn default() -> Self {
+        ffi::DbOpenReport {
+            used_shared_resources: false,
+            overrode_options_file_cache: false,
+            options_file_cache_capacity: 0,
+            shared_cache_capacity: 0,
         }
     }
 }

--- a/cozorocks/src/lib.rs
+++ b/cozorocks/src/lib.rs
@@ -11,7 +11,11 @@
 
 pub use bridge::db::DbBuilder;
 pub use bridge::db::RocksDb;
+pub use bridge::db::RocksMemoryConfig;
+pub use bridge::db::RocksMemoryConfigError;
+pub use bridge::db::RocksMemoryResources;
 pub use bridge::db::SnapReader;
+pub use bridge::ffi::DbOpenReport;
 pub use bridge::ffi::RocksDbStatus;
 pub use bridge::ffi::SnapshotBridge;
 pub use bridge::ffi::StatusCode;


### PR DESCRIPTION
Implements the signed [cross-instance-memory spec](docs/specs/cross-instance-memory.md): one shared LRU cache **is** the envelope (`NewLRUCache(total)`), memtable memory charges into it via the WriteBufferManager cost-to-cache carve-out (`total × memtable_fraction`, `allow_stall=false`, high-pri index/filter pool on), carried by an opaque refcounted `RocksMemoryResources` handle crossing cxx as a `SharedPtr` function argument. `open_db`'s body refactors into a shared helper (signature unchanged); `open_db_with_resources` joins it; the CF loop is fixed (`[i]`, null checks, plus an empty-descriptor guard in the same defect class). Engine side: `new_cozo_rocksdb_with_memory`, the conflict-checked `shared_memory` process default reachable from the options JSON (typed conflict naming both configs — never first-writer-wins), three per-instance property reads + handle-level WBM/cache metrics (all-`None` off rocksdb), and a loud `log::warn!` when the handle overrides an options-file cache (transported via a `DbOpenReport` bridge struct; tested via log capture).

No version bumps (bank-don't-cut); the changelog carries the mnestic-rocks-publishes-first note. All bridge/Rust additions are additive — 0.1.11 at release per the signed Q5.

Deviations recorded in the agent build report: private serde mirror for the JSON config (cozorocks stays dependency-free), the empty-descriptor guard, **strict parsing of the rocksdb `options` JSON** (malformed input now errors instead of being silently ignored — `""`/`"{}"` unchanged), one untestable matrix item (closed-instance property reads — covered by the bridge null check), and two test-discovery adjustments (RocksDB never serializes `block_cache`, so the override test patches a generated OPTIONS file; the CF-loop test covers null-factory and PlainTable descriptors).

Tests: 8-test §8 matrix green on first run; lib 357 green; existing rocksdb storage tests untouched (bit-parity); clippy clean on the CI gate and the rocksdb/test matrix; combined run with the two just-landed features green (8+15+11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)