### PR TITLE
fix: keep JSON object pairing Clippy-clean

### DIFF
--- a/cozo-core/src/data/functions.rs
+++ b/cozo-core/src/data/functions.rs
@@ -194,7 +194,7 @@ pub(crate) fn op_json_object(args: &[DataValue]) -> Result<DataValue> {
         "json_object requires an even number of arguments"
     );
     let mut obj = serde_json::Map::with_capacity(args.len() / 2);
-    for pair in args.chunks_exact(2) {
+    for pair in args.chunks(2) {
         let key = val2str(&pair[0]);
         let value = to_json(&pair[1]);
         obj.insert(key.to_string(), value);


### PR DESCRIPTION
## Summary

- avoid the Rust 1.98 `chunks_exact_to_as_chunks` lint in JSON object construction
- preserve the Rust 1.85-compatible slice API and exact-pair semantics guaranteed by the existing even-length check

## Verification

- `cargo test -p mnestic test_json_objects --lib`
- `cargo clippy -p mnestic --all-targets -- -D warnings`
- `git diff --check`