### PR TITLE
docs: DRAFT specs for #53 string literals and #54 canonical JSON conversion

### DIFF
--- a/docs/specs/json-canonical.md
+++ b/docs/specs/json-canonical.md
@@ -1,0 +1,342 @@
+# Spec — Canonical DataValue→JSON conversion: one representation at every nesting depth (mnestic #54)
+
+_Created 2026-08-28. Status: **DRAFT — awaiting owner review**. Tracks [issue #54](https://github.com/shuruheel/mnestic/issues/54) (upstream [cozodb/cozo#269](https://github.com/cozodb/cozo/issues/269)). Roadmap gate, quoted verbatim from [`docs/strategy/MNESTIC-ROADMAP.md:33`](../../../docs/strategy/MNESTIC-ROADMAP.md): `| 5 | Canonical nested JSON conversion (#54) | Ready for design | 2 | 4 | Compatibility contract before output changes |`. A spec never self-approves._
+
+**Provenance (all five passes run, 2026-08-28):** Pass 1 grounding (3 lenses) · Pass 2 lean draft · Pass 3 adversarial panel — 26 findings (3 blocker, 9 major, 14 minor; 5 are duplicates of an earlier finding), **26 folded, 0 rejected**, triage in §7 · Pass 4 prior art — 13 decision verdicts (9 CONFIRMS, 1 CONTRADICTS, 3 GAP) plus one essential omission, all folded and cited at the decision · Pass 5 simplification — 6 requirement-neutral cuts applied (§7), 2 owner rulings listed below. **Blockers still open: 0.** A second probe binary confirmed every panel-predicted value (§2 rows marked *(probe)*).
+
+**Owner rulings requested (not applied — each amends a premise outside this spec):**
+
+1. **Release placement.** Proposed 0.18.0 (§D5). Alternative: bank into 0.17.0, which is merged but unreleased and whose verify gate is still ahead of it (`MNESTIC-ROADMAP.md:29`, `versions.toml:28` = 0.16.0).
+2. **NaN.** This spec keeps NaN → `null` at every depth so no top-level form changes except `Bot`. Prior art treats the non-finite family uniformly (Postgres `"NaN"`/`"Infinity"`/`"-Infinity"`); switching to `"NAN"` would be a second deliberate top-level change (§7).
+
+## 1. Outcome and scope
+
+Every `DataValue` that crosses the JSON boundary gets **one** representation, and that representation does not depend on whether the value is a top-level result cell, a member of a `{..}` map literal, an element of a nested list, the payload of `json()` / `json_object()` / `set_json_path()` / `to_string()`, or a value coerced into a `Json` column by `:put`.
+
+This is a serialization contract, not a type system:
+
+- **One outbound seam.** The recursive helper in `data/functions.rs` and the hand-rolled `ColType::Json` coercion arm in `data/relation.rs` are deleted; the `data/json.rs` conversion becomes the only DataValue→JSON policy in the engine (D2).
+- **Top-level forms are already the contract.** Every host surface (HTTP, C, wasm, Java, Swift, embedded Rust) already emits the `json.rs` policy through `NamedRows::into_json`. The canonical table (D1) therefore *is* today's top-level table, with one deliberate change (`Bot`). The observable change is confined to nested values, `to_string()`, JSON keys derived from non-string values, and what `:put` stores in a `Json` column from now on.
+- **One-way.** JSON→DataValue is declared lossy and left as it is (D3). No type sniffing is added on the way back.
+- **Engine-only.** mindgraph-rs keeps its own snapshot converter, pinned by one test but not rewritten (D4, D8). Native bindings' non-JSON value conversions are out of scope (D1 scope note).
+- **Compatibility contract first.** D5 is the deliverable the roadmap gate names; the code change is Batch A and cannot merge before D5 is owner-approved.
+
+**Worked example — the issue script, before and after** (probe output, 2026-08-28; the `after` column is what D1 + D2 require):
+
+| Cell | Before (today) | After |
+|---|---|---|
+| `x = to_uuid("a6bba931-e2a6-4040-8816-2b33603acf84")` | `"a6bba931-e2a6-4040-8816-2b33603acf84"` | unchanged |
+| `m = {"x": x}` | `{"x":[166,187,169,49,226,166,64,64,136,22,43,51,96,58,207,132]}` | `{"x":"a6bba931-e2a6-4040-8816-2b33603acf84"}` |
+| `s = to_string(x)` (57 chars today) | `"[166,187,169,49,226,166,64,64,136,22,43,51,96,58,207,132]"` | `"a6bba931-e2a6-4040-8816-2b33603acf84"` (36 chars, no quotes) |
+| `{x: 1}` / `json_object(x, 1)` (key from a Uuid) | `{"[166,187,…,132]":1}` | `{"a6bba931-e2a6-4040-8816-2b33603acf84":1}` |
+| `b = decode_base64("AQID")` / `{"b": b}` | `"AQID"` / `{"b":[1,2,3]}` | `"AQID"` / `{"b":"AQID"}` |
+| `i = 1.0/0.0` / `{"inf": i, "ninf": -i, "nan": 0.0/0.0}` | `"INFINITY"` / `{"inf":null,"nan":null,"ninf":null}` | `"INFINITY"` / `{"inf":"INFINITY","nan":null,"ninf":"NEGATIVE_INFINITY"}` |
+| `:put r {k => j}` with `j = x` into a `Json` column, read back | `[166,187,…,132]` | `"a6bba931-e2a6-4040-8816-2b33603acf84"` (new rows only — D5) |
+| `vld` from a `Validity` column / `{"vld": vld}` | `[1787956506172712,true]` / same | unchanged |
+| `vec([0.1])` / `{"v": ..}` | `[0.10000000149011612]` / same | unchanged (F32 widened to f64; D1) |
+
+Effort/impact per the roadmap row: 2 / 4. The change is a few dozen lines of engine code plus tests; the value is in the contract and the migration note.
+
+## 2. Verified current state (2026-08-28)
+
+Every row was checked against the working tree today. Rows marked *(probe)* were additionally observed by running a throwaway binary against `cozo-core` (mem backend, `run_script` → `into_json`); the probe lives in the session scratchpad and left no footprint in the repo.
+
+| Current fact | Where | Consequence |
+|---|---|---|
+| `DataValue` has exactly 13 variants: `Null, Bool, Num, Str, Bytes, Uuid, Regex, List, Set, Vec, Json, Validity, Bot`; `Regex`, `Set`, `Bot` are documented "used internally only" | [`cozo-core/src/data/value.rs:146-174`](../../cozo-core/src/data/value.rs) | Fixes the row set of D1; three rows are internal-only and need a form but no user-facing promise |
+| `DataValue` and `NamedRows` derive `serde::Serialize` (the storage/wire encoding, externally-tagged enum form); cozo-bin's REPL prints `params` through it | [`value.rs:143-145`](../../cozo-core/src/data/value.rs), [`runtime/db.rs:263`](../../cozo-core/src/runtime/db.rs), [`cozo-bin/src/repl.rs:238`](../../cozo-bin/src/repl.rs) | A latent third JSON form exists in the type system; Invariant 2 declares it not a JSON boundary rather than pretending it is absent |
+| `Set` is a `BTreeSet<DataValue>`, iterated in `Ord` order | [`value.rs:165`](../../cozo-core/src/data/value.rs) | JSON array order for sets is deterministic |
+| Top-level policy: `impl From<DataValue> for JsonValue` — Uuid `json!(u.0)` (string), Bytes base64 `String`, Float NaN→`null` / ±∞→`"INFINITY"`/`"NEGATIVE_INFINITY"`, `Bot` → `panic!("found bottom")`, Vec `json!(a.as_slice().unwrap())`, Validity `json!([v.timestamp.0, v.is_assert])`, Json `j.0` pass-through, List/Set arrays with per-element `.clone()` | [`cozo-core/src/data/json.rs:55-101`](../../cozo-core/src/data/json.rs) (Float 61-75, Bytes 77, List 78-80, Bot 81, Set 82-84, Regex 85-87, Uuid 88-90, Vec 91-94, Validity 95-97, Json 98) | Survivor seam (D2); two panic paths (`Bot`, `as_slice().unwrap()`) to remove |
+| `uuid` is built with the `serde` feature, so `json!(u.0)` is the hyphenated string; `serde_json` is pulled with no features (no `preserve_order`, so object keys serialize in `BTreeMap` order) | [`cozo-core/Cargo.toml:139, 163`](../../cozo-core/Cargo.toml) | D1 Uuid row; Invariant 3 is stated as value identity, not byte identity |
+| Nested policy #1: `fn to_json(&DataValue)` — Uuid `json!(u.0.as_bytes())` (16-int array), Bytes `json!(b)` (int array), Float bare `json!(f)`, `Bot` → `null`, Validity `[vld.timestamp.0, vld.is_assert.0]`, Json `j.0.clone()`, List/Set/Vec element-wise | [`cozo-core/src/data/functions.rs:205-271`](../../cozo-core/src/data/functions.rs) (Float 217-219, Bytes 224-226, Uuid 227-229, Set 240-246, Vec 247-262, Json 263, Validity 264-266, Bot 267-269) | Root cause of #54; to be deleted (D2) |
+| **Nested policy #2: the `ColType::Json` arm of `coerce`** — the `:put`/`:insert`/import write path for `Json` columns — hand-rolls the same nested forms (`Uuid => json!(u.0.as_bytes())`, `Bytes => json!(b)`, `Float => json!(f)`, Validity `[ts, is_assert]`, `Bot => null`); List/Set elements recurse through `self.coerce` | [`cozo-core/src/data/relation.rs:440-504`](../../cozo-core/src/data/relation.rs); external callers of `.coerce(`: `runtime/db.rs:1254,1313,1325,2663,2964` (the last two are the import/restore key-coercion paths), `query/stored.rs:2197,2200`, `runtime/columnar.rs:460`, `parse/sys.rs:593`, `runtime/stored_queries.rs:233`, `fixed_rule/utilities/csv.rs:62`, `data/program.rs:1542`; internal recursions at `relation.rs:259, 340, 470, 477` | The path that **persists** the old form; a third independent match body, to be deleted (D2). Reached by `:put`, `:create … default`, stored-query defaults, Parquet import, CSV typing |
+| *(probe)* `:create r {k: Int => j: Json}` then `:put` of `to_uuid(..)`, `decode_base64("AQID")`, `1.0/0.0`, `vec([0.1])`, and `[uuid, bytes]` → stored `[166,187,…]`, `[1,2,3]`, `null`, `[0.10000000149011612]`, `[[166,…],[1,2,3]]` | probe, 2026-08-28 | Old forms are on disk in any `Json` column written this way; D5 items 4-5 and the migration note say so |
+| `to_json` call sites: `op_json` (83), `op_set_json_path` (88, 93), `op_remove_json_path` (163), `op_json_object` (199), `val2str` (2091) | [`functions.rs:81-96, 161-188, 190-203, 2086-2094`](../../cozo-core/src/data/functions.rs) | Six call-site edits in one file, plus the `relation.rs` arm |
+| JSON **keys** are derived by `val2str`: `json_object` keys (198), `{..}` literal keys (parse builds each key with `build_expr`, then `OP_JSON_OBJECT`), object path elements in `get_json_path` (105, 137) and `remove_json_path` (173) | [`functions.rs:105, 137, 173, 198`](../../cozo-core/src/data/functions.rs), [`cozo-core/src/parse/expr.rs:280-295`](../../cozo-core/src/parse/expr.rs) | A Uuid/Bytes key changes text with D2 — in the contract (D5 item 3) |
+| `val2str` has three arms: `Str(s)` → raw `s`; `Json(JsonValue::String(s))` → raw `s`; every other variant → `to_json(v).to_string()` — the serialized JSON **literal**, so a `JsonValue::String` would come back with surrounding quotes | [`functions.rs:2086-2094`](../../cozo-core/src/data/functions.rs) | The `val2str` site is not a plain swap (D2 step 3); `to_string("a")` is `a`, not `"a"` (Invariant 1 carve-out) |
+| *(probe)* `?[x,m,s] := x = to_uuid("a6bb…"), m = {"x": x}, s = to_string(x)` → `x = "a6bba931-…"`, `m = {"x":[166,187,169,…]}`, `s = "[166,187,…]"` (`length(s)` = 57); `json_object(x, 1)`, `{x: 1}` → `{"[166,…,132]":1}`; `remove_json_path({"a":1, x: 2}, [x])` → `{"a":1}` | probe | Issue #54 reproduced; keys confirmed depth-dependent |
+| *(probe)* Bytes `decode_base64("AQID")`: top `"AQID"`, nested `{"b":[1,2,3]}`, `to_string` `"[1,2,3]"` | probe | Second depth-dependent variant, not named in the issue |
+| *(probe)* Floats `1.0/0.0`: top `"INFINITY"`, nested `{"inf":null,"ninf":null,"nan":null}`, `to_string(inf)` `"null"`, `to_string(0.0/0.0)` `"null"`; `1.0` → `1.0`, `{"f": 1.0}` → `{"f":1.0}`, `to_string(1.0)` → `"1.0"`, `-0.0` → `-0.0` | probe; [`json.rs:61-75`](../../cozo-core/src/data/json.rs), [`functions.rs:217-219`](../../cozo-core/src/data/functions.rs) both `json!(f)` for finite values | Third depth-dependent variant; integral floats already keep `.0` at both depths (pinned by D6) |
+| *(probe)* `vec([0.1])` → `[0.10000000149011612]` at both depths; `vec([0.1], "F64")` → `[0.1]`; `vec([1.0/0.0, -1.0/0.0, 0.0/0.0])` → `[null,null,null]` at both depths | probe; `json!(el)` on `f32`/`f64` → `serde_json::Value::from`, which widens `f32` to `f64` and yields `Null` for non-finite (`Number::from_f64` → `None`); `vec()` accepts any `get_float()` ([`functions.rs:2139-2147`](../../cozo-core/src/data/functions.rs)) | Two unnamed lossy edges in the draft; now D1 rows (Vec) |
+| *(probe)* List/Json identical at both depths; a nested `9007199254740993` stays an exact integer; `json_to_scalar(parse_json('9007199254740993'))` exact | probe | Already agree; pinned by D6 |
+| *(probe)* Validity `'ASSERT'` row: `[1787956506172712,true]` at top level, nested, via `to_string`, and via `get({"v": vld}, "v")`; but `:put` of that `get()` result into a `Validity` column **errors** (`when executing against relation 'v'`) | probe; [`relation.rs:411-437`](../../cozo-core/src/data/relation.rs) accepts only `List([Int, Bool])`, `v => bail!(InvalidValidity(v))`; `json2val` Array → `Json` ([`functions.rs:1869`](../../cozo-core/src/data/functions.rs)) | The two Validity expressions agree; the `get()`-extracted pair cannot be re-typed by coercion (D3 named gap) |
+| `Regex` has no constructor op; `Set` has no constructor op | probe; [`value.rs:161,165`](../../cozo-core/src/data/value.rs) | Neither reachable from a script; pinned by Rust unit tests only |
+| Inbound policy A, two impls with the same policy: `impl From<JsonValue> for DataValue` (17-34) and `impl From<&JsonValue> for DataValue` (36-53) — Number → `as_i64` else `as_f64` else `Str` of the digits; String→`Str`; Array→`List`; Object→`Json`; no UUID/base64 recognition | [`json.rs:17-53`](../../cozo-core/src/data/json.rs) | Canonical forms do not round-trip (D3); integers outside `i64` degrade to `Float` inbound |
+| Inbound policy B: `json2val` (used by `json_to_scalar` and `get` on Json) — String→`Str`, **Array→`Json`**, Object→`Json` | [`functions.rs:321-325, 1848, 1855-1872`](../../cozo-core/src/data/functions.rs) | Two inbound policies disagree on arrays; out of scope, recorded (D3) |
+| *(probe)* `is_uuid(json_to_scalar(parse_json('"a6bb…"')))` = `false`, `is_string(..)` = `true`; `is_json(json_to_scalar(parse_json('[1,2]')))` = `true`, `is_list(..)` = `false`; `is_uuid(to_uuid(get(parse_json('{"u":"…"}'), "u")))` = `true`; `to_string(json("abc"))` = `abc`, `to_string(json(1))` = `1` | probe | Inbound is lossy by construction; `to_uuid` is the explicit re-typing step; non-object `Json` payloads are indistinguishable from scalars at the boundary |
+| `NamedRows::into_json` maps every cell through `JsonValue::from` (top-level policy); nested values inside a `Json` cell pass through verbatim | [`runtime/db.rs:315-330`](../../cozo-core/src/runtime/db.rs) | The only result-set boundary; fixing the nested policies fixes what `into_json` shows inside `Json` cells |
+| `into_json` is called at three `lib.rs` sites — `run_script_fold_err` (613), `run_script_fold_err_with_options` (641, the fork's budgeted variant), `export_relations_str` (747, per relation); `run_script_str` (656) calls `run_script_fold_err`. Host surfaces on those: C (`cozo-lib-c/src/lib.rs:144, 214`), wasm (`cozo-lib-wasm/src/lib.rs:40, 42-44`), Java (`cozo-lib-java/src/lib.rs:91, 108`), Swift (`cozo-lib-swift/src/lib.rs:18-19`); HTTP server `res.into_json()` at `cozo-bin/src/server.rs:680` (also 811, 1082, 1152) | cited files | One outbound policy across all six surfaces and the relation-export path; the change is observed identically everywhere |
+| Python binding converts cells natively (`Bytes`→`PyBytes` 387, `Uuid`→str 388, `Validity`→`[i64,bool]` 398, `Bot`→`None` 401, `Vec`→list 402-411) and hands `Json` cells to `json_to_py` verbatim (412); `json_to_py` never sees a `DataValue` | [`cozo-lib-python/src/lib.rs:378-414`](../../cozo-lib-python/src/lib.rs) (`json_to_py` at 350) | Top-level Python cells unaffected; nested values inside `Json` cells are fully determined by the engine — a Rust test is the guard |
+| `cozo-lib-python/` has no `tests/` directory (only `integrations/*/tests`, separate packages); `build.yml` runs no maturin build or pytest; `python-publish.yml`'s gate is "the engine test suite" | `ls cozo-lib-python`; `find cozo-lib-python -name 'test*.py'`; [`.github/workflows/python-publish.yml:31-37`](../../.github/workflows/python-publish.yml) | No Python harness exists to add a binding test to (§7 cut) |
+| Node binding: `Bytes`→`JsBuffer` (143), `Uuid`→string (147), `Bot`→`undefined` (173), `Json`→`json2js` (192) | [`cozo-lib-nodejs/src/lib.rs:143-192`](../../cozo-lib-nodejs/src/lib.rs) | Same shape as Python |
+| CI: the `test` job runs `cargo test -p mnestic` on default (SQLite) features (lib unit tests use whatever `DbInstance` they build — `mem`); the `storage-rocksdb` job is `cargo build` plus two named `--test` targets; clippy is `cargo clippy -p mnestic --all-targets -- -D warnings` on default features | [`.github/workflows/build.yml:14-32, 120-141, 164-181`](../../.github/workflows/build.yml) | There is no per-backend matrix for lib tests; the D6 gate is stated in those terms (§5) |
+| No `panic = "abort"` in any workspace profile | [`Cargo.toml:21-26`](../../Cargo.toml) (only `[profile.bench]` and a `mnestic-rocks` dev override) | A `Bot` panic in an axum handler kills the request, not the process (D7) |
+| CozoScript `Display` is a separate literal form (`to_uuid("..")`, `decode_base64("..")`, `vec([..])`, Validity as a struct, `Bot` as `null`) | [`value.rs:632-672`](../../cozo-core/src/data/value.rs) | Not a JSON boundary; D1 does not touch it |
+| The published docs already state the top-level forms as the contract: "`Bytes` render as a Base64 string, `Uuid` as its string form, `Vector` as a plain list of numbers, and `Validity` as a `[timestamp, is_assert]` pair. The stored value keeps its engine type — only the display coincides." | [`mnestic-site/src/app/docs/types/page.mdx:65-68`](../../../mnestic-site/src/app/docs/types/page.mdx) | D1 is that sentence extended to every depth; only the `functions` page examples for `json_object` (`:465`) and `set_json_path` (`:491`) need re-checking |
+| Existing engine coverage: `bad_values` prints four lines (one plain `serde_json` literal, three `DataValue`→JSON conversions) and asserts nothing; `test_json_objects` only checks map literals parse | [`cozo-core/src/data/tests/json.rs:16-21`](../../cozo-core/src/data/tests/json.rs), [`cozo-core/src/runtime/tests.rs:611-619`](../../cozo-core/src/runtime/tests.rs) | D6 starts from zero pinned shapes |
+| mindgraph-rs has its own converter `datavalue_to_json`: `Bytes`→`{"__bytes__": base64}` (14439), `Json` pass-through (14435), catch-all `_ => String(format!("{:?}", dv))` (14440); inverse `json_to_datavalue` recognises only the `__bytes__` tag (14463-14469); `named_rows_to_json` (14476-14493) is the sole caller, used only by `export_all` (7932-7975; 25 relations, `node_embedding` not among them); `import_snapshot` reads back via `json_to_named_rows` (7986) | [`mindgraph-rs/src/storage/cozo.rs:7932-7990, 14426-14493`](../../../mindgraph-rs/src/storage/cozo.rs) | A product-owned policy that never calls the engine seam; unaffected by D2 (D8) |
+| No mindgraph-rs relation in `migrations.rs` declares a `Uuid`, `Bytes`, `Validity` or vector column (the only `Validity` hit is a comment at 308); props are `Json` (29). **Correction:** the product does declare one vector column outside `migrations.rs` — `node_embedding { uid => embedding: <F32; N> }` at `cozo.rs:8280` — but it is not among `export_all`'s 25 relations | [`mindgraph-rs/src/storage/migrations.rs:29, 308`](../../../mindgraph-rs/src/storage/migrations.rs), [`cozo.rs:8280`](../../../mindgraph-rs/src/storage/cozo.rs) | The `__bytes__` tag and the Debug catch-all are unreachable from exported relations today; the `node_embedding` vector column never reaches the export seam |
+| `extract_json` accepts only `DataValue::Json` / `Null`; `row_to_node` reads props through it (13237); vector traffic is typed: the `node_embedding` column is declared `<F32; N>` (8280), reads unwrap `Vector::F32` (8490) and match `DataValue::Vec(v)` (8613, 9984) | [`cozo.rs:8280, 8490, 8613, 9984, 13237, 14208`](../../../mindgraph-rs/src/storage/cozo.rs) | `Json` pass-through is load-bearing for the product's hottest read path; Vec JSON form has no product consumer |
+| mindgraph-rs runs no CozoScript that uses `json(`, `json_object(`, `set_json_path(`, `remove_json_path(` or `to_string(`, and no product `:put` writes a Uuid/Bytes/Float/Validity/Vec into a `Json` column (props arrive as `DataValue::Json` params) | grep of `src/storage/*.rs`, `mindgraph-server/src/*.rs`, 2026-08-28 | The nested path and the coercion path have zero product callers |
+| Three product files read engine cells natively — `storage/cozo.rs`, `storage/budgeted_oracle.rs` (`NamedRows` at 34, 144, 165, 172, 567), `mindgraph-server/src/synthesis.rs` (`DataValue` at 19, 276, 376, 547-562); none calls `into_json`, `run_script_str`, or `JsonValue::from(DataValue)` (the `into_json` hits in `openai*.rs`/`biblio.rs` are ureq); HTTP `GET /export` returns a typed `TypedSnapshot` | greps of `mindgraph-rs/src`, `mindgraph-server/src`; [`mindgraph-server/src/lib.rs:3535`](../../../mindgraph-rs/mindgraph-server/src/lib.rs) | No product path crosses the JSON seam; the public export route is insulated |
+| Existing mindgraph-rs snapshot tests assert counts only (`test_export_import_roundtrip`, `test_snapshot_serialization`); `graph.rs:6734-6737` compares two `export()` outputs by value (`assert_eq!` at 6737) | [`mindgraph-rs/tests/integration.rs:1894`](../../../mindgraph-rs/tests/integration.rs), [`mindgraph-rs/src/graph.rs:6734-6737`](../../../mindgraph-rs/src/graph.rs) | No per-variant shape is pinned on the product side (D8) |
+| mindgraph-cloud depends only on `mindgraph` + `mindgraph-server` by path; no `DataValue`/`NamedRows`/`into_json` in `src/`; agent tooling emits `node.props.to_json()` (typed). TS SDK types props as `Record<string, unknown>`; dashboard renders props generically | [`mindgraph-cloud/Cargo.toml:7`](../../../mindgraph-cloud/Cargo.toml), [`mindgraph-cloud/src/agent_tools.rs:1330`](../../../mindgraph-cloud/src/agent_tools.rs), [`mindgraph-ts/src/types.ts:11`](../../../mindgraph-ts/src/types.ts), [`mindgraph-dashboard/src/app/dashboard/chat/[id]/page.tsx:2158`](../../../mindgraph-dashboard/src/app/dashboard/chat/[id]/page.tsx) | Cloud breaks iff mindgraph-rs breaks; it does not. No compile-time or parse-time consumer of the array form |
+| Changelog precedent for a behaviour-is-the-fix change: `### Changed — …` with "The migration note first, because the break is the fix working"; precedent for naming the guarding fixture by test name | [`CHANGELOG-FORK.md:319, 1489-1491`](../../CHANGELOG-FORK.md) | The D5 note follows that shape |
+| Published engine is `mnestic 0.16.0`; roadmap row 1 is `Release 0.17.0 \| Merged import, unreleased \| … \| Verify crates.io, PyPI, GitHub, and clean-install artifacts` | [`versions.toml:28`](../../../versions.toml), [`MNESTIC-ROADMAP.md:29`](../../../docs/strategy/MNESTIC-ROADMAP.md) | 0.17.0 is merged but not yet verified or cut; release placement is an owner ruling (status header) |
+
+## 3. Decisions
+
+### D1 — The canonical table (seam: `cozo-core/src/data/json.rs`, the single match body)
+
+Scope: the **JSON boundary only** — `NamedRows::into_json`, the `Json`-producing builtins, `to_string()`, JSON keys derived from values, `Json`-column coercion, and every host surface that serialises through them. Native binding conversions (Python `value_to_py`, Node `value2js`) and CozoScript `Display` are **explicitly out of scope**; they keep their own top-level forms and inherit this table only for values nested inside a `Json` cell.
+
+| Variant | Canonical JSON | Today: top / nested | Lossy boundary (named) |
+|---|---|---|---|
+| `Null` | `null` | same / same | — |
+| `Bool(b)` | `true` / `false` | same / same | — |
+| `Num(Int(i))` | JSON integer, exact `i64` | same / same | exact outbound; inbound integers outside `i64` degrade to `Float` (`json.rs:22-26`); consumers that parse to IEEE double lose precision above 2^53 (RFC 8259 §6 interoperable range) — a consumer-side hazard this spec documents but does not paper over with string-encoded ints |
+| `Num(Float(f))`, finite | JSON number in `serde_json` f64 formatting — integral values keep a fractional marker (`1.0` → `1.0`, `-0.0` → `-0.0`), so `Int(1)` and `Float(1.0)` are textually distinct | same / same | — |
+| `Num(Float(NaN))` | `null` | `null` / `null` | **lossy, and the only non-recoverable row**: NaN is indistinguishable from `Null` after conversion. Kept because it is today's top-level form; prior art would treat the non-finite family uniformly (owner ruling 2, §7) |
+| `Num(Float(+∞))` | `"INFINITY"` | `"INFINITY"` / `null` | **lossy**: a `Str("INFINITY")` produces the same JSON; nested form changes. Spelling is Cozo's inherited top-level form (Postgres uses `"Infinity"`); kept for compatibility |
+| `Num(Float(−∞))` | `"NEGATIVE_INFINITY"` | same / `null` | as above |
+| `Str(s)` | JSON string | same / same | — |
+| `Bytes(b)` | base64 (`STANDARD`, padded) JSON string | base64 / int array | **lossy**: indistinguishable from a `Str` holding the same text; nested form changes. Prior art is unanimous that bytes are one string (Postgres `\x` hex, Arrow hex, Neo4j base64) but splits hex/base64 — base64 is a **compatibility choice** (today's top-level form, already on the types page), not a prior-art norm |
+| `Uuid(u)` | hyphenated lowercase string (`uuid::Uuid` `Serialize`) | string / 16-int array | **lossy**: indistinguishable from `Str`; `to_uuid()` re-types; nested form changes (the #54 headline). Confirmed by Postgres `to_json` (text output of the type) and DuckDB (lowercase on the JSON path) |
+| `Regex(r)` | pattern string | same / same | internal-only; lossy (becomes `Str`) |
+| `List(l)` | JSON array, elements by this table, recursively | same / same | — |
+| `Set(s)` | JSON array in `BTreeSet` (`DataValue::Ord`) order, elements by this table | same / same | internal-only; **lossy**: becomes a `List` on the way back (RFC 8785: deterministic order is the canonical-form requirement; JSON has no set) |
+| `Vec(F32(a))` / `Vec(F64(a))` | flat JSON array, iterated element-wise; each element is `Number::from_f64(el as f64)`, or `null` when that is `None` | same / same | **lossy, three ways**: (1) F32 vs F64 element type is not recorded (matches DuckDB/Arrow, where width lives in schema metadata); (2) F32 elements are widened to f64 before formatting — `vec([0.1])` → `[0.10000000149011612]`, `vec([0.1], "F64")` → `[0.1]`; (3) **non-finite elements → `null`**, sign and NaN/∞ distinction lost — differs from the scalar `Float` row **by design** so that `vec()` can still re-type the array via `as_f64()`; becomes a `List` on the way back |
+| `Json(j)` | `j` **unchanged** — no re-wrapping, no re-encoding | same / same | load-bearing for mindgraph-rs `extract_json`; **lossy when the payload is not an object**: scalar/array payloads parse back as `Str`/`Num`/`Bool`/`Null`/`List` (policy A) or `Json` (policy B) |
+| `Validity{ts, is_assert}` | `[ts_i64, is_assert_bool]` (two-element array) | same / same | **lossy**: becomes a `List` (policy A) or `Json` array (policy B) on the way back; only the `List` form re-enters a `Validity` column (D3). An in-house positional form with no prior-art precedent (Neo4j/Postgres emit ISO-8601 text); kept because it is Cozo's inherited top-level contract and already documented on the types page |
+| `Bot` | `null` | **panic** / `null` | internal-only; see D7 |
+
+Rules that apply to every row: nesting is recursive with no depth cap (a `List` of `Json` of `List` renders each layer by this table, and `Json` payloads are never re-walked); the table is a function of the variant alone, never of position; no variant is silently truncated (base64 is exact; `i64` is exact).
+
+### D2 — The single conversion seam (survivor: `json.rs`; deleted: `functions.rs::to_json` and the `relation.rs` `ColType::Json` arm)
+
+1. `cozo-core/src/data/json.rs` gains `impl From<&DataValue> for JsonValue` — a borrowing, recursive conversion whose match body **is** D1. This is the one and only hand-written policy (Postgres has exactly one `datum_to_json_internal` behind `to_json`, `row_to_json`, `json_build_object`, `json_agg`; the recursion re-entering the same function is precisely what #54 lost).
+2. The existing owning `impl From<DataValue> for JsonValue` (`json.rs:55-101`) is reduced to a delegate with **one** arm of its own: it moves the `Json` payload (avoids deep-cloning `Json` result cells on the HTTP/string-API path) and delegates every other variant to the borrowing impl.
+3. `fn to_json` at `functions.rs:205-271` is **deleted**. Five of its six call sites (`functions.rs:83, 88, 93, 163, 199`) become `JsonValue::from(&x)`. The sixth, `val2str` (`2086-2094`), is **not** a plain swap: `serde_json::Value::to_string()` on a `JsonValue::String` emits the quoted literal, so `val2str` unwraps a string payload before stringifying — a match on `JsonValue`, not on `DataValue`, so Invariant 2 holds. This generalises the existing `Json(JsonValue::String)` arm.
+4. The `ColType::Json` arm of `coerce` (`relation.rs:440-504`) is **replaced** by one line delegating to the owning impl. Its List/Set arms already terminated in `From<DataValue>` via `arr.into()`, so nothing is lost; its scalar arms were the old nested forms.
+5. `NamedRows::into_json` (`db.rs:315-330`) is unchanged. So are `run_script_str`, `export_relations_str`, `cozo-bin`, and every binding.
+
+The resulting seam, in full:
+
+```rust
+// cozo-core/src/data/json.rs
+impl From<&DataValue> for JsonValue {            // the policy: one match body, D1 row per arm
+    fn from(v: &DataValue) -> Self {
+        /* 13 arms; recursive through List/Set; Vec elements via
+           Number::from_f64(el as f64).map_or(JsonValue::Null, JsonValue::Number) */
+    }
+}
+impl From<DataValue> for JsonValue {             // delegate: moves the Json payload, nothing else
+    fn from(v: DataValue) -> Self {
+        match v {
+            DataValue::Json(j) => j.0,
+            other => JsonValue::from(&other),
+        }
+    }
+}
+
+// cozo-core/src/data/functions.rs — the only call site that is not a plain swap
+fn val2str(arg: &DataValue) -> String {
+    match JsonValue::from(arg) {
+        JsonValue::String(s) => s,               // bare text: Str, Uuid, Bytes, ±∞, Regex, Json string payloads
+        other => other.to_string(),              // compact JSON text for everything else (incl. NaN → "null")
+    }
+}
+
+// cozo-core/src/data/relation.rs — ColType::Json coercion
+ColType::Json => DataValue::Json(JsonData(JsonValue::from(data))),
+```
+
+Bounds that are explicit rather than implied: recursion depth is bounded only by the value's own depth (a `List` nests as deep as the script built it; `Json` payloads are not walked, so a stored JSON blob adds zero recursion); there is no size cap and no truncation at any depth — a 4096-dimension `Vec` emits 4096 numbers; F32 widening is deliberate (`el as f64`), not incidental.
+
+Why `json.rs` survives and not `functions.rs`: `into_json` is the public result boundary for six host surfaces, its forms are what every published consumer already sees at top level, and mindgraph-rs has zero callers of the nested builtins. Unifying on the nested policy would change the top-level contract for everyone to fix a bug nobody outside `Json` cells can see.
+
+### D3 — Round trip: the contract is one-way (seam: `json.rs:17-53` (both inbound impls), `functions.rs:1855-1872`, unchanged)
+
+JSON→DataValue does **not** accept the canonical forms as typed values and this spec does not make it do so. A canonical UUID string parses back as `Str`; base64 parses back as `Str`; Validity, Vec and Set arrays parse back as `List` (via either `From<JsonValue>` impl) or `Json` (via `json_to_scalar` / `get`). The explicit re-typing steps remain `to_uuid()`, `decode_base64()`, `vec()`, and Validity column coercion on `:put` of a **`List`** — a Validity pair extracted from a `Json` cell with `get()` is a `Json` array and is rejected by coercion (probe, §2); it re-enters only via params or `parse_json` → `From<JsonValue>` (policy A). Named gap, not fixed here. The two inbound policies' disagreement on arrays (`List` vs `Json`) is recorded and left alone — it predates #54, has no depth-dependence, and changing it would alter `get()` chaining semantics.
+
+Prior art confirms the shape: Postgres maps JSON string→text, number→numeric and nothing else (a UUID that went through `to_json` comes back as text; re-typing is an explicit cast); Neo4j states the same loss for plain JSON and solves it with a separate opt-in typed format rather than sniffing. No production system infers uuid/bytes from string shape.
+
+### D4 — Blast radius across the boundary (verified negatives and the positives)
+
+| Consumer | Path | Observes the change? | Breaks? |
+|---|---|---|---|
+| HTTP (`cozo-bin`), C, wasm, Java, Swift, embedded `run_script*` / `export_relations_str` | `into_json` | Only inside `Json` cells, `to_string()` results, and derived keys; top-level cells identical except `Bot` (panic→`null`) | No — nested arrays become strings; no consumer in this workspace parses the array form |
+| Python binding (`mnestic` on PyPI) | native cells; `json_to_py` for `Json` | Nested only (same as above) | No |
+| Node binding | native cells; `json2js` for `Json` | Nested only | No |
+| CozoScript `to_string(uuid \| bytes \| ±inf)` | `val2str` → seam | **Yes, directly**: `"[166,…]"` → `"a6bb…"`, `"[1,2,3]"` → `"AQID"`, `"null"` → `"INFINITY"` | Behavioural change, D5 item 3 |
+| CozoScript JSON keys from a Uuid/Bytes value (`{x: 1}`, `json_object(x, 1)`, `remove_json_path(j, [x])`) | `val2str` → seam | **Yes, directly**: key text follows `to_string()` | Behavioural change, D5 item 3 |
+| CozoScript `:put` / `:insert` / import of a non-`Json` value into a `Json` column | `coerce` → seam | **Yes, directly; this is the write path that persisted the old form** | New rows store the canonical form; old rows are untouched — D5 items 4-5 |
+| mindgraph-rs `export_all` / `import_snapshot` | own `datavalue_to_json` | **No** — never calls the engine seam | No; format unchanged (D8) |
+| mindgraph-rs `row_to_node` / `extract_json`, HNSW / embeddings, stored data (`String` uids; no Uuid/Bytes/Validity columns), CozoScript (no JSON builtins, no `to_string`, no non-`Json` writes into `Json` columns) | typed cells / `Json` pass-through | No | No |
+| `GET /export` (server), mindgraph-cloud, TS/Python SDKs, dashboard | typed structs / `Record<string, unknown>` | No | No |
+
+Prior art has no analogue for this table; it warns only that nested-form changes surface as downstream driver bug reports (node-postgres #1356, DuckDB #14646) — residual risk 1 is the correct framing. Named silent-failure mode retained from grounding: `export_all_embeddings` (`cozo.rs:9984`) has `_ => continue`, so if a future change ever made vectors arrive as a non-`Vec`/`List` variant, embeddings would be dropped silently rather than erroring. Not touched here; recorded so the next reader knows the arm exists.
+
+### D5 — Compatibility contract and migration note (deliverable named by the roadmap gate)
+
+**Contract, stated for consumers:**
+
+1. Top-level result cells are value-identical before and after, for every variant a script can produce. (`Bot` cannot be produced by a script.)
+2. Values nested inside a `Json` cell — from `{..}` literals, `json()`, `json_object()`, `set_json_path()`, `remove_json_path()` — now use the top-level forms. Three variants change shape: `Uuid` (16-int array → string), `Bytes` (int array → base64 string), non-finite floats (`null` → `"INFINITY"` / `"NEGATIVE_INFINITY"`). NaN stays `null` and is the single value that cannot be told from `Null` after conversion (D1). Non-finite `Vec` elements stay `null` (D1).
+3. `to_string()` of those three variants changes accordingly and returns the bare text (no surrounding quotes). Keys derived from non-string values — `json_object` keys, `{..}` literal keys, and object path elements in `get`/`set_json_path`/`remove_json_path` — follow `to_string()` and change identically, so `remove_json_path(j, [x])` with a Uuid `x` now addresses the string-form key.
+4. `DataValue::Json` payloads are never re-encoded on read: mindgraph-rs props and every JSON value the user wrote as JSON are unchanged.
+5. **No relation, index or snapshot is rewritten.** However, `Json` column values that were *built* from Uuid/Bytes/±∞/Vec before this release — by a map literal, `json_object`, `set_json_path`, or by `:put`/`:insert`/import coercion of a non-`Json` value into a `Json` column — keep their old nested forms on disk (16-int arrays, int arrays, `null`); rows written after it use the canonical forms. A column written across the upgrade holds both, and the engine cannot tell an old-form UUID array from a genuine 16-element list. Position independence is guaranteed per conversion, not across the history of a stored column. No CozoScript expression converts the array form (`to_uuid` accepts strings only); the rewrite is client-side.
+6. mindgraph-rs snapshot files (`GraphSnapshot.relations`) keep their format; `mindgraph_version` stays the snapshot-compat key.
+7. JSON→DataValue stays lossy (D3). Nothing that parsed as `Str` before parses differently after.
+
+Prior art confirms the shape of the contract: serialization-shape fixes ship as behaviour changes with a note, not flags (DuckDB #17329 is a plain bug; Postgres documents json/jsonb representational differences in the reference; Neo4j's `Accept`-header versioning applies to an additive typed format, not to fixing a defect).
+
+**Release placement (owner ruling 1):** the change is a `### Changed` entry, not a patch. Proposed: 0.18.0, so that 0.17.0 (merged, unreleased, its own verify gate still pending — `MNESTIC-ROADMAP.md:29`) ships with only the Parquet import it was scoped to. Alternative: bank into 0.17.0 if the owner prefers one minor with two `### Changed` entries. Either way it is banked, not cut alone ("bank releases, don't cut them").
+
+**Migration note (draft, `CHANGELOG-FORK.md`, following the `:319` precedent):**
+
+> ### Changed — nested values now serialize exactly like top-level values (#54)
+>
+> **The migration note first, because the break is the fix working:** a UUID, byte string, or infinite float placed inside a JSON object or list — `{"id": rand_uuid_v4()}`, `json_object("blob", decode_base64(..))`, `set_json_path(j, ["x"], 1.0/0.0)` — or written by `:put` into a `Json` column, previously rendered as a 16-element integer array, an integer array, and `null` respectively, while the same value at the top level of a result row rendered as a UUID string, a base64 string, and `"INFINITY"`. Nested values now use the top-level forms at every depth; `to_string()` of those values returns the same bare text; and a JSON key derived from a UUID or byte value (`{x: 1}`, `json_object(x, 1)`, a path element in `remove_json_path`) is now that text too. If you parsed the integer-array form of a nested UUID or key, switch to the string (`to_uuid()` in CozoScript, `uuid.UUID(s)` in Python).
+>
+> **Stored `Json` columns are not rewritten.** Values built from a UUID, bytes or ±∞ *before* this release keep the array/`null` form on disk; rows written *after* it carry strings, so one column can hold both, and no CozoScript expression converts the old form. To find old rows: `?[k] := *rel{k, j}, is_list(get(j, "u"))` (adjust the key). To rewrite: read them, convert client-side (`uuid.UUID(bytes=bytes(arr))` / `base64.b64encode(bytes(arr))` in Python), and `:put` the row back. Top-level cells are unchanged; NaN is still `null`; non-finite vector elements are still `null`. The internal `Bot` value now serializes as `null` instead of panicking. One policy now lives in `data/json.rs`; the copies in `data/functions.rs` and the `Json` column coercion in `data/relation.rs` are gone. Regression-guarded by `data/tests/json.rs::canonical_*` (one test per variant, each asserting top-level == map-literal == list-nested == `json_object` == `set_json_path` == `to_string` == `:put` into a `Json` column).
+
+mindgraph-rs is unaffected by item 5: no product script builds `Json` from those variants and props arrive as `DataValue::Json` params (§2).
+
+### D6 — Tests (seam: `cozo-core/src/data/tests/json.rs`, replacing `bad_values`)
+
+All engine tests are **lib unit tests** (`cargo test -p mnestic --lib`) on the `mem` backend — the seam is storage-independent, and `mem` supports `:create`/`:put` of `Validity` and `Json` columns, so no stored backend is needed. Each asserts a literal expected value (no `println!`, no snapshot files). Arrow's per-type golden files and RFC 8785's per-number-class test vectors are the prior-art shape.
+
+| Test | Pins |
+|---|---|
+| `canonical_uuid` | the #54 script verbatim: `x` string, `m.x` same string; `to_string(x)` same string with `length(to_string(x)) == 36` and `to_string(x) == to_string(json(x))`; `json_object("u", x)`, `set_json_path({}, ["u"], x)`, `json(x)`, `[x]` and `{"l": [x]}` all yield the string; key form: `json_object(x, 1)` and `{x: 1}` both have the string as their only key, and `remove_json_path({x: 2, "a": 1}, [x])` → `{"a":1}` |
+| `canonical_bytes` | `decode_base64("AQID")` → `"AQID"` at every depth; `to_string` → `AQID` (4 chars) |
+| `canonical_floats` | `1.0` → `1.0` and `to_string(1.0)` → `"1.0"`; `-0.0` → `-0.0`; NaN → `null` at every depth **and** `{"n": 0.0/0.0} == {"n": null}` (the aliasing is pinned, not incidental); `1.0/0.0` → `"INFINITY"`, `-1.0/0.0` → `"NEGATIVE_INFINITY"` at top level, nested, and via `to_string` (bare, 8 / 17 chars) |
+| `canonical_int_exact` | `9007199254740993` nested stays an exact integer at every depth (documents the >2^53 consumer-side hazard both ways: exact here, IEEE-lossy in a double-based consumer) |
+| `canonical_vec` | `vec([0.1])` → `[0.10000000149011612]` and `vec([0.1], "F64")` → `[0.1]` at every depth (F32 widening is contract); `vec([1.0/0.0, 0.0/0.0])` → `[null,null]` at every depth; a non-contiguous `Array1` view (Rust-level) converts without panic |
+| `canonical_validity` | a `Validity` column row → `[ts, true]` at top level, nested, and via `to_string`; the retracted case `[ts, false]` |
+| `canonical_put_json_column` | `:put` of Uuid, Bytes, `1.0/0.0`, `vec([0.1])`, a Validity value and `[uuid, bytes]` into a `Json` column; reading each back equals the corresponding map-literal form |
+| `canonical_list_json_passthrough` | `[1,"a",null]` and `json({"k":[1,2]})` identical at every depth; a `Json` payload containing an int array that *looks like* a UUID is **not** rewritten; `to_string("a")` is `a` and `to_string(json("a"))` is `a` (the unquoted carve-out, Invariant 1) |
+| `canonical_internal_variants` (Rust unit) | for one instance of each of the 13 variants, `JsonValue::from(v.clone()) == JsonValue::from(&v)`; `Set` of three unordered elements → ascending array, stable across two conversions; `Regex` → pattern string; `Bot` → `null` through both impls, no panic |
+| `bad_values` | deleted (subsumed by `canonical_floats`) |
+
+Product side (Batch B, no behaviour change): `mindgraph-rs/tests/integration.rs::snapshot_cell_shapes_are_pinned` — after `export()`, every cell of every exported relation is `null`/bool/number/string/array/object as produced by the enumerated arms, and no cell is a Rust `Debug` string (asserting the catch-all at `cozo.rs:14440` is unreachable). It runs in ordinary mindgraph-rs CI; `datavalue_to_json` never calls the engine seam, so its result is independent of Batch A by construction.
+
+### D7 — `Bot` serializes as `null` (seam: `json.rs:81`)
+
+`Bot` is internal-only, unconstructible from a script, already `null` in `Display` (`value.rs:652`), `None` in Python, `undefined` in Node, and `null` on both nested paths. A `panic!` inside `From<DataValue>` turns an engine invariant violation into an unwinding panic that kills the request on the HTTP path (`cozo-bin/src/server.rs:680`, inside a tokio task; no workspace profile sets `panic = "abort"`) instead of returning a value. Canonical: `null`. Prior art neither confirms nor contradicts (no external system has a bottom value; serde_json/ECMAScript degrade unrepresentable values to `null`, RFC 8785 errors). Rejected: panic everywhere (would make `json_object` on a `Bot` panic where it returned `null`).
+
+### D8 — mindgraph-rs keeps its own converter; it is pinned, not replaced (seam: `mindgraph-rs/src/storage/cozo.rs:14426-14493`)
+
+The engine will have one policy; the product's snapshot writer/reader is a *second*, product-owned encoding, and this spec says so rather than pretending otherwise. It stays because: (a) it is a matched writer/reader pair with a self-describing `__bytes__` tag, which the engine form deliberately is not (D3) — the same layering production systems use (Neo4j Typed JSON `{"$type","_value"}`, Arrow extension metadata: a tagged round-trippable form sits *above* the plain lossy form, never merged into it); (b) every exported relation is `String`/`Int`/`Float`/`Bool`/`Json` typed, so its `Uuid`/`Vec`/`Validity` Debug-string catch-all is unreachable today; (c) replacing it would change a persisted format for no consumer need. Batch B pins (b) with one test so that the day a relation with one of those column types is added to `export_all`, the test — not a customer — finds the Debug string.
+
+## 4. Invariants
+
+1. **Position independence.** For every `DataValue` `v` and every JSON-producing context `C` (`into_json` cell, `{..}` member, list element, `json()`, `json_object()`, `set_json_path()`, `remove_json_path()`, `Json`-column coercion), `C(v)` is D1(`v`). `to_string(v)` renders D1(`v`) as compact JSON text, except that a `JsonValue::String` result (`Str`, `Uuid`, `Bytes`, `±∞`, `Regex`, `Json` string payloads) is returned unquoted. Keys derived from `v` are `to_string(v)`.
+2. **One body.** Exactly one hand-written DataValue→`JsonValue` policy exists in `cozo-core` (the borrowing impl); the owning impl's single `Json` move is the only other arm, and `val2str` matches on `JsonValue`, never on `DataValue`. The `serde::Serialize` derive on `DataValue`/`NamedRows` is the storage/wire encoding (and cozo-bin's `params` REPL display), not a JSON boundary: no host surface may serialize `NamedRows` through serde — `into_json` is the only route.
+3. **`Json` is opaque.** A `DataValue::Json` payload is emitted value-identically (`JsonValue` equality) and never re-walked. Byte layout (key order, whitespace) belongs to the host's serializer, not the engine.
+4. **No panic on conversion.** No variant, contiguous or not, panics in the seam.
+5. **Determinism.** Equal `DataValue`s produce equal JSON across runs (`Set` ordering is `Ord`).
+6. **Exactness bounds.** `i64` is exact; base64 is exact; every other lossy edge is one of the rows named in D1 (including F32 widening and non-finite `Vec` elements) — there is no unnamed lossy edge.
+7. **One-way.** No inbound path (`json.rs:17-53`, both impls; `json2val`) grows type sniffing as part of this work.
+
+## 5. Acceptance tests
+
+- All D6 engine tests pass as lib unit tests on `mem` under the existing `test` job (`cargo test -p mnestic`, default features).
+- The #54 script (`?[x, m] := x = rand_uuid_v4(), m = {"x": x}`) returns `m.x == x` through `run_script_str` (the string API), which covers C/wasm/Java/Swift — and, because `json_to_py`/`json2js` receive the already-converted `Json` payload, Python and Node — by construction.
+- `cargo clippy -p mnestic --all-targets -- -D warnings` (default features, as `build.yml` scopes it). `cargo fmt --check` is **not** a CI gate (`build.yml` deliberately omits it: the inherited tree is not rustfmt-clean); run `cargo fmt` only on the files this work touches, never on the whole package.
+- Batch B (`mindgraph-rs`): `snapshot_cell_shapes_are_pinned` passes in mindgraph-rs CI.
+- `mnestic-docs` `doc_check` passes on `docs/functions` and `docs/types` against the Batch A engine (examples that print nested UUID/bytes forms regenerate).
+- The migration note in D5 is present in `CHANGELOG-FORK.md` "Unreleased" in the same PR as Batch A, and links this spec.
+
+## 6. Layering ruling
+
+**mnestic only.** DataValue→JSON serialization is engine mechanism: it passes the stranger test (any CozoDB user hits #269), carries no cognitive or tenancy vocabulary, and is stable ([`docs/strategy/LAYERING.md:18-25, 31`](../../../docs/strategy/LAYERING.md)). Nothing new is added to the engine's surface — the work deletes two match bodies and adds tests; the only "new" public behaviour is `Bot → null` replacing a panic.
+
+mindgraph-rs: **nothing new** — one pinning test, no behaviour change, no dependency on the engine's conversion. mindgraph-cloud: nothing.
+
+## 7. Rejected alternatives
+
+| Alternative | Why not |
+|---|---|
+| Patch `to_json`'s `Uuid` arm in place (the minimal fix for #269) | Leaves three policies; `Bytes`, non-finite floats and the `:put` coercion path stay depth-dependent; the next divergence is a matter of time |
+| Unify on the nested (`functions.rs`) policy | Changes top-level output for every host surface (UUIDs and bytes become int arrays); breaks the one contract consumers already rely on |
+| Self-describing tagged forms in the engine (`{"$uuid": "…"}`, `{"__bytes__": "…"}`) to make the round trip typed | Changes the top-level contract for everyone; type-tagging is a product-layer choice (mindgraph-rs already made it for its own snapshots; Neo4j ships it as a separate opt-in format); the engine's `Json` column would then contain tagged objects a user did not write |
+| Type-sniff on the way back (UUID-shaped strings → `Uuid`) | Silently changes the type of ordinary strings; `to_uuid()` already exists as the explicit step; no production system does it (D3) |
+| Fold `json2val` into `From<JsonValue>` | Changes `get()` on JSON arrays from `Json` to `List`, altering chaining semantics; unrelated to depth-dependence |
+| Accept a `Json` array as a `Validity` on `:put` (close the D3 gap) | New coercion behaviour outside #54's scope; the `List` route exists; named, not fixed |
+| Replace mindgraph-rs `datavalue_to_json` with an engine-exported canonical function | Changes a persisted snapshot format for no consumer; loses the `__bytes__` round trip; pulls product I/O policy down the stack |
+| Make `Bot` panic at every depth (unify on `json.rs:81`) | Introduces a new panic in `json_object`/`set_json_path`/coercion where `null` was returned |
+| Emit `null` for ±∞ at every depth (unify on the nested float policy) | Changes top-level output; loses the sign/infinite distinction that top-level consumers get today |
+| NaN → `"NAN"` (uniform non-finite family, as Postgres does) | Would be a second deliberate top-level change beside `Bot`, breaking D5 item 1 for a value already `null` everywhere today; the aliasing is instead stated in D1/D5 and pinned by `canonical_floats`. **Owner ruling 2** if the uniform family is preferred |
+| Apply the scalar `Float` row per `Vec` element (`"INFINITY"` strings inside a numeric array) | Breaks `vec()` re-typing of the emitted array (`as_f64()` on a string fails); `null` per element is kept and named lossy in D1 |
+| Record the F32/F64 element type in the Vec JSON form | Changes a top-level form that already agrees at both depths, for no consumer; named as lossy instead (DuckDB/Arrow keep width in schema metadata, not in the array) |
+| A data migration rewriting old-form values in `Json` columns | The engine cannot distinguish an old-form UUID array from a genuine 16-int list; any rewrite would be a guess. Detection query + client-side recipe in the migration note instead |
+| A compatibility flag keeping the old nested forms | Keeps two policies alive, which is the defect; prior art ships shape fixes as plain behaviour changes (D5) |
+| A grep-lint against `serde_json::to_*(&NamedRows)` in CI | The existing antipattern lint job lives in mindgraph-rs, not mnestic, and no such caller exists; Invariant 2 states the rule, a reviewer enforces it |
+| Touch `Display` / CozoScript literal form | Different boundary; #54 is about JSON |
+
+### Panel triage (Pass 3, 26 findings — all folded)
+
+| Finding (severity) | Disposition |
+|---|---|
+| `val2str` returns the quoted JSON literal for a `JsonValue::String`, so every stated `to_string` value was wrong (blocker, reported twice) | Folded: D2 step 3 + code block (`val2str` matches on `JsonValue`), §1 row, §2 three-arm row, `canonical_uuid`/`canonical_bytes`/`canonical_floats` pin bare text and lengths |
+| Third match body in `relation.rs` `ColType::Json` coercion — the write path persisting the old form (blocker) | Folded: §2 row + probe, D2 step 4, D4 row, D5 item 5, `canonical_put_json_column`, Invariant 2 |
+| CI cannot deliver "green on all three backends"; clippy is default-features (major, reported twice) | Folded, option (a): lib unit tests on `mem`; §5 and Batch A gate reworded; clippy bullet quotes `build.yml` |
+| No Python test harness exists for the binding (major, reported twice) | Folded: Python bullet deleted; covered by construction (`json_to_py` receives the converted payload); manual binding check stays in Batch C's PyPI verify step |
+| JSON keys from Uuid/Bytes change too (major) | Folded: §2 key row + probe, D4 row, D5 item 3, migration note, `canonical_uuid` key assertions, Invariant 1 |
+| "Stored data does not change" hides the mixed-encoding `Json` column (major, reported twice) | Folded: D5 items 4-5 rewritten, migration note gains detection + client-side rewrite recipe, residual risk 2 generalised, migration alternative rejected above |
+| Non-finite `Vec` elements → `null` and F32 widening are unnamed lossy edges (major) | Folded: D1 Vec row (three named edges), D2 element conversion and bounds, `canonical_vec` pins `[null,null]` and `0.10000000149011612`, per-element `"INFINITY"` rejected above |
+| Batch B two-engine gate proves nothing; `__bytes__` round-trip pins unreachable code (major) | Folded: one ordinary test, gate "passes in mindgraph-rs CI"; `__bytes__` round-trip test dropped |
+| `to_string` is not D1 for `Str` and `Json` string payloads (minor) | Folded: Invariant 1 carve-out; §2 row; `canonical_list_json_passthrough` asserts the carve-out |
+| "Only in `cozo.rs`" is false (`budgeted_oracle.rs`, `synthesis.rs`) (minor) | Folded: §2 row names three files; conclusion unchanged |
+| Two inbound impls at `json.rs:17-53` (minor) | Folded: §2 row, D3 seam, Invariant 7 |
+| `into_json` arrow backwards; three `lib.rs` sites + export paths; serde `Serialize` is a latent third form (minor, two overlapping findings) | Folded: §2 rows, D4 row, Invariant 2 scoped; grep-lint declined (rejected above) |
+| `canonical_vec` cannot detect F32 widening with dyadic inputs (minor) | Folded into the Vec fold: `vec([0.1])` pinned |
+| D7 "process abort" overstated (minor) | Folded: reworded; `panic = "abort"` absence verified (§2 row) |
+| Validity coercion rejects the `get()`-extracted `Json` array (minor) | Folded: D3 named gap, D1 Validity row, probe row in §2, alternative rejected above |
+| Non-object `Json` payloads and >`i64` inbound integers are lossy (minor) | Folded: D1 `Json` and `Int` rows |
+| Integral floats keep `.0` — unpinned (minor) | Folded: D1 Float row, `canonical_floats` |
+| Owning delegate's `Str` move cites a non-existent consumer (minor) | Folded: delegate reduced to the single `Json` move; rationale reworded |
+| "§5" points at the wrong gate artifact (minor) | Folded: §1 bullet and Batch A gate say D5 |
+| Release-placement premise false (0.17.0 not yet verified) (minor) | Folded: rewritten as owner ruling 1 with the roadmap row quoted |
+| Invariant 3 "byte-identically" overstates (minor) | Folded: value identity; `preserve_order` absence recorded in §2 |
+
+Prior-art folds (Pass 4): CONTRADICTS on non-finite floats → D1 NaN/±∞ rows, D5 item 2, `canonical_floats` aliasing pin, owner ruling 2; GAP on Validity → D1 row names it an in-house form; GAP on D4 → prior-art warning cited, residual risk 1 retained; GAP on D7 → rationale cites the two divergent precedents; essential omission (uniform non-finite family) → same as the CONTRADICTS fold; CONFIRMS verdicts cited at D1 (Uuid, Bytes, Vec, Set), D2, D3, D5, D6, D8; the D6 suggestion to document the >2^53 hazard both ways → `canonical_int_exact`.
+
+### Simplification pass (Pass 5) — requirement-neutral cuts applied
+
+1. Owning delegate reduced from two moves (`Json`, `Str`) to one (`Json`) — one residual arm, one test.
+2. Python binding test and its implied maturin/pytest CI step dropped — covered by construction.
+3. Three-backend engine test gate dropped — lib unit tests on `mem` under the existing job.
+4. Batch B two-engine gate and the `__bytes__` round-trip unit test dropped — one ordinary test in mindgraph-rs CI.
+5. Four Rust-level unit tests (`canonical_set_sorted`, `canonical_regex`, `canonical_bot`, `owning_and_borrowing_agree`) collapsed into `canonical_internal_variants`.
+6. Grep-lint for serde serialization of `NamedRows` not added — Invariant 2 states the rule.
+
+Owner-ruling cuts (not applied) are the two in the status header.
+
+## 8. Batches = review units
+
+| Batch | Repo | Content | Gate |
+|---|---|---|---|
+| **A** | mnestic | D2 seam (`json.rs` borrowing impl + owning delegate; delete `functions.rs::to_json`; five plain call-site swaps + the `val2str` unwrap; replace the `relation.rs` `ColType::Json` arm), D7, D6 engine tests, `CHANGELOG-FORK.md` Unreleased entry with the D5 note, `functions`/`types` doc pages through `doc_check` | D5 owner-approved first ("Compatibility contract before output changes"); existing CI green (`test` + `clippy` jobs, default features) |
+| **B** | mindgraph-rs | `snapshot_cell_shapes_are_pinned` (D8). No behaviour change. Can land before A. | Passes in mindgraph-rs CI |
+| **C** | mnestic release | Ship A in the release the owner rules (0.18.0 proposed); `versions.toml` + `bump.py`; roadmap row 5 → shipped; the existing PyPI verify step additionally runs the #54 script through the wheel and checks the nested value is a `str` | `/release` procedure; not cut alone |
+
+## 9. Residual risks (stated honestly)
+
+1. **Unknown external consumers of the nested array form.** The PyPI `mnestic` package and the HTTP server are public; someone may parse the 16-int UUID form. The migration note is the mitigation; there is no compatibility flag (§7).
+2. **Mixed encodings in stored data.** Every `Json` column written before the upgrade from Uuid/Bytes/±∞ via any write-time JSON builtin or `:put` coercion keeps the old form; new rows differ, and the engine cannot tell the two apart (D5 item 5). The same applies to `String` columns filled from `to_string()`. No mindgraph-rs script does either (verified); external databases are unknown; the migration note carries the detection query and client-side recipe.
+3. **Non-`.rs` query sources were not exhaustively searched** for JSON builtins (stored-query catalogs, `.md` docs examples). The `.rs` grep is the evidence; a stored query using `json_object` on a UUID would see the change — correctly.
+4. **The `Json` payload move in the owning impl** is the one place two code paths remain; `canonical_internal_variants` is the guard, and a reviewer should reject any further arm added there.
+5. **`Vec` non-contiguous case** is asserted at the Rust level only; no script can produce a non-contiguous `Array1` today, so the assertion proves the seam, not a user path.
+6. **Validity re-entry gap** (D3): a Validity pair pulled out of a `Json` cell cannot be `:put` back into a `Validity` column. Pre-existing, unchanged, now documented.
+7. **Doc pages.** `types/page.mdx:65-68` already states the top-level forms; the `functions` page entries for `json_object` (`:465`) and `set_json_path` (`:491`) were not run through `doc_check` in this pass — Batch A runs the `mnestic-docs` harness so any example that shows nested output is regenerated, not hand-edited.
+
+## 10. Spec-authoring provenance
+
+1. **Pass 1 — grounding (three lenses, 2026-08-28):** engine conversion paths and host surfaces; mindgraph-rs / mindgraph-cloud consumers and snapshot format; roadmap, changelog precedent, tests. Every citation re-checked against the working tree on 2026-08-28; a throwaway probe binary observed the nested/top-level/`to_string` output for Uuid, Bytes, floats, Vec, List, Json, Validity and the parse-back predicates.
+2. **Pass 2 — lean draft.** Cuts: no compatibility flag, no tagged forms, no inbound type sniffing, no `json2val` fold, no product converter rewrite, no Display change.
+3. **Pass 3 — adversarial panel (code-grounding verifier + semantics adversary + CI/process lens):** 26 findings, 3 blocker / 9 major / 14 minor; all folded (§7 triage). The two distinct blockers — the `val2str` quoting error and the third match body in `relation.rs` — each changed D2.
+4. **Pass 4 — prior art (Postgres `json.c`/`to_json`, DuckDB `to_json` + #14646/#17329, SQLite JSON1, Arrow integration JSON + canonical extensions, Neo4j Typed JSON/Jolt/APOC, RFC 8259/8785, serde_json `Number`):** 9 CONFIRMS, 1 CONTRADICTS (non-finite float family), 3 GAP (Validity form, D4, D7), one essential omission (uniform NaN treatment); folded and cited at D1, D2, D3, D5, D6, D7, D8 and §7.
+5. **Pass 5 — simplification (2026-08-28):** second probe confirmed every panel-predicted value (F32 widening, non-finite `Vec` elements, key derivation, `:put` coercion forms, Validity re-entry error, integral float text); six requirement-neutral cuts applied (§7); two owner rulings listed in the status header; leftover-sweep grep for pre-revision terminology (`all three backends`, `Python nested-UUID`, `both engines`, `one file`, `byte-identical`, `six call sites`, `§5`) run on the final text.

--- a/docs/specs/string-literals.md
+++ b/docs/specs/string-literals.md
@@ -1,0 +1,307 @@
+# Spec — CozoScript string-literal correctness: JSON escapes in double-quoted strings, `#` inside raw strings (mnestic #53)
+
+_Created 2026-08-28. Source: [shuruheel/mnestic#53](https://github.com/shuruheel/mnestic/issues/53) (upstream cozodb/cozo#223 and cozodb/cozo#234), `docs/strategy/MNESTIC-ROADMAP.md` backlog row 4. Every `file:line` below is relative to the `mnestic/` checkout unless prefixed `mindgraph-rs/` or `.claude/` (the workspace-root `docs/strategy/*.md` and `versions.toml` cited by the roadmap gate, §5 and S25 live in the parent of `mnestic/`, not inside it), and was read against the working tree on 2026-08-28 (HEAD = 0.16.0 era, `cozo-core/Cargo.toml:3`). Behavioural claims marked **(run)** were executed against the installed `mnestic` 0.10.1 Python wheel. The string and comment rules (`cozoscript.pest:72-75`, `:193-219`) and the three decoders (`parse/expr.rs:451-513`) are byte-identical from `fork-base` to HEAD — the pest diff (45+/13−) is confined to other rules; its only hunk touching that region (`@@ -192,3 +220,6 @@`, `git diff -U0 fork-base HEAD -- cozo-core/src/cozoscript.pest`) begins after `string = …` with the `boolean`/`null` word-boundary fix — so the wheel's parser is the working tree's parser for this surface._
+
+**Status: DRAFT — awaiting owner review**
+
+- **Provenance:** Pass 1 code-facts grounding (3 lenses) · Pass 2 lean draft · Pass 3 bounded panel — 26 findings (10 major, 16 minor; 3 were duplicates of another finding), **26 folded, 0 rejected** · Pass 4 prior-art grounding — 7 verdicts (5 CONFIRMS with refinements folded, 1 CONTRADICTS folded as D7, 2 GAPs folded) + 1 essential omission folded as D7 · Pass 5 simplification — 9 requirement-neutral cuts applied (listed in §6.2), 4 owner-ruling cuts listed below, not applied. Triage record: §6.1.
+- **Blockers open: 0.** Two decisions were taken here that the owner may reverse at review without re-running the panel: D2's BMP-only `\u` contract (surrogate pairs stay rejected; the alternative is ≈20 lines in two decoders, R11) and D7's one-release detection warning (the prior-art fold; the alternative is the pass-2 note-only shape, R6).
+- **Owner-ruling cuts (not applied):** (1) drop D7 and ship note-only, as the pass-2 draft did — prior art says no, lean discipline could say yes; (2) delete the dead `raw_string` alternative from `fts_phrase` (`:297`) — a third grammar token, cosmetic; (3) drop the seeded 2,000-string half of D5.4 and keep only the exhaustive ≤4 enumeration plus the D5.2 table; (4) drop B3 (mindgraph-rs `$types` hygiene) from this spec into an ordinary mindgraph-rs commit with no batch row — it is not a prerequisite for the tag.
+- Status is set by the owner: APPROVED after this review; SHIPPED after the B4 tag. This spec never self-approves.
+
+> **Roadmap gate, verbatim** (`docs/strategy/MNESTIC-ROADMAP.md:32`):
+> `| 4 | String-literal correctness (#53) | Ready for design | 3 | 6 | Migration note and soak for changed decoding behavior |`
+>
+> Both halves of the gate are deliverables here: the migration note is D3, the soak is D6 (with D7 as its external-consumer signal). Cx 3 / Ci 6 bounds this to a grammar-modifier change plus a bounded warning, tests, docs and one consumer hygiene conversion — not a lexer or decoder rewrite. No storage-format or public-API change (issue #53, "Scope").
+
+---
+
+## 1. Verified current state
+
+The issue reports two failures. Reading the grammar and running the engine shows they are two symptoms of **one** rule and **one** modifier, plus a third, unreported behaviour (silent whitespace trimming) that the same rule causes and that the fix necessarily changes.
+
+| # | Claim | Where | Consequence |
+|---|---|---|---|
+| S1 | `string` is an ordered choice that tries `raw_string` first: `string = _{(raw_string \| s_quoted_string \| quoted_string)}` | `cozo-core/src/cozoscript.pest:219` | PEG commits to the first alternative that *succeeds*. `quoted_string` is reached only when `raw_string` fails outright. |
+| S2 | `raw_string`'s fence is `PUSH("_"*)` — zero or more underscores | `cozoscript.pest:208` | A bare `"…"` matches `raw_string` with an empty fence. **Every ordinary double-quoted literal in expression position is parsed as a zero-underscore raw string.** |
+| S3 | `raw_string` and `raw_string_inner` are plain `{ }` rules — neither atomic `@{` nor compound-atomic `${` — while `quoted_string` and `s_quoted_string` are `${` | `cozoscript.pest:207`, `:212` vs `:193`, `:200` | pest inserts the implicit `WHITESPACE`/`COMMENT` skip between every sequence element and repetition of a non-atomic rule, so `WHITESPACE` (`:72`) and `LINE_COMMENT`/`COMMENT` (`:74-75`) are live *inside* the raw-string body. |
+| S4 | **(run)** `?[x] <- [["blah\"\""]]` → `parser::pest` at `17..17`; `?[x] <- [["a\"b#"]]` → `parser::pest` at `14..14` | issue #53 case 1; S1+S2 | The zero-fence raw string closes at the first inner `"` (`blah\`), the enclosing list fails on the leftover, and PEG does **not** re-enter `string` to try `quoted_string`. Root cause is S1+S2, not the escape set. |
+| S5 | **(run)** `?[x] <- [[___"#298594"___]]` → `parser::pest` at `13..13`; but **(run)** `_"a # x⏎ b"_` → `a # x⏎ b` (no error) while `_"a⏎ b # x"_` → `parser::pest` | issue #53 case 2; S3; `LINE_COMMENT = _{ "#" ~ (!"\n" ~ ANY)* }` (`:74`) | After the opening `"`, the implicit skip runs `LINE_COMMENT`, which eats to end-of-line. **When the `#` is on the closing quote's line** the closing `"` is gone and the parse fails; when it is on an earlier line of a multi-line literal the comment ends at `⏎`, the literal still closes, and the value is verbatim (the span covers the skipped text). Root cause is S3. |
+| S6 | **(run)** `?[x] <- [["#298594"]]` → `#298594`; `?[x] <- [["a#b"]]` → `a#b`; **`?[n] := n = length("a#\nb")` → `4`**; but **`length("x#⏎y\tz")` → `7`** | S1+S3; `cozoscript.pest:193-199` | The brief's assumption that the zero-fence case fails identically is **wrong**: a `#` on the closing quote's line makes `raw_string` *fail* (comment eats the closing quote), the choice falls through, and `quoted_string` — with full JSON escape decoding — succeeds. So today **a `#` on the closing line silently switches escape decoding ON** for that literal (`a#\nb` is 4 chars: the `\n` became a newline). A `#` on an earlier line does not: `x#⏎y\tz` stays 7 verbatim characters. |
+| S7 | **(run)** `?[x] <- [[" a "]]` → `a`; `[["a\n"]]` (real newline) → `a`; `[["a /* x */ "]]` → `a`; `[[__" a "__]]` → `a`; but `[["a  b"]]` → `a  b`, `[["a /* c */ b"]]` → `a /* c */ b`, `[["/* x */a"]]` → `a`, and `[[" a#b "]]` → ` a#b ` (fall-through to the atomic `quoted_string`, S6) | S3 | **Unreported defect:** the implicit skip before `raw_string_inner` and before the closing `"` strips leading and trailing whitespace (and leading/trailing block comments) from every double-quoted and fenced raw string; interior characters survive because a pest span covers everything between a rule's start and end. |
+| S8 | **(run)** `?[x] <- [[__ "abc" __]]` → `abc` (whitespace between fence and quote accepted) | S3 | A currently-valid spelling that any atomicity fix rejects. Must appear in the migration note. |
+| S9 | **(run)** `"a\nb"` → 4 chars (`length` = 4 vs 3 for `'a\nb'`); `"a\qb"` → `a\qb`; `"a\\"` → 3 chars; `"\t"` → 2 chars; **`?[x, y] <- [["a\", "b"]]` → `a\`, `b`** (a `"…"` ending in a backslash is valid today) | S1+S2; `parse/expr.rs:509-513` | Double-quoted literals decode **nothing** today. `parse_raw_string` returns the inner span verbatim. |
+| S10 | `char` already implements the JSON escape set: `!("\"" \| "\\") ~ ANY \| "\\" ~ ("\"" \| "\\" \| "/" \| "b" \| "f" \| "n" \| "r" \| "t") \| "\\" ~ ("u" ~ ASCII_HEX_DIGIT{4})`; `s_char` mirrors it with `\'` | `cozoscript.pest:195-199`, `:202-206` | The double-quoted escape **contract is already written**. Any fix that edits `char` changes nothing; the job is to make `quoted_string` reachable. Both rules admit raw newlines and control characters (laxer than RFC 8259). The parser runs over a Rust `&str` (`parse/mod.rs:43-44`) and `ANY` (`:196`, `:216`) consumes one Unicode scalar value, so the unit of every literal is the **character**, never a byte; no literal form can express invalid UTF-8. |
+| S11 | `parse_quoted_string` (`:451-478`) decodes the nine escapes, raises `parser::invalid_utf8_code` (`:443`) for an unencodable `\uXXXX` and `parser::invalid_escape_seq` (`:448`) for any other `\`-prefixed token; `parse_s_quoted_string` (`:480-507`) is its `'` twin; `parse_raw_string` (`:509-513`) is verbatim. **Each `\uXXXX` is decoded independently through `char::from_u32` (`:465-470`, `:494-499`) — no surrogate-pair joining.** | `cozo-core/src/parse/expr.rs` | **(run)** `"a\qb#"` → `parser::pest` at `12..12`; `"a\uD800#"` → `parser::invalid_utf8_code`: the grammar rejects unknown escapes first, so `invalid_escape_seq` is a defensive arm; `invalid_utf8_code` **is** reachable. **(run)** `'\uD83D\uDE00'` → `parser::invalid_utf8_code` (55357): a well-formed JSON surrogate pair is rejected in the single-quoted form today, and `"\uD83D\uDE00"` yields the 12 raw characters. Python's `json.dumps` emits exactly that pair for every non-BMP character by default (`ensure_ascii=True`). |
+| S12 | `parse_string` (`:431-439`) is the single dispatch on `Rule::quoted_string \| s_quoted_string \| raw_string \| ident`; consumers: `build_expr` (`parse/expr.rs:262`), FTS `build_phrase` (`parse/fts.rs:94-95`), `::describe` (`parse/sys.rs:236`) | `cozo-core/src/parse/` | One grammar change propagates to every string consumer through one function; no call-site edits. |
+| S13 | `string` is referenced from two grammar positions — `literal` (`:243`, hence every `term`, `:153`) and `describe_relation_op` (`:53`); `fts_phrase` (`:297`) references the three underlying rules directly | `cozo-core/src/cozoscript.pest` | The compatibility enumeration (D3) is closed over these three positions. Validity clauses (`:104`) take `expr`, so they inherit through `literal` — no separate form. |
+| S14 | `fts_phrase = {(fts_phrase_group \| quoted_string \| s_quoted_string \| raw_string) ~ …}` (`:297`) tries `fts_phrase_group` first, and `fts_phrase_simple = @{… (XID_CONTINUE+)}` (`:293`) matches `_` (U+005F is XID_Continue). **The `raw_string` arm is unreachable, before and after D1.** **(run)** with bodies `a b c`, `#tag x`, `x z`, `C:\Users`, `___ y` indexed: FTS `___"#tag"___` → `[[2]]` (parsed as word `___` AND phrase `#tag` AND word `___`, no error); `_"tag"_` → `[[2]]`; `___` → `[]`; `__"zzz" __` → `[]`, no error. Separately, a `"…"` phrase with a non-JSON escape **falls through to the empty-fence raw string**: FTS `"C:\Users"` → `[[4]]` (raw text matched), `"a\qb"` → `[]` with no error. | `cozoscript.pest:293-297`; `parse/fts.rs:94-95` | Raw strings are not available as FTS phrases today and D1 does not make them so (fenced text is tokenised as words). The one FTS behaviour D1 changes is the empty-fence fall-through: it disappears with `_+`, so a `"…"` phrase containing a bad escape becomes a hard `parser::pest` (C12). mindgraph-rs cannot reach either: `sanitize_fts_query` keeps only alphanumerics (`mindgraph-rs/src/storage/cozo.rs:6593-6611`). |
+| S15 | Cypher has an independent grammar and decoder: `string = @{…}` is atomic (`cypher/cypher.pest:82`), `COMMENT` uses `//` and `/* */` only (`:18`), and `unquote` (`cypher/parse.rs:511-542`) passes unknown escapes through (`:534`), accepts `\0` (`:523`) and substitutes U+FFFD for a bad `\uXXXX` (`:530`) | `cozo-core/src/cypher/` | Unaffected by both issue cases; a third, laxer escape contract exists in the fork. Precedent that atomic string rules are the house pattern. |
+| S16 | `#[grammar = "cozoscript.pest"]` on `CozoScriptParser` (`parse/mod.rs:43-44`); `pest = "2.8"` with a load-bearing floor comment (`cozo-core/Cargo.toml:155-159`); lock resolves pest 2.8.7 (`Cargo.lock:3216-3217`) | one grammar file, one parser | `@`/`$` trivia suppression, `PUSH`/`PEEK`/`POP` and ordered-choice commitment are pest 2.8 semantics — no dependency change. Atomicity cascade is documented pest behaviour: `ParserState::atomic` sets `self.atomicity` for the whole closure ("we take atomicity of the top rule and not of the leaf", `pest-2.8.7/src/parser_state.rs:1439-1455`), every nested `state.rule(...)` inherits it, and `PUSH`/`PEEK` do not touch that mechanism. |
+| S17 | No test anywhere covers raw strings or double-quoted escapes: `parse/mod.rs:531` tests error diagnostics only; `parse/fts.rs:149` tests FTS structure; `grep '___"'` over `cozo-core/src`, `cozo-core/tests`, `cozo-lib-python`, `cozo-bin`, `mindgraph-rs/src` = 0 hits; `[dev-dependencies]` (`Cargo.toml:217`) has no proptest/quickcheck/arbitrary | mnestic | Regression net is greenfield; nothing in the suite pins the wrong behaviour, so every migration risk is in *user* scripts. `serde_json` (`Cargo.toml:139`) is a normal dependency and gives a JSON encoder for the round-trip test without a new dev-dep. |
+| S18 | The public docs state the current behaviour as the contract: "Double-quoted strings … take every character between the quotes exactly as typed, backslashes included"; the example pins `length("a\nb")` = 4 (`[3,4]`); a warning callout says escapes are processed "**only in single-quoted strings**" and that this diverges from the upstream manual | `mnestic-site/src/app/docs/types/page.mdx:287-311` | Documented behaviour changes. `page.mdx:295` is the only doc listing whose value changes; the raw-string example at `:314` (`___"a "quoted" word"___`) is unchanged. |
+| S19 | mindgraph-rs interpolates double-quoted literals into CozoScript at exactly three byte-identical sites, all `.map(\|t\| format!("\"{}\"", t)).join(", ")` feeding `is_in(node_type, [{type_list}])`: `src/storage/cozo.rs:10520-10524` and `:10579-10583` (hard-coded ASCII `article_types`, `:10508-10519`) and `:10651-10655` inside `pub fn top_connected_entities(&self, types: &[&str], …)` (`:10641`, script at `:10669`), whose `types` are **caller-supplied** via `MindGraph::top_connected_entities` (`src/graph.rs:1365`) / `AsyncMindGraph` (`src/async_graph.rs:866`, `Vec<String>`); the only in-tree caller passes a hard-coded local `Vec<String>` (`mindgraph-server/src/wiki.rs:1637-1651`, call at `:1660`) duplicating `ARTICLE_ELIGIBLE_TYPES` (`:136`) | `mindgraph-rs/` | One site can receive arbitrary strings from a library caller; no untrusted input reaches it in-tree today. Today a `\` in a type name is passed through verbatim; after the fix it would decode or error. Convert all three to `$params` (D4). |
+| S20 | Every other mindgraph-rs interpolation is single-quoted and either a compile-time constant (`TRAVERSAL_EXCLUDED_EDGE_TYPES`, `cozo.rs:78` used at `:1176`) or a whitelisted `[A-Za-z0-9_]` identifier (`:4022-4030` guard before `:4042`; same guard at `:6987-6994`, `:7011`, `:7054`, `:7077`); values go through `str_val(...)` parameters (`:14169`; 459 sites, e.g. `:9353` feeding `:9358`, `:14133` feeding `:14140`); user FTS text is reduced to alphanumerics before reaching the FTS grammar (`:6593-6611`; `:14907` test) | `mindgraph-rs/src/storage/cozo.rs` | Single-quoted decoding is untouched; no untrusted value reaches a double-quoted literal. `mindgraph-server/src` has no double-quoted interpolation into script text (grep hits are log/prompt strings only); `mindgraph-cloud/src` constructs no CozoScript. |
+| S21 | Corpus census (this pass, by hand): no `.rs`, `.py` under `mnestic/`, `mnestic-site/`, `mindgraph-rs/` contains a fenced raw string, and the only `.md`/`.mdx` hit is the docs example `mnestic-site … types/page.mdx:314` (`___"a "quoted" word"___`, S18 — a proper fence, unchanged by D1); the only double-quoted CozoScript literal with a backslash is `mnestic-site … types/page.mdx:295` (input; value changes). Three further pattern hits are **output-only listings, not scripts**: `types/page.mdx:318` (result JSON), `functions/page.mdx:514` (result JSON), `tips/page.mdx:88` (an `::explain` output table). Rust `format!("\"{}\"", t)` literals in `cozo.rs` (S19) match the same regex and are not CozoScript. | this pass | Beyond `page.mdx:295`, no in-tree script changes meaning. The user-facing corpus (PyPI/crates consumers) is unknowable from here — hence D6 and D7. |
+| S22 | **(run)** `?[x] := x = "a /* " ++ " */ b"` → **one** string `a /* " ++ " */ b`; `?[x] := x = "a # " ++ "⏎ b"` → one string `a # " ++ "⏎ b` | S3; `cozoscript.pest:73-74` | Inside today's zero-fence raw string a block or line comment **hides a `"`**: the comment is skipped, the literal runs on. After D1 the hidden quote terminates the literal and the remainder re-pairs — a today-valid script whose meaning changes silently (C3b). Undetectable by any per-literal check (the re-paired script carries no marker). |
+| S23 | The fork already has a typed warning channel: `crate::runtime::diagnostics::emit(code, message, hint)` (`runtime/diagnostics.rs:50`) pushes into a thread-local sink; `Db::flush_warnings` (`runtime/db.rs:723`) drains it into a 256-entry ring (`WARNING_RING_CAP`, `:384`) at the end of **every** script run, success or error (`:714`), after `parse_script` (`:633`) has run on the same thread; `::warnings` / `Db::recent_warnings` (`:742`) read it. Five emitters exist (`query/reorder.rs:648`, `fixed_rule/algos/pagerank.rs:62`, `runtime/stored_queries.rs:446`, `runtime/graph_projection.rs:1158`, `runtime/db.rs:4070`); codes are dotted and "new ones may appear in any release" (`CHANGELOG-FORK.md:421-441`) | mnestic | A parser-side warning reaches every binding with no FFI, no knob and no grammar change — the existing primitive D7 reuses. |
+| S24 | The docs harness `doc_check` takes **one** `.cozo` file (`.claude/skills/mnestic-docs/scripts/doc_check:4`, `:23-26`) and rebuilds only when a `*.rs` under `cozo-core/src` is newer than the binary (`:30-33`); there is **no** checked-in `.cozo` page corpus — `find mnestic-site mnestic/docs .claude/skills/mnestic-docs -name '*.cozo'` returns only `references/seed.cozo`; the skill's own method says to develop each page's examples in a `.cozo` file kept with the work (`SKILL.md:44-53`) | `.claude/skills/mnestic-docs/` | A `.pest`-only change would not trigger the rebuild, and "every `.cozo` page file" iterates over nothing. D6.2 names real inputs and forces the rebuild. |
+| S25 | CI: `build.yml` runs on push/PR only (`:3-7`); the string suite would run in the `cargo test -p mnestic --verbose` step (`:25`, feature-ungated per the warning at `:26-28`). The two scheduled workflows are `planner-guard.yml` (nightly cron `:22`, also `pull_request:` at `:24`; LSQB execution tier `--test lsqb --ignored`, `:67`) and `dependency-freshness.yml` — neither runs the string suite. Release cadence: "mnestic ships independently and often (liveness-first)" (`versions.toml:11`); 0.17.0 is the pending merged-import release (`MNESTIC-ROADMAP.md:29`) | mnestic | "Days on main with nightly green" adds no signal beyond the merge-time run; a downstream deploy gate would be an upward dependency. D6.3 is one sentence. |
+
+---
+
+## 2. Decisions
+
+### D1 — Grammar change: two edits on one rule, nothing else
+
+**Seam:** `cozo-core/src/cozoscript.pest:207-208` (`raw_string`). No change to `char`/`s_char` (`:195-206`), `quoted_string`/`s_quoted_string` (`:193`, `:200`), `string` (`:219`), `fts_phrase` (`:297`), `LINE_COMMENT`/`BLOCK_COMMENT`/`COMMENT` (`:73-75`), or `raw_string_inner` (`:212-217`).
+
+```pest
+raw_string = ${                    # was: raw_string = {
+    PUSH("_"+) ~ "\""              # was: PUSH("_"*)
+    ~ raw_string_inner
+    ~ "\"" ~ POP
+}
+```
+
+1. **`PUSH("_"+)`** — a raw string needs at least one underscore. A bare `"` can no longer match `raw_string`, so `string`'s ordered choice reaches `quoted_string` for every `"…"` literal (fixes #223 / S4). In expression and `::describe` position the three forms become unambiguous on their first character: `'` → single-quoted, `"` → double-quoted, `_` → raw. The fence is unbounded (Rust caps `r#…` at 255 hashes; with `PUSH`/`POP` an unbounded `_+` is harmless and no cap is added). This is pest's own stack-idiom example (Rust raw strings via `PUSH("#"*)`/`POP`); Rust affords zero hashes only because the `r` prefix disambiguates — without a prefix, `_+` *is* the prefix.
+2. **`${`** — `raw_string` becomes compound-atomic. pest's implicit `WHITESPACE`/`COMMENT` skip is suppressed inside it, and atomicity cascades into the plain `raw_string_inner` by documented pest semantics (S16: `ParserState::atomic` holds the top rule's atomicity for every nested rule; only an explicit `!{}` rule stops the cascade) — the same construct as `quoted_string = ${…}` over `quoted_string_inner = { char* }` (`:193-194`), which is what makes `"a#b"` come back intact via the fall-through in S6. `raw_string_inner` keeps its `{ }` body so `parse_raw_string`'s `into_inner().next()` (`expr.rs:511`) still finds the inner pair (an `@{` on the outer rule would erase it). Fixes #234 (S5), the whitespace trim (S7) and the fence-gap acceptance (S8).
+
+Expected values are the "After D1" column of §4; B1's suite is the verification. Why not only (2): atomicity alone leaves `"blah\"\""` broken (S4 is independent of trivia). Why not only (1): a fenced `___"#…"___` still fails (S5). Why not reorder `string` instead of (1): §6 R1.
+
+### D2 — Decoding contract per form (normative source = existing code)
+
+**Seam:** `cozo-core/src/parse/expr.rs:431-513` (`parse_string` + three helpers) — **no decoder-semantics change**; this decision pins what the grammar routes to them. (D7 adds a warning emission to two of them; it never alters a returned value.)
+
+| Form | Grammar | Decoder | Recognised escapes | Cannot contain |
+|---|---|---|---|---|
+| Double-quoted `"…"` | `quoted_string` `:193`, `char` `:195-199` | `parse_quoted_string` `:451` | `\"` `\\` `\/` `\b` `\f` `\n` `\r` `\t` `\uXXXX` — the RFC 8259 §7 escape grammar, **BMP only**: each `\uXXXX` is one code point, a surrogate pair is `parser::invalid_utf8_code`, no `\U` | an unescaped `"`; a `\` not followed by one of the nine |
+| Single-quoted `'…'` | `s_quoted_string` `:200`, `s_char` `:202-206` | `parse_s_quoted_string` `:480` | same nine with `\'` in place of `\"`; same BMP-only rule (unchanged since `fork-base`) | an unescaped `'`; a stray `\` |
+| Raw `_…_"…"_…_` (n ≥ 1 underscores each side, equal) | `raw_string` `:207` (per D1) | `parse_raw_string` `:509` | **none** — the characters between the delimiters are the value | a `"` followed by **n or more** underscores (`PEEK` matches a prefix, `:214`; **(run)** `__"a"___` → `parser::pest`) |
+
+Contract statements:
+
+- **Laxer than JSON, deliberately:** both quoted forms accept raw newlines, `␍`, and control characters inside the literal (`char`'s first alternative admits any character but `"` and `\`). Single-quoted strings have always behaved this way; double-quoted strings match them. Raw strings admit `␍` too (Rust forbids CR in raw strings; we do not — §4 has a CRLF row). No change.
+- **Unit is the character.** Scripts are UTF-8 `&str` (S10); no form can express invalid UTF-8 or a bare byte.
+- **Unknown escapes are a parse error at the backslash** (C4), code `parser::pest`, offset = the `\` (S11). A `"…"` literal that *ends* in `\` is a different failure: `\"` consumes the closing quote and the literal runs to the next `"` or end of input (C5, remote offset). `parser::invalid_escape_seq` stays as a defensive arm; the spec does not promise it. `parser::invalid_utf8_code` is the one decoder error a user can reach (`"\uD800"`, and any surrogate pair).
+- **BMP only, stated where users read it:** RFC 8259 §7 says `"\uD834\uDD1E"` *is* U+1D11E; this engine rejects it, exactly as `'…'` always has. Python callers must use `json.dumps(s, ensure_ascii=False)` or `$params`; every other client should pass non-BMP text raw (`serde_json::to_string` already does). The note, `page.mdx` and §4 carry `"😀"`-shaped rows. Joining pairs is R11 (owner-reversible).
+- **Raw strings are the escape hatch:** a raw string can represent every string except one containing its own closing delimiter; choosing n greater than the longest run of underscores following any `"` in the content always works (I1). This is Rust's `r#"…"#` rule and PostgreSQL's `$tag$…$tag$` rule with `_` for the tag.
+- **`#`, `/*`, `*/`, `//` are ordinary characters inside all three forms.** Comment recognition happens only between tokens. Enforced by atomicity (D1.2), not by editing `COMMENT` — the same mechanism PostgreSQL (`'this -- is not a comment'`) and SPARQL §19.4 use: the string token is lexed as one unit.
+- **Identifier adjacency:** `x_"a"_` and `_x_"a"_` are parse errors today and after D1 (**(run)**; `term` tries `literal` before `var`, `:153`; after `_+` fails at the required `"` the choice falls to `var` and the leftover `"a"_` fails) — PostgreSQL's dollar-quote-after-identifier rule, pinned as a §4 row rather than left as a note.
+- **FTS phrase literals** (`fts_phrase`, `:297`): `quoted_string` and `s_quoted_string` are live and decode as in expression position; the `raw_string` alternative is **dead code before and after D1** (S14) — raw strings are not available as FTS phrases, a fenced query is tokenised as bare words. Left as is (R10; owner-ruling cut 2). The one FTS change is C12.
+- **Cypher is out of scope, explicitly.** `cypher/parse.rs:511 unquote` keeps its lenient contract (`\q` → `q`, `\0` accepted, bad `\u` → U+FFFD). Recording the divergence here is the deliverable; aligning it is a separate row because the Cypher surface is alpha and feature-gated (`docs/specs/cypher-read.md:3`) and has no reported bug.
+
+### D3 — Compatibility: what changes meaning, and the migration note
+
+**Seam:** the three positions of S13 — `literal` (`:243`) in every expression, `::describe` (`:53`, `parse/sys.rs:236`), `fts_phrase` (`:297`) — plus `mnestic-site/src/app/docs/types/page.mdx:287-311` and `CHANGELOG-FORK.md` (Unreleased).
+
+The #234 half is a widening **only for single-line fenced strings**: a `#` on the closing line of a fenced raw string always ended in a hard parse error (S5). A multi-line fenced string with `#` on an earlier line parses today (S5) and only changes under the trim rule (C10). The #223 half changes the value of currently-valid scripts. Exhaustive enumeration:
+
+| Class | Script today | Value today | After D1 | Kind |
+|---|---|---|---|---|
+| C1 | `"…"` containing one of the nine escapes, e.g. `"a\nb"`, `"C:\\x"`, `"\u0041"`, `"a\b"`; includes a multi-line `"…"` with `#` on an earlier line and an escape later (`"x#⏎y\tz"`, S6) | backslash kept (`a\nb` = 4 chars; `x#⏎y\tz` = 7) | decoded (`a⏎b` = 3 chars; `C:\x`; `A`; `a` + U+0008; 6 chars) | **silent value change** — the roadmap's "changed decoding behavior"; D7 warns |
+| C2 | `"…"` with leading/trailing whitespace or newlines, e.g. `" a "`, a multi-line literal starting with `⏎` | trimmed to `a` (S7) | preserved: ` a ` | **silent value change** (unreported today); D7 warns |
+| C3 | `"…"` with a leading/trailing block comment, e.g. `"/* x */a"` | `a` (S7) | `/* x */a` | silent value change; no in-tree occurrence; D7 warns |
+| C3b | `"…"` whose body contains a block or line comment that itself contains a `"`, e.g. `"a /* " ++ " */ b"` (S22) | one string `a /* " ++ " */ b` | two strings: `a /* ` ++ ` */ b` = `a /*  */ b` | silent value change, **remainder re-pairs; not detectable** (§7.1) |
+| C4 | `"…"` with `\` before any other character, e.g. `"C:\Users"`, `"a\qb"` | raw characters | `parser::pest` at the `\` | **loud** — parse error at a precise offset |
+| C5 | `"…"` ending in a backslash, e.g. `"a\"`, `"C:\Users\"` | `a\` (valid, S9) | `\"` escapes the closing quote → the literal runs to the next `"` → `parser::pest` **at end of input or a later token**, not at the backslash (**(run)** single-quoted analogue: `?[x] <- [['a\']]` → `16..16` = EOI) | **loud, remote offset** — the least diagnosable class; named in the note |
+| C6 | `"…\"…"` (issue case 1) | error at the leftover | works | widening (#223) |
+| C7 | `"…#…"` with the `#` on the closing quote's line | already decoded via fall-through (S6) | decoded | **unchanged** — but `" a#b "` now keeps its spaces (C2) |
+| C8 | fenced `_"…#…"_` with the `#` on the closing line (issue case 2) | error | works | widening (#234) |
+| C9 | fenced with a gap: `__ "abc" __` (S8) | `abc` | `parser::pest` at the space | loud |
+| C10 | fenced with leading/trailing whitespace or comment inside: `__" a "__`; includes multi-line fenced strings with `#` on an earlier line (S5) | `a` | ` a ` | silent value change (same mechanism as C2); D7 warns |
+| C11 | `::describe rel "…"` with any of C1–C5 | stored as today's value | stored as the new value **only when re-executed**; existing stored descriptions are untouched (no storage change) | as C1–C5, persisted |
+| C12 | FTS phrase `"…"` containing a `\` not followed by one of the nine escapes (S14) | silently accepted as raw text via the empty-fence fall-through | `parser::pest` | **loud** on the direct-mnestic FTS surface; unreachable from mindgraph-rs (S14) |
+| C13 | FTS phrase `"…"` with valid escapes, or `_"…"_` in an FTS query | already `quoted_string`; fenced text tokenised as words (S14) | identical | none |
+| C14 | `$params`, single-quoted `'…'`, ordinary line/block comments between tokens, `""`, `__""__` | — | identical (**(run)**: `?[x] <- [["a"]] # c` and `""` both work today and are covered by D5) | none |
+
+**Migration note (ships in `CHANGELOG-FORK.md` Unreleased and the release readme, following the FTS-phrase entry's shape at `CHANGELOG-FORK.md:353-365` — named error where one exists, workaround in the text, external citation):**
+
+> **Double-quoted strings now decode JSON escapes; raw strings are comment-proof.** Fixes upstream cozo#223 / cozo#234 (mnestic #53).
+>
+> - `"…"` literals follow the RFC 8259 §7 escape grammar — `\" \\ \/ \b \f \n \r \t \uXXXX` — exactly as `'…'` already did. `\uXXXX` is one BMP code point; a surrogate pair (`"\uD83D\uDE00"`) is rejected with `parser::invalid_utf8_code`, as it always was in `'…'`. Pass non-BMP text raw (Python: `json.dumps(s, ensure_ascii=False)`) or as a `$param`.
+> - `_"…"_` raw strings (one or more underscores, equal on both sides) take every character verbatim, including `#`, `/*` and newlines. A bare `"…"` is no longer a raw string. The only thing a raw string cannot contain is a `"` followed by as many (or more) underscores as its fence — use a longer fence.
+>
+> **Behaviour changes for existing scripts:**
+>
+> 1. A `"…"` literal containing one of the nine escapes **changes value**: `"a\nb"` is now 3 characters, not 4; `"C:\\x"` is now `C:\x`. Silent — check your scripts for `"` … `\` … `"`; for one release the engine reports each such script once as warning `parser.string_decoding_changed` (`::warnings`).
+> 2. A `"…"` literal containing a backslash before any other character is now a **parse error at the backslash** (`parser::pest`). Rewrite as `'…'` with `\\`, or as a raw string: `_"C:\Users"_`. The same applies to a `"…"` phrase inside a full-text query.
+> 3. A `"…"` literal **ending in a backslash** (`"C:\Users\"`) is now unterminated: the `\"` escapes the closing quote and the literal continues to the next `"`; the parse error points at the end of input or a later token, not at the backslash. Write `\\"` or use a raw string.
+> 4. Leading and trailing whitespace (including newlines and block comments) inside `"…"` and raw strings is now **preserved**; it was silently trimmed (also reported by the warning above).
+> 5. Whitespace between a raw string's underscores and its quote (`__ "abc" __`) is no longer accepted.
+> 6. A comment inside a `"…"` literal no longer hides a `"` it contains — the quote now closes the literal. This case cannot be warned about; grep for `"` … `/*` … `"` … `*/`.
+> 7. `::describe` descriptions re-executed after upgrade store the new value; stored descriptions are untouched until then.
+>
+> Unaffected: `$params`, single-quoted strings, comments between tokens. Parameters remain the recommended path for untrusted input. Precedent: JSON (RFC 8259) for the quoted forms; Rust `r#"…"#` and PostgreSQL dollar-quoting for the fenced raw form; PostgreSQL's `escape_string_warning` for the one-release warning.
+
+The `page.mdx:287-311` paragraph, example (`[3,4]` → `[3,3]`) and warning callout are rewritten in the same commit; the callout is replaced by a note that the engine now matches the upstream manual, with the BMP-only sentence.
+
+### D4 — Blast radius into mindgraph-rs: three interpolation sites become one parameter helper
+
+**Seam:** `mindgraph-rs/src/storage/cozo.rs:10520-10524`, `:10579-10583`, `:10651-10655` (S19).
+
+- All three `is_in(node_type, [{type_list}])` sites (script text at `:10669` for `top_connected_entities`) become `is_in(node_type, $types)` with `params.insert("types", DataValue::List(types.iter().map(|t| str_val(t)).collect()))` through one small helper; `top_connected_entities` already carries `params` for `min_edges`/`limit` (`:10661-10662`). No double-quoted interpolation of a type list remains in mindgraph-rs, so no audit note has to be maintained.
+- Nothing else changes: S20 shows every remaining literal is single-quoted (untouched by D1) and either constant or `[A-Za-z0-9_]`-guarded; all values go through `$params`. `mindgraph-server` and `mindgraph-cloud` build no double-quoted literals. FTS user text is reduced to alphanumerics upstream (`cozo.rs:6593-6611`), so neither S14 nor C12 can surface through `/retrieve`.
+- No mindgraph release is required by this change; the conversion ships in the next ordinary mindgraph-rs commit and is *not* a prerequisite for the mnestic tag (the in-tree caller passes constants).
+
+### D5 — Tests: one new integration suite, no new dependency, `mem` backend throughout
+
+**Seam:** new file `cozo-core/tests/string_literals.rs` (house convention: one suite per spec, cf. `fts_phrase.rs`, `pareto_skyline.rs`; `fork_regressions.rs` is the naming precedent for upstream-bug regressions). Picked up by the existing `cargo test -p mnestic --verbose` step (`.github/workflows/build.yml:25`) with no workflow edit — it must stay feature-ungated, per that workflow's own warning (`:26-28`). Parsing precedes backend dispatch and no stored-relation join is involved, so the `spec_doc_validation.rs:9-12` sqlite rule does not apply; **(run)** `::describe` + `::relations` work on `mem` (description column read back as `l1\nl2` today), so the whole suite runs on `mem`.
+
+1. **Issue regressions** (issue #53 scope line 1), asserting the post-fix contract; the §4 table is the record of the pre-fix values.
+   - #223: `?[x] <- [["blah\"\""]]` → `blah""`.
+   - #234: `?[x] <- [[___"#298594"___]]` → `#298594`; `#` at start, middle, end of body; `#` immediately before the closing delimiter; `/* … */` and `*/` inside a raw body (the runtime pin for the atomicity cascade, S16); a newline and a `␍␊` inside a raw body; a multi-line raw body with `#` on its first line (`_"a # x⏎ b"_` → `a # x⏎ b`, unchanged) and on its last line (`_"a⏎ b # x"_` → `a⏎ b # x`, was error).
+2. **Per-form decoding table** — one `run_script` per row of D2: each of the nine escapes individually in `"…"` and in `'…'` (the D5.4 encoder never emits `\/`, `\b`, `\f` or `\u`, so this table is their only coverage — by design); `"\u0041"` → `A`, `"\u00e9"` → `é`; `"\uD800"` and `"\uD83D\uDE00"` → `parser::invalid_utf8_code`; `"😀"` raw → `😀`; `"a\qb"` and `"C:\Users"` → `parser::pest` with the error offset asserted at the `\`; `"a\"` → `parser::pest` with the offset asserted at **EOI** (the remote position of C5, pinned); `""`, `''`, `_""_`, `___""___`; delimiter-like substrings (`"a'b"`, `'a"b'`, `__"a"_"__` → `a"_`, `__"a"_b"__` → `a"_b`); `__"a"___` → error (the n-or-more pin); leading/trailing whitespace preserved in all three forms (C2/C10); `"x#⏎y\tz"` → 6 chars; `__ "abc" __` → error (C9); fence mismatch `_"a"` and `"a"_` → error; identifier adjacency `x_"a"_` and `_x_"a"_` → error.
+3. **Comments still comments:** `?[x] <- [["a"]] # tail`, a `# line` between rules, `/* block */` between tokens, and `"a" /* c */ , "b"` inside a list — all parse and yield the expected rows. Plus the C7 pin `" a#b "` → ` a#b ` and the C3b pin `x = "a /* " ++ " */ b"` → `a /*  */ b`.
+4. **Round-trip property test, bounded, batched, dependency-free:** for every string over the alphabet `{a, ", ', \, #, _, /, *, ␠, ⏎, n, u, 0}` of length ≤ 4 (1 + 13 + 13² + 13³ + 13⁴ = 30,941 strings, empty string included), plus 2,000 strings of length 5–40 from a seeded xorshift generator over that alphabet extended with `é`, `😀` and `␍` (seed fixed in the test), encode each with (a) `serde_json::to_string` for `"…"`, (b) a local single-quote encoder mirroring `s_char`, (c) a raw fence of `1 + max run of _ after any "` underscores — and assert the original value comes back for all three encodings. Shape: batched, `?[x] <- [[lit1],[lit2],…]` in chunks of ≤ 1,000 literals per script per encoding, compared against the expected list (≈ 99 scripts total; measured 3.2 ms per 1,000-literal script on the 0.10.1 release wheel, ≈ 0.3 s; debug-profile pest is slower but stays well inside the default job). Hard cap is the enumeration bound, stated in the test's doc comment.
+5. **FTS surface:** `parse_fts_query` (`parse/fts.rs:19`, crate-private → test lives as a `#[cfg(test)]` addition to `parse/fts.rs:149`'s module) accepts `"a \"b\" c"` as a phrase with kernel `a "b" c`, `is_phrase = true`; `"C:\Users"` → error after D1 (C12; today a phrase with the raw text); `___"#tag"___` → three `fts_expr`s (word, phrase `#tag`, word) both before and after, pinning S14.
+6. **`::describe` round-trip:** `::describe t "l1\nl2"` stores a two-line description (today the six characters `l1\nl2`, backslash included — read back through `::relations`, description column), and `::describe t _"x # y"_` stores `x # y` (today: `parser::pest`).
+7. **D7 warning:** `?[x] <- [["a\nb"], ["c\td"]]` yields exactly one `parser.string_decoding_changed` in `::warnings` (first literal's offset in the message); `" a "` and `__" a "__` yield one each; `"abc"`, `'a\nb'`, `_"a\nb"_` and `$params` yield none; a failing script that contains an escaped literal still leaves the warning in the ring (flush on error, `db.rs:714`).
+
+### D6 — Soak plan (the second half of the gate)
+
+The change turns errors into successes *and* silently alters values (C1–C3, C10), which is why a plain test pass is not the gate. What the gate's "soak" consists of — stated so it is closed by evidence that exists:
+
+1. **In-tree census = S21.** Done by hand in this pass; the B1 PR description pastes the grep (`grep -rnE '"[^"]*\\[^"]*"' … --include='*.mdx' --include='*.rs' --include='*.py'`, plus the `_+"` fence pattern and the multi-line shapes `"` … (`/*`|`#`) … `"` … (`*/`|⏎) … `"`) and its hit list with each hit classified — expected: `types/page.mdx:295` (C1), the fenced raw-string example `types/page.mdx:314` (valid fence, unchanged), the three output-only listings of S21 and the Rust `format!` literals of S19 (not scripts). No engine test file walks consumer paths (that would point the dependency upward). **Stop condition:** any hit not already listed in S21 is triaged before merge.
+2. **Consumer suites against the patched engine.** `cargo test -p mnestic` (as `build.yml`), then `cd mindgraph-rs && cargo test --all-features` against the sibling path dep, then `.claude/skills/mnestic-docs/scripts/doc_check types.cozo` where `types.cozo` is the new example file B2 adds (the listings of `types/page.mdx:287-320`, per the skill's step 4/5) — after forcing the harness rebuild (`cargo build --manifest-path .claude/skills/mnestic-docs/scripts/harness/Cargo.toml`; B2 also widens the guard at `doc_check:30` to `\( -name '*.rs' -o -name '*.pest' \)` so a grammar-only change can never be validated against a stale binary again). Transcripts pasted in the B2 PR. **Stop condition:** any listing whose output differs from the rewritten page.
+3. **Release vehicle.** Rides **0.18.0** — 0.17.0 is the pending merged-import release (`MNESTIC-ROADMAP.md:29`) and this change does not hold it; never a patch. No calendar hold, no nightly clause, no downstream-deploy gate (S25).
+4. **External-consumer signal = D7** for one release, plus the migration note. Not part of the soak: no telemetry, no compatibility flag, no dual-decoding mode.
+
+### D7 — One-release detection warning for silently changed literals
+
+**Seam:** `cozo-core/src/parse/expr.rs:451` (`parse_quoted_string`) and `:509` (`parse_raw_string`), emitting through the existing `crate::runtime::diagnostics::emit` (`runtime/diagnostics.rs:50`, S23); one new 6-line `emit_once(code, …)` helper beside it that skips if the thread-local sink already holds that code. ≈ 25 lines total; no grammar, no `Db` knob, no storage change, no change to any returned value.
+
+- **Code:** `parser.string_decoding_changed` (dotted, per the house convention at `CHANGELOG-FORK.md:421-441`, whose table gains a row).
+- **Fires when** a `"…"` literal contains at least one escape (any `char` pair whose text starts with `\` — its value differs from the 0.16 value, C1), or when the inner span of a `"…"` or fenced raw literal starts or ends with whitespace, or starts with `/*` or ends with `*/` (would have been trimmed, C2/C3/C10). Never for `'…'` (unchanged), `$params` (never lexed), or a `"…"` with no escape and no edge trivia. C3b is not detectable (S22) and is not claimed.
+- **Bound:** at most **one** warning per script run — the first qualifying literal, with its character offset in the message; the ring cap (256, `db.rs:384`) is the outer bound as for every other code. Message: `double-quoted/raw literal at <offset> is decoded differently since 0.18.0 (JSON escapes applied; edge whitespace kept)`; hint: `if the old verbatim text was intended, write it as a raw string _"…"_; if the new value is intended, ignore — this warning is removed in 0.19.0`.
+- **Reach:** every binding, via `::warnings` / `Db::recent_warnings` — including `parse_fts_query` (same thread, same drain). Literals parsed outside a script run (the Python `eval_expressions` path) sit in the thread-local sink until that thread's next flush, per the existing contract (`db.rs:718-722`).
+- **Lifetime:** ships in the same minor as D1 (0.18.0); **deleted in 0.19.0** — a one-line `CHANGELOG-FORK.md` removal entry, added to the Unreleased section at tag time so it cannot be forgotten. Codes are "match the ones you know, ignore the rest" (`CHANGELOG-FORK.md:440-441`), so removal is not a breaking change.
+- **Why a warning and not a flag (R6):** the decoded value is the new value regardless; nothing is threaded through `Db`; there is no second decoder and no second migration. Precedent: PostgreSQL's `escape_string_warning` (8.1, on by default), the detection signal it judged necessary before flipping `standard_conforming_strings` in 9.1 — the only production precedent for exactly this change.
+
+---
+
+## 3. Invariants
+
+- I1 **Representability.** For every `&str` value `s`, at least one literal form encodes `s`: JSON-escaped `"…"` always does for BMP text and raw non-BMP text; `'…'` likewise; a raw string does iff `s` does not contain `"` followed by `n` or more underscores for the chosen `n` (choose `n` larger than any such run).
+- I2 **Form is decided by the first character — in expression and `::describe` position.** `'` → single-quoted, `"` → double-quoted, `_+"` → raw. No fall-through between forms exists after D1.1. In FTS position the bare-word group is tried first, so a leading `_` is a word and raw strings do not exist there (S14).
+- I3 **Comment recognition never crosses a string boundary.** Inside any of the three forms, `#`, `//`, `/*`, `*/` are data. Between tokens, `LINE_COMMENT`/`BLOCK_COMMENT` behave exactly as at `cozoscript.pest:73-75` today.
+- I4 **Whitespace inside a literal is data.** No trimming, in any form.
+- I5 **Raw strings are character-verbatim.** `parse_raw_string` returns the inner span unchanged (`expr.rs:509-513`); the only unrepresentable sequence is a `"` followed by n or more underscores.
+- I6 **Escape sets are closed and shared.** Double- and single-quoted forms accept the same nine escapes (differing only in which quote is escapable); anything else after `\` is a parse error. The set is the RFC 8259 §7 escape grammar, BMP-only, and is not extended (no `\0`, no `\x`, no `\U`, no surrogate joining).
+- I7 **One decoder entry point.** All string consumers route through `parse_string` (`expr.rs:431`); no consumer re-implements decoding for CozoScript (Cypher is a separate language with its own documented contract, D2).
+- I8 **Parameters are unaffected.** `$x` binding bypasses the lexer entirely; nothing in this spec changes a bound value.
+- I9 **No storage or API change.** Stored `::describe` text and every relation's bytes are untouched by the upgrade; only re-executed scripts see the new decoding.
+- I10 **D7 never changes a value.** The warning is emitted beside the decoded result; removing it in 0.19.0 changes no parse.
+
+---
+
+## 4. Acceptance tests
+
+Each row is a `cozo-core/tests/string_literals.rs` test unless marked otherwise; `✓` marks rows pinned by an engine run in this pass (pre-fix behaviour, the record of the flip), `→` the post-fix expectation the test asserts.
+
+| Script | Today ✓ | After D1 → |
+|---|---|---|
+| `?[x] <- [["blah\"\""]]` | `parser::pest` 17..17 | `blah""` |
+| `?[x] <- [[___"#298594"___]]` | `parser::pest` 13..13 | `#298594` |
+| `?[n] := n = length("a\nb")` | 4 | 3 |
+| `?[n] := n = length("x#⏎y\tz")` (multi-line, `#` on line 1) | 7 | 6 |
+| `?[x] <- [["\u0041"]]` | `\u0041` | `A` |
+| `?[x] <- [["a\qb"]]` | `a\qb` | `parser::pest`, offset at `\` |
+| `?[x] <- [["a\"]]` (C5) | `a\` | `parser::pest` at EOI (16..16) |
+| `?[x] <- [["a\uD800"]]` | `a\uD800` | `parser::invalid_utf8_code` |
+| `?[x] <- [["\uD83D\uDE00"]]` (JSON surrogate pair) | 12 raw chars | `parser::invalid_utf8_code` (BMP-only, D2) |
+| `?[x] <- [["😀"]]`, `[['😀']]`, `[[_"😀"_]]` | `😀` (all three) | `😀` |
+| `?[x] <- [[" a "]]` | `a` | ` a ` |
+| `?[x] <- [[__" a "__]]` | `a` | ` a ` |
+| `?[x] <- [[__ "abc" __]]` | `abc` | `parser::pest` |
+| `?[x] <- [["a#b"]]`, `[[" a#b "]]` | `a#b`, ` a#b ` | same (C7) |
+| `?[x] := x = "a /* " ++ " */ b"` (C3b) | `a /* " ++ " */ b` (one string) | `a /*  */ b` (two strings) |
+| `?[x] <- [[_"a /* c */ b # d"_]]` | `parser::pest` | `a /* c */ b # d` |
+| `?[x] <- [[_"a # x⏎ b"_]]` / `[[_"a⏎ b # x"_]]` | `a # x⏎ b` / `parser::pest` | `a # x⏎ b` / `a⏎ b # x` |
+| `?[x] <- [[_"a␍␊b"_]]`, `[["a␍␊b"]]` (CRLF inside) | 4 chars | 4 chars |
+| `?[x] <- [["a"]] # tail` / block comment between tokens | `a` | `a` |
+| `?[x] <- [[""]]`, `[['']]`, `[[__""__]]` | `` | `` |
+| `?[x] <- [[__"a"_"__]]`, `[[__"a"_b"__]]` | `a"_`, `a"_b` | `a"_`, `a"_b` |
+| `?[x] <- [[__"a"___]]` (n or more) | `parser::pest` | `parser::pest` |
+| `?[x] <- [[_"a"]]`, `[["a"_]]` | `parser::pest` | `parser::pest` |
+| `?[x] := x = x_"a"_`, `[[_x_"a"_]]` (identifier adjacency) | `parser::pest` | `parser::pest` |
+| `?[x] <- [['a\nb']]` (single-quoted, control) | 3 chars | 3 chars |
+| round-trip enumeration (D5.4) | n/a | all 30,941 + 2,000 strings round-trip through all three encodings, batched |
+| `parse_fts_query("\"a \\\"b\\\" c\"")` (`parse/fts.rs` module test) | phrase `a "b" c` | phrase `a "b" c`, `is_phrase = true` |
+| `parse_fts_query("\"C:\\Users\"")` | phrase with raw text `C:\Users` | `parser::pest` (C12) |
+| `parse_fts_query("___\"#tag\"___")` | word `___`, phrase `#tag`, word `___` | identical (S14 pin) |
+| `::describe t "l1\nl2"` then `::relations` | `l1\nl2` (6 chars, backslash kept) | `l1⏎l2` (5 chars) |
+| `::describe t _"x # y"_` then `::relations` | `parser::pest` | `x # y` |
+| `?[x] <- [["a\nb"], ["c\td"]]` then `::warnings` (D7) | no such code | exactly one `parser.string_decoding_changed` |
+| `?[x] <- [["abc"], ['a\nb'], [_"a\nb"_]]` then `::warnings` (D7) | no such code | none |
+| mindgraph-rs `top_connected_entities(&["Per\"son"], 1, 5)` (D4; mindgraph-rs test) | parse error | `Ok(vec![])` — the type is bound, not lexed |
+
+---
+
+## 5. Layering ruling
+
+Per `docs/strategy/LAYERING.md` (checklist 1–5, `:31-35`): this is lexer/grammar **mechanism** in the engine — a stranger running a fraud graph hits the same two bugs, it carries no cognitive vocabulary, it is stable, and it is pulled by a real consumer report (#53, filed from MindGraph usage) *and* fits the "better CozoDB" wedge (two long-open upstream issues). D7 rides the engine's own diagnostics channel, a mechanism that already exists. **Verdict: mnestic — this spec IS a mnestic spec.** MindGraph's only obligation is the D4 hygiene conversion, which is independent of the engine change. Nothing moves across the seam; no primitive is added; no engine behaviour is shaped by a MindGraph concept; no engine file references a consumer path.
+
+---
+
+## 6. Rejected alternatives
+
+- **R1 — Reorder `string` to `quoted_string | s_quoted_string | raw_string` and keep `PUSH("_"*)`.** Fixes #223 for well-formed literals, but a `"…"` with an invalid escape (`"C:\Users"`) would make `quoted_string` fail and *fall through* to the zero-fence raw string, silently yielding raw text — exactly what the FTS surface does today (S14, C12). Two spellings for one lexical form with data-dependent meaning is what I2 forbids. Rejected: requiring `_+` makes the form decidable from the first character.
+- **R2 — Make `raw_string` `@{` atomic.** Erases the inner pair; `parse_raw_string` (`expr.rs:511`) `unwrap()`s it. Would need a decoder edit to slice the span manually. `${` is the zero-decoder-change modifier and matches `quoted_string`'s existing form.
+- **R3 — Edit `char` to "add escapes".** `char` already carries the full JSON set (S10); the rule is unreachable, not incomplete. An implementer who patches here ships nothing. Recorded so the change is not re-attempted at the wrong seam.
+- **R4 — Scope the `#` fix to `LINE_COMMENT` (e.g. only treat `#` as a comment at line start or after whitespace).** Changes comment semantics language-wide for a bug that is purely a string-rule atomicity omission; would break `x = 1 # c`. No production language checked (PostgreSQL, SPARQL) does this — every one makes the string token atomic instead. Rejected.
+- **R5 — Keep zero-fence raw strings by adding a fourth form (e.g. `r"…"`).** New syntax for a behaviour nobody documented as wanted (the mnestic-site callout at `page.mdx:306` describes it as an accident relative to the upstream manual). Fenced `_"…"_` is a one-character migration. Rejected as speculative surface.
+- **R6 — Compatibility flag / dual decoding for one release.** Two decoders for the same literal, a runtime knob to thread through `Db`, and a second migration later. Rejected as machinery for a customer that does not exist. What prior art (PostgreSQL 8.1→9.1) actually required was a *detection signal*, not a second decoder — that is D7, which costs no knob and no grammar. If the owner cuts D7 (owner-ruling cut 1), R6 stands unchanged and §7.1's user-corpus risk reverts to unmitigated.
+- **R7 — Align the Cypher `unquote` decoder in this spec.** Different language, different grammar, alpha and feature-gated, no bug report. Recording the divergence (D2) is enough; a merge would widen a Cx-3 change into two surfaces.
+- **R8 — Add `proptest` for the round-trip test.** New dev-dependency and, per `build.yml:26-28`, a new explicit CI step if feature-gated. A bounded exhaustive enumeration plus a seeded generator gives the same coverage with no dependency and a stated cap (D5.4).
+- **R9 — Extend the escape set (`\0`, `\x41`, `\U0001F600`).** Not JSON; not what the upstream manual promises; adds a third contract. The 8-digit `\U` form is a divergence from the whole neighbourhood (SPARQL 19.7, Neo4j Cypher, PostgreSQL E-strings all offer it), recorded as such; still out of scope — the raw form and `$params` carry any code point.
+- **R10 — Reorder `fts_phrase` to `(quoted_string | s_quoted_string | raw_string | fts_phrase_group)` so raw strings become live FTS phrases.** A second grammar edit and a new compatibility class (today `___"x"___` in FTS = AND(word `___`, phrase `x`, word `___`); after = phrase `x`) for a capability nobody asked for; mindgraph-rs strips the syntax before it reaches the engine. Rejected; the dead arm is left in place (deleting it is owner-ruling cut 2).
+- **R11 — Join well-formed `\uXXXX` surrogate pairs in the two quoted decoders** (≈ 10 lines each at `expr.rs:465` and `:494`; lone surrogate stays `invalid_utf8_code`). Would make `"…"` fully RFC 8259 and rescue Python's default `json.dumps` output. Rejected for this spec because the failure is **loud** (`parser::invalid_utf8_code`, not a silent value), the contract is the one `'…'` has had since `fork-base`, the workaround is one keyword argument or `$params`, and it would relax D2's "no decoder-semantics change" and the Cx 3 bound. Owner-reversible at review without re-running the panel; if reversed, D5.2 gains the pair as a success row and D2's table drops "BMP only".
+
+### 6.1 Panel triage
+
+All 26 panel findings folded (0 rejected); the three duplicates (FTS-unreachable ×2, n-or-more ×2, atomicity-cascade ×2 counted once each in their twin's fold) folded together. Where a finding offered a choice, the choice taken:
+
+- **FTS `raw_string` unreachable (major, ×2):** option (b) — keep D1's single seam; C13 rewritten to "identical", raw-string FTS tests dropped, S14/§4 corrected to "group + phrase + group, no error", R10 records the reorder. I2 qualified to expression/`::describe` position.
+- **FTS empty-fence fall-through (major):** C12 rewritten as loud; note item 2 extended; §4 and D5.5 gain `"C:\Users"` → error.
+- **Multi-line `#` (major):** S5/S6/C7/C8 qualified with "on the closing quote's line"; multi-line shapes filed under C1/C10; "pure widening" replaced; C3b added with S22 evidence; census shapes extended; §4 gains both scripts.
+- **C5 missing from the note (major):** note item 3 added; C5 kind is "loud, remote offset"; D2 scopes "at the backslash" to C4; D5.2 pins the EOI offset.
+- **Surrogate pairs (major):** option (b) — BMP-only stated in the D2 table, the note and `page.mdx`; `"😀"` and the pair are §4 rows; D5.4's generator gains `😀`/`é`; R11 records option (a).
+- **doc_check corpus / rebuild guard (major, ×2):** D6.2 rewritten — forced rebuild, `*.pest` guard widening, `types.cozo` as the named input; D5.7 deleted (the Rust suite pins only its own table).
+- **Census test (major):** deleted; D6.1 = S21 + PR-description paste; layering §5 states no engine file references a consumer path.
+- **D6.3 (major):** reduced to one sentence naming 0.18.0.
+- **Minor citation fixes:** S19/D4 (`wiki.rs:1637-1650`, `:1660`; `node_type` at `cozo.rs:10669`), S21 (`tips/page.mdx:88`), D5 (`build.yml:25`, `:26-28`), S15 (`:523`), header provenance and S13 (pest diff scope; `:297` references the three rules), n-or-more wording (D2, note, I5), `__"a"_"__` replaces the malformed fence-2 example, "byte" → "character" throughout, atomicity residual replaced with the pest citation (S16), `mem` for `::describe`, D5.4 batched with the measured figure, red-first ceremony and doc-comment pins dropped, status flip removed from the batches, D4 collapses three sites into one helper.
+
+### 6.2 Simplification pass — requirement-neutral cuts applied
+
+1. The `#[ignore]`d `census` test (an engine test hard-coding consumer paths) — replaced by S21 + a PR-description paste.
+2. D6.3's 7-day/nightly/cloud-deploy clauses and the log-grep stop condition — none produced evidence (S25).
+3. The two-commit red-first ceremony and doc-comment offset pins — one commit; §4 is the record of the flip.
+4. The sqlite backend for the `::describe` test — `mem` throughout.
+5. D5.7's second, hand-copied doc pin — `types.cozo` through `doc_check` is the single pin.
+6. The self-set status flip in the docs batch — status is the owner's act.
+7. The atomicity-cascade fallback (`raw_string_inner = ${…}`) — documented pest semantics, cited in S16.
+8. D1's "one-shot verification" listing — a duplicate of five §4 rows; replaced with a pointer.
+9. B1/B2 merged into one batch (follows from cut 3) and D4's "convert one, audit two" replaced by one helper — no audit note to maintain.
+
+---
+
+## 7. Batches = review units
+
+B1 is one `mnestic` PR with one commit; B2 spans `mnestic` (`CHANGELOG-FORK.md`), `mnestic-site` and the overlay skill; B3 is a `mindgraph-rs` PR; B4 is the tag. Each row is reviewed on its own question. Status is set by the owner: APPROVED after this review; SHIPPED after the B4 tag.
+
+| Batch | Contents | Seam | Review question |
+|---|---|---|---|
+| **B1 — Grammar + tests + warning** (PR A, one commit) | the two-token change at `cozoscript.pest:207-208` (D1); `cozo-core/tests/string_literals.rs` with D5.1–D5.4, D5.6–D5.7; the D5.5 module test in `parse/fts.rs`; D7 (`emit_once` helper + two emission sites); PR description carries the D6.1 census paste | `cozo-core/src/cozoscript.pest:207-208`, `cozo-core/tests/`, `parse/fts.rs:149` module, `parse/expr.rs:451`/`:509`, `runtime/diagnostics.rs` | Is the grammar diff exactly `{`→`${` and `*`→`+`, with `raw_string_inner` untouched? Do the assertions match D2/D3 exactly, including the C4 (`\`) and C5 (EOI) offsets? Is D7 ≤ ~25 lines, once per run, and value-neutral (I10)? |
+| **B2 — Docs + migration note + doc pin** | `types/page.mdx:287-320` rewrite (example `[3,4]`→`[3,3]`, callout replaced, BMP-only sentence); new `types.cozo` example file (mnestic-docs skill step 4/5) and the `doc_check:30` guard widened to `*.pest`; `doc_check types.cozo` transcript in the PR; `CHANGELOG-FORK.md` Unreleased entry = D3's migration note verbatim plus the `parser.string_decoding_changed` row in the warnings table | `mnestic-site/…/types/page.mdx`, `.claude/skills/mnestic-docs/`, `CHANGELOG-FORK.md` | Does every class C1–C5/C9/C10/C12 (and the undetectable C3b) appear in the note with a workaround? Does `doc_check` pass against a freshly built harness? |
+| **B3 — Consumer hygiene** | the three `is_in(node_type, […])` sites → one `$types` helper (D4); mindgraph-rs test from §4 last row | `mindgraph-rs/src/storage/cozo.rs:10520-10524`, `:10579-10583`, `:10651-10655` | Is every interpolated `type_list` gone, and is `is_in(node_type, $types)` the only reader? |
+| **B4 — Tag** | B1–B2 merged; D6.2 transcripts recorded; `versions.toml`/`bump.py` minor bump to 0.18.0; tag per the release skill; the 0.19.0 removal of D7 is added to `CHANGELOG-FORK.md` Unreleased at tag time | `versions.toml`, release skill | Did the census (D6.1) find anything beyond `page.mdx:295`? Are the D6.2 transcripts in the PRs? Is the D7 removal entry banked? |
+
+### 7.1 Residual risks carried into review
+
+- **Wheel-vs-tree evidence.** Every **(run)** result came from the 0.10.1 PyPI wheel. The string/comment grammar and the three decoders are unchanged from `fork-base` to HEAD, and `pest` was already at the 2.8 floor, but the authoritative confirmation is B1's suite against the working tree; if any §4 "Today" cell disagrees, the table — not the tests — is what gets corrected.
+- **User corpus is unknowable.** C1–C3/C10 silently change values in scripts we cannot see (PyPI/crates.io/npm consumers). D7 makes each such script self-report once in the user's own `::warnings` for one release; the migration note and a minor bump are the rest. **C3b is not detectable** by any per-literal check and is covered only by the note's grep hint — stated honestly.
+- **D7 is a two-release commitment.** It ships in 0.18.0 and must be deleted in 0.19.0; the removal is banked in Unreleased at tag time (B4) so it cannot be forgotten. If the owner cuts D7, this risk and the previous one collapse into "note only".
+- **BMP-only `\u` is a decision, not an accident.** R11 records the ≈20-line alternative; reversing it at review changes D2's table, the note, `page.mdx` and one D5.2 row, nothing else.
+- **`InvalidEscapeSeqError` is dead code.** The grammar rejects unknown escapes first (S11). Harmless; noted so no one claims it as a user-facing diagnostic.
+- **Upstream provenance.** The `raw_string`-first ordering and `_*` fence are inherited verbatim from upstream cozo (the rules are unchanged since `fork-base`); whether upstream intended zero-fence raw strings was not researched. The fix is offered upstream only after B4 — nothing here depends on that.


### PR DESCRIPTION
## Summary

Docs only — two design specs for backlog rows 4 and 5 of the engine roadmap, both marked **DRAFT — awaiting owner review**:

- `docs/specs/string-literals.md` — #53. Grounding found the real cause: PEG precedence (`string` tries `raw_string` first; its fence is `PUSH("_"*)`, so every bare `"…"` is a zero-fence raw string) plus non-atomic raw rules that let the comment skip consume `#…` and silently trim whitespace. The fix is two edits on one rule, with a decoding contract, migration note, soak plan, and a one-release detection warning. Owner rulings: BMP-only `\u`, whether to keep the warning.
- `docs/specs/json-canonical.md` — #54. One outbound seam in `data/json.rs`; canonical table = today's top-level forms with `Bot → null`; one-way round trip; mindgraph-rs keeps its own pinned converter. The compatibility contract (D5) is the gate deliverable and must be approved before code. Owner rulings: release placement (0.18.0 vs 0.17.0), NaN handling.

Closes nothing yet; implementation PRs follow approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)