### PR TITLE
Reconcile Parquet import delivery status

### DIFF
--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -21,8 +21,11 @@ provenance and licensing.
   measured macOS arm64 ABI3 wheel delta is +1,711,642 bytes (+14.92%), and a
   clean source archive builds and exposes the method. Independent PyArrow
   fixtures cover canonical extensions, delta dictionaries, encrypted Parquet,
-  checksums, and a 500,000-row GIL-release smoke. Hosted cross-platform CI is
-  still required before merge.
+  checksums, and a 500,000-row GIL-release smoke. Hosted engine CI passed on
+  PR #51, and the publication-disabled Python build matrix passed on Linux
+  x86/ARM, macOS x86/ARM, and Windows with wheel smoke tests plus the sdist
+  (`python-publish` run 32287514329). Batch A is merged but unreleased; Arrow
+  export remains a separate, unmerged Batch B review unit.
 
 ## 0.16.0 — 2026-08-18
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ Every item is judged against that goal — and described as a general database m
 
 ## Unreleased on main
 
-- **Parquet / Arrow copy-in — Batch A implemented, pending hosted CI/merge** ([#11](https://github.com/shuruheel/mnestic/issues/11), [approved spec](docs/specs/parquet-arrow.md)): the off-by-default `columnar-io` feature adds whole-file-atomic, row-chunked import from one local Parquet or Arrow IPC file into an existing non-`TxTime` relation. The target schema stays authoritative; unsupported logical meaning and lossy numeric conversions fail closed; the host API exposes explicit timeout and source/row/batch/value/nesting ceilings. Local SQLite, real RocksDB, Python wheel/sdist, independent PyArrow, feature-isolation, and lint gates pass. Arrow export remains Batch B and requires a separate owner sign-off.
+- **Parquet / Arrow copy-in — Batch A merged on `main`, pending release** ([#11](https://github.com/shuruheel/mnestic/issues/11), [approved spec](docs/specs/parquet-arrow.md), [PR #51](https://github.com/shuruheel/mnestic/pull/51)): the off-by-default `columnar-io` feature adds whole-file-atomic, row-chunked import from one local Parquet or Arrow IPC file into an existing non-`TxTime` relation. The target schema stays authoritative; unsupported logical meaning and lossy numeric conversions fail closed; the host API exposes explicit timeout and source/row/batch/value/nesting ceilings. Local SQLite, real RocksDB, independent PyArrow, feature-isolation, lint, hosted engine CI, and build-only Python wheel/sdist matrices pass. No Mnestic release contains this work yet. Arrow export remains separately gated Batch B work and is not merged.
 
 ## What's released through 0.16.0
 
@@ -97,7 +97,7 @@ Tiered by value and readiness. This is direction, not a dated commitment. Stored
 - **Extending the Cypher-read surface** — variable-length paths, `OPTIONAL MATCH`, `WITH`, and undirected relationships (today these return explicit not-yet-supported errors). Spec: [`docs/specs/cypher-read.md`](docs/specs/cypher-read.md).
 - **A first-class ULID type and sortable auto-keys** ([#8](https://github.com/shuruheel/mnestic/issues/8), `priority: low`; the scalar functions already ship, the type/default syntax does not).
 - **An official schema-migration tool** ([#10](https://github.com/shuruheel/mnestic/issues/10), design-first) — versioned schema, diff, apply, and rollback.
-- **Parquet/Arrow ingestion and Arrow export** ([#11](https://github.com/shuruheel/mnestic/issues/11), `priority: high`) — Batch A's feature-gated, atomic chunked import is implemented under the [approved D1–D11 contract](docs/specs/parquet-arrow.md), pending hosted CI and merge; record-batch and Python Arrow-buffer handoff remain separately gated Batch B work.
+- **Parquet/Arrow ingestion and Arrow export** ([#11](https://github.com/shuruheel/mnestic/issues/11), `priority: high`) — Batch A's feature-gated, atomic chunked import is merged on `main` under the [approved D1–D11 contract](docs/specs/parquet-arrow.md) and pending release; record-batch export and Python Arrow-buffer handoff remain separately gated, unmerged Batch B work.
 
 ### Integrations — meeting people where they already are
 

--- a/docs/specs/parquet-arrow.md
+++ b/docs/specs/parquet-arrow.md
@@ -1,6 +1,6 @@
 # Spec — Parquet / Arrow boundary I/O: atomic, chunked copy-in first; record-batch copy-out second
 
-_Created 2026-08-18. Status: **BATCH A IMPLEMENTED — D1–D11 signed by the owner 2026-08-18; local Rust, SQLite, RocksDB, Python wheel/sdist, and interoperability gates passed; hosted cross-platform CI remains pending.** Tracks [issue #11](https://github.com/shuruheel/mnestic/issues/11). Batch B export retains its separate sign-off gate in §8 and §11._
+_Created 2026-08-18. Status: **BATCH A MERGED — D1–D11 signed by the owner 2026-08-18; local Rust, SQLite, RocksDB, Python wheel/sdist, and interoperability gates passed; hosted engine CI passed on PR #51; the publication-disabled cross-platform Python wheel/sdist matrix passed in run 32287514329. The feature remains unreleased.** Tracks [issue #11](https://github.com/shuruheel/mnestic/issues/11). Batch B export retains its separate sign-off gate in §8 and §11 and is not merged._
 
 ## 1. Outcome and scope
 


### PR DESCRIPTION
## What changed

- records Parquet/Arrow Batch A import as merged on main and pending release
- records the successful publication-disabled cross-platform Python package matrix
- keeps Arrow export explicitly separate, unmerged, and subject to its own Batch B sign-off

## Why

The implementation PR and hosted package evidence are complete, but the public roadmap, changelog, and specification still described hosted CI and merge as pending.

## Impact

Documentation now distinguishes merged-but-unreleased import support from the unfinished Arrow-export feature. No runtime code or release artifacts change.

## Validation

- git diff --check
- PR #51 hosted CI passed
- python-publish run 32287514329 passed across Linux x86/ARM, macOS x86/ARM, Windows, sdist, and wheel smoke tests with all publish jobs skipped