### PR TITLE
feat: add governed multi-transaction workers with deadlines and cancellation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       # job above compiles them to zero tests. They must be named explicitly here
       # or they silently never run.
       - name: Test (test-hooks suites)
-        run: cargo test -p mnestic --features test-hooks --test commit_fence --test callback_commit_contract --verbose
+        run: cargo test -p mnestic --features test-hooks --test commit_fence --test callback_commit_contract --test governed_transaction --verbose
       - name: Test (columnar import contract)
         run: cargo test -p mnestic --features columnar-io,test-hooks --test columnar_import --verbose
 
@@ -134,6 +134,8 @@ jobs:
       # can run the interleaving suite.
       - name: Test (graph-projection interleaving)
         run: cargo test -p mnestic --features storage-rocksdb,test-hooks --test graph_projection_interleaving --verbose
+      - name: Test (governed read and write transactions)
+        run: cargo test -p mnestic --features storage-rocksdb,test-hooks --test governed_transaction --verbose
       - name: Test (columnar rollback and concurrency on RocksDB)
         run: >
           cargo test -p mnestic

--- a/CHANGELOG-FORK.md
+++ b/CHANGELOG-FORK.md
@@ -5,6 +5,24 @@ provenance and licensing.
 
 ## Unreleased
 
+### Added
+
+- Native Rust governed multi-transactions: a serialized client and host-owned
+  worker with an absolute deadline, bounded idle waiting, inherited statement
+  memory limits, cooperative cancellation and per-query warning flushes. Every
+  query error rolls back the whole transaction; the legacy API remains unchanged.
+  Hosts can retain admission until the actual worker exits. Stalled bounded
+  callbacks are disconnected with `callback.delivery_timeout` after a successful
+  commit, without undoing committed data. See
+  [the contract](docs/specs/governed-transactions.md), including SQLite/RocksDB
+  concurrency differences and uncertain outcomes when cancellation races commit.
+
+### Fixed
+
+- `::warnings` reads and clears the in-memory ring without opening a storage
+  transaction. It no longer waits behind an active multi-transaction on memory
+  or SQLite backends, which could otherwise stall inspection until idle expiry.
+
 ## 0.18.0
 
 This release corrects string-literal decoding, makes nested JSON conversions

--- a/cozo-core/README-mnestic.md
+++ b/cozo-core/README-mnestic.md
@@ -93,6 +93,11 @@ capabilities on top of it:
   drop a database that fails an integrity check.
 - **Interruptibility that works** — `::kill` and `:timeout` abort running
   queries, including long graph-adjacency builds.
+- **Governed multi-transactions (unreleased)** — a host-owned worker retains
+  admission through cancellation and cleanup, with one transaction deadline,
+  bounded idle waiting, inherited statement memory limits and warning flushes.
+  Any query error aborts the transaction. The legacy API remains available.
+  ([contract](https://github.com/shuruheel/mnestic/blob/main/docs/specs/governed-transactions.md))
 
 Everything else — CozoScript, the storage engines, the data model — is upstream
 CozoDB, unchanged unless noted in

--- a/cozo-core/src/lib.rs
+++ b/cozo-core/src/lib.rs
@@ -125,6 +125,11 @@ pub use crate::runtime::db::Poison;
 pub use crate::runtime::db::ScriptMutability;
 pub use crate::runtime::db::ScriptRunOptions;
 pub use crate::runtime::db::TransactionPayload;
+#[cfg(not(target_arch = "wasm32"))]
+pub use crate::runtime::governed_transaction::{
+    GovernedTransaction, GovernedTransactionCancellation, GovernedTransactionOptions,
+    GovernedTransactionWorker,
+};
 
 #[cfg(feature = "cypher")]
 pub mod cypher;
@@ -1060,8 +1065,36 @@ impl DbInstance {
             DbInstance::TiKv(db) => db.run_multi_transaction(write, payloads, results),
         }
     }
+    /// Prepare a governed client and host-owned worker. The worker must be run
+    /// on a dedicated blocking thread. Limits are captured now, before any
+    /// scheduling delay; Db defaults only tighten the supplied limits.
+    /// See [`GovernedTransactionWorker`] for admission and cancellation ownership.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn governed_transaction(
+        &self,
+        write: bool,
+        options: GovernedTransactionOptions,
+    ) -> Result<(GovernedTransaction, GovernedTransactionWorker)> {
+        let options = match self {
+            DbInstance::Mem(db) => db.governed_limits(options),
+            #[cfg(feature = "storage-sqlite")]
+            DbInstance::Sqlite(db) => db.governed_limits(options),
+            #[cfg(feature = "storage-rocksdb")]
+            DbInstance::RocksDb(db) => db.governed_limits(options),
+            #[cfg(feature = "storage-new-rocksdb")]
+            DbInstance::NewRocksDb(db) => db.governed_limits(options),
+            #[cfg(feature = "storage-sled")]
+            DbInstance::Sled(db) => db.governed_limits(options),
+            #[cfg(feature = "storage-tikv")]
+            DbInstance::TiKv(db) => db.governed_limits(options),
+        };
+        GovernedTransactionWorker::pair(self.clone(), write, options)
+    }
+
     /// A higher-level, blocking wrapper for [crate::Db::run_multi_transaction]. Runs the transaction on a dedicated thread.
     /// Write transactions _may_ block other reads, but we guarantee that this does not happen for the RocksDB backend.
+    /// This legacy API does not inherit script budgets, bound idle waiting or
+    /// flush query warnings. Native hosts should use `governed_transaction`.
     pub fn multi_transaction(&self, write: bool) -> MultiTransaction {
         let (app2db_send, app2db_recv) = bounded(1);
         let (db2app_send, db2app_recv) = bounded(1);

--- a/cozo-core/src/runtime/callback.rs
+++ b/cozo-core/src/runtime/callback.rs
@@ -77,7 +77,45 @@ impl<'s, S: Storage<'s>> Db<S> {
     }
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn send_callbacks(&'s self, collector: CallbackCollector) {
+        self.send_callbacks_inner(collector, None);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn send_callbacks_until(
+        &'s self,
+        collector: CallbackCollector,
+        deadline: std::time::Instant,
+    ) {
+        self.send_callbacks_inner(collector, Some(deadline));
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn send_callbacks_inner(
+        &'s self,
+        collector: CallbackCollector,
+        deadline: Option<std::time::Instant>,
+    ) {
         let mut to_remove = vec![];
+        let send = |sender: &Sender<(CallbackOp, NamedRows, NamedRows)>, message| {
+            if let Some(deadline) = deadline {
+                match sender.send_deadline(message, deadline) {
+                    Ok(()) => true,
+                    Err(crossbeam::channel::SendTimeoutError::Timeout(_)) => {
+                        crate::runtime::diagnostics::emit(
+                            "callback.delivery_timeout",
+                            "A committed change could not be delivered before the governed \
+                             transaction deadline; the stalled subscription was disconnected"
+                                .into(),
+                            "resubscribe and reconcile the change feed with stored data",
+                        );
+                        false
+                    }
+                    Err(crossbeam::channel::SendTimeoutError::Disconnected(_)) => false,
+                }
+            } else {
+                sender.send(message).is_ok()
+            }
+        };
 
         for (table, vals) in collector {
             for (op, new, old) in vals {
@@ -87,14 +125,14 @@ impl<'s, S: Storage<'s>> Db<S> {
                     if let Some(fst) = it.next() {
                         for cb_id in it {
                             if let Some(cb) = cbs.get(cb_id) {
-                                if cb.sender.send((op, new.clone(), old.clone())).is_err() {
+                                if !send(&cb.sender, (op, new.clone(), old.clone())) {
                                     to_remove.push(*cb_id)
                                 }
                             }
                         }
 
                         if let Some(cb) = cbs.get(fst) {
-                            if cb.sender.send((op, new, old)).is_err() {
+                            if !send(&cb.sender, (op, new, old)) {
                                 to_remove.push(*fst)
                             }
                         }

--- a/cozo-core/src/runtime/db.rs
+++ b/cozo-core/src/runtime/db.rs
@@ -753,6 +753,42 @@ impl<'s, S: Storage<'s>> Db<S> {
         self.warnings.lock().unwrap().iter().cloned().collect()
     }
 
+    /// Diagnostics do not need a storage transaction. In particular, a
+    /// warning read must not wait for the transaction being inspected to end.
+    fn list_warnings(&self, clear: bool) -> Result<NamedRows> {
+        // Structured diagnostics (mnestic fork): list — or with
+        // `clear`, empty — the Db's recent-warnings ring. Read-only
+        // safe in both forms: the ring is diagnostics state, not data.
+        if clear {
+            self.warnings.lock().unwrap().clear();
+            return Ok(NamedRows::new(
+                vec![STATUS_STR.to_string()],
+                vec![vec![DataValue::from(OK_STR)]],
+            ));
+        }
+        let rows = self
+            .recent_warnings()
+            .into_iter()
+            .map(|(seq, w)| {
+                vec![
+                    DataValue::from(seq as i64),
+                    DataValue::from(w.code),
+                    DataValue::from(w.message.as_str()),
+                    DataValue::from(w.hint.as_str()),
+                ]
+            })
+            .collect_vec();
+        Ok(NamedRows::new(
+            vec![
+                "seq".to_string(),
+                "code".to_string(),
+                "message".to_string(),
+                "hint".to_string(),
+            ],
+            rows,
+        ))
+    }
+
     /// Compute the whole-script deadline from the per-call timeout and the Db
     /// default (mnestic fork, query budget), both anchored at one clock reading.
     /// Returns the earliest (`min`) of whichever are set; `None` if neither is
@@ -785,6 +821,120 @@ impl<'s, S: Storage<'s>> Db<S> {
         match (call_limit, default) {
             (Some(a), Some(b)) => Some(a.min(b)),
             (a, b) => a.or(b),
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn governed_limits(
+        &self,
+        mut options: crate::GovernedTransactionOptions,
+    ) -> crate::GovernedTransactionOptions {
+        if let Some(default) = self.effective_outer_deadline(None) {
+            options.deadline = options.deadline.min(default);
+        }
+        options.mem_limit = self.effective_outer_mem_limit(options.mem_limit);
+        options
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn run_governed_transaction(
+        &'s self,
+        worker: &crate::GovernedTransactionWorker,
+    ) -> Result<()> {
+        worker.poison.check()?;
+        let mut tx = if worker.write {
+            self.transact_write()?
+        } else {
+            self.transact()?
+        };
+        tx.script_deadline = Some(worker.options.deadline);
+        tx.script_mem_limit = worker.options.mem_limit;
+        tx.script_cancellation = Some(worker.poison.flag.clone());
+        let ts = current_validity();
+        let callback_targets = self.current_callback_targets();
+        let mut callback_collector = BTreeMap::new();
+        let mut cleanups: Vec<(Vec<u8>, Vec<u8>)> = vec![];
+
+        loop {
+            match worker.next()? {
+                TransactionPayload::Abort => {
+                    drop(tx);
+                    return worker.reply(NamedRows::default());
+                }
+                TransactionPayload::Commit => {
+                    for (lower, upper) in cleanups {
+                        worker.poison.check()?;
+                        tx.store_tx.del_range_from_persisted(&lower, &upper)?;
+                    }
+                    worker.poison.check()?;
+                    self.commit_tx_with_test_hook(&mut tx)?;
+                    drop(tx);
+                    // The commit already succeeded. Its success is independent
+                    // of caller disconnect or change-feed backpressure.
+                    let reply = worker.reply(NamedRows::default());
+                    self.send_callbacks_until(callback_collector, worker.options.deadline);
+                    self.flush_warnings();
+                    return reply;
+                }
+                TransactionPayload::Query((script, params)) => {
+                    let result = (|| {
+                        let mut p = parse_script(
+                            &script,
+                            &params,
+                            &self.fixed_rules.read().unwrap(),
+                            crate::data::aggr::CustomAggrRegistries {
+                                meet: &self.custom_aggrs.read().unwrap(),
+                                bounded: &self.custom_bounded_meets.read().unwrap(),
+                            },
+                            ts,
+                        )?
+                        .get_single_program()?;
+                        let lock_name = p.needs_write_lock();
+                        ensure!(
+                            worker.write || lock_name.is_none(),
+                            "write lock required for read-only transaction"
+                        );
+                        let locks = self.obtain_relation_locks(lock_name.iter());
+                        let _guard = if let Some(lock) = locks.first() {
+                            Some(loop {
+                                worker.poison.check()?;
+                                if let Ok(guard) = lock.try_read() {
+                                    break guard;
+                                }
+                                worker.sleep(Duration::from_millis(2), None)?;
+                            })
+                        } else {
+                            None
+                        };
+                        worker.poison.check()?;
+                        let sleep = p.out_opts.sleep.take();
+                        let block_deadline = p
+                            .out_opts
+                            .timeout
+                            .and_then(|seconds| deadline_from_secs(Instant::now(), seconds));
+                        let rows = self.execute_single_program(
+                            p,
+                            &mut tx,
+                            &mut cleanups,
+                            ts,
+                            &callback_targets,
+                            &mut callback_collector,
+                        )?;
+                        if let Some(seconds) = sleep {
+                            worker.sleep(
+                                Duration::from_micros((seconds * 1_000_000.) as u64),
+                                block_deadline,
+                            )?;
+                        }
+                        worker.poison.check()?;
+                        Ok(rows)
+                    })();
+                    // Includes parse/compile/evaluation failures. Any error
+                    // exits this worker and drops all uncommitted writes.
+                    self.flush_warnings();
+                    worker.reply(result?)?;
+                }
+            }
         }
     }
 
@@ -1843,6 +1993,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             tt_hwm_dirty: false,
             reconciled_tt_relations: Default::default(),
             script_deadline: None,
+            script_cancellation: None,
             script_mem_limit: None,
             projections: self.graph_projections.clone(),
             watermark,
@@ -1867,6 +2018,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             tt_hwm_dirty: false,
             reconciled_tt_relations: Default::default(),
             script_deadline: None,
+            script_cancellation: None,
             script_mem_limit: None,
             projections: self.graph_projections.clone(),
             watermark,
@@ -2458,39 +2610,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                     vec![vec![DataValue::from(OK_STR)]],
                 ))
             }
-            SysOp::Warnings(clear) => {
-                // Structured diagnostics (mnestic fork): list — or with
-                // `clear`, empty — the Db's recent-warnings ring. Read-only
-                // safe in both forms: the ring is diagnostics state, not data.
-                if *clear {
-                    self.warnings.lock().unwrap().clear();
-                    return Ok(NamedRows::new(
-                        vec![STATUS_STR.to_string()],
-                        vec![vec![DataValue::from(OK_STR)]],
-                    ));
-                }
-                let rows = self
-                    .recent_warnings()
-                    .into_iter()
-                    .map(|(seq, w)| {
-                        vec![
-                            DataValue::from(seq as i64),
-                            DataValue::from(w.code),
-                            DataValue::from(w.message.as_str()),
-                            DataValue::from(w.hint.as_str()),
-                        ]
-                    })
-                    .collect_vec();
-                Ok(NamedRows::new(
-                    vec![
-                        "seq".to_string(),
-                        "code".to_string(),
-                        "message".to_string(),
-                        "hint".to_string(),
-                    ],
-                    rows,
-                ))
-            }
+            SysOp::Warnings(clear) => self.list_warnings(*clear),
             SysOp::CreateStoredQuery {
                 name,
                 params,
@@ -3318,7 +3438,7 @@ impl<'s, S: Storage<'s>> Db<S> {
         outer_deadline: Option<Instant>,
         outer_mem_limit: Option<usize>,
     ) -> Result<NamedRows> {
-        // ::running and ::kill touch only the in-memory query registry, so
+        // ::warnings, ::running and ::kill touch only in-memory state, so
         // they dispatch before any transaction is opened: on mem/sqlite a
         // write tx takes a store-wide lock that queues behind every running
         // read query — a ::kill would otherwise block until the query it is
@@ -3326,6 +3446,7 @@ impl<'s, S: Storage<'s>> Db<S> {
         // in run_sys_op_with_tx stay for the imperative in-script path)
         match &op {
             SysOp::ListRunning => return self.list_running(),
+            SysOp::Warnings(clear) => return self.list_warnings(*clear),
             SysOp::KillRunning(id) => {
                 let queries = self.running_queries.lock().unwrap();
                 return Ok(match queries.get(id) {
@@ -3477,7 +3598,11 @@ impl<'s, S: Storage<'s>> Db<S> {
                 }),
             }
         };
-        let poison = Poison::with_limits(effective_deadline, mem_budget.clone());
+        let mut poison = Poison::with_limits(effective_deadline, mem_budget.clone());
+        poison.parent_cancellation = tx.script_cancellation.clone();
+        if poison.parent_cancellation.is_some() {
+            poison.check()?;
+        }
         // give the query an ID and store it so that it can be queried and cancelled
         let id = self.queries_count.fetch_add(1, Ordering::AcqRel);
 
@@ -3507,6 +3632,11 @@ impl<'s, S: Storage<'s>> Db<S> {
         } else {
             None
         };
+
+        // A custom fixed rule may be uncooperative while running. Governed
+        // transactions also check its query poison after it returns, before
+        // the query is reported successful or any transaction can commit.
+        let governed_poison = tx.script_cancellation.as_ref().map(|_| poison.clone());
 
         // the real evaluation
         let (result_store, early_return) = tx.stratified_magic_evaluate(
@@ -3543,7 +3673,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             }
         }
 
-        if !out_opts.sorters.is_empty() {
+        let result = if !out_opts.sorters.is_empty() {
             // sort outputs if required
             let sorted_result = tx.sort_and_collect(
                 result_store,
@@ -3671,7 +3801,11 @@ impl<'s, S: Storage<'s>> Db<S> {
                     clean_ups,
                 ))
             }
+        };
+        if let Some(poison) = governed_poison {
+            poison.check()?;
         }
+        result
     }
     pub(crate) fn list_running(&self) -> Result<NamedRows> {
         let rows = self
@@ -4041,6 +4175,7 @@ impl MemBudget {
 #[derive(Clone, Default)]
 pub struct Poison {
     pub(crate) flag: Arc<AtomicBool>,
+    pub(crate) parent_cancellation: Option<Arc<AtomicBool>>,
     pub(crate) deadline: Option<Instant>,
     /// Query memory budget (mnestic fork); `None` = unlimited. Rides the
     /// poison so every shipped check cadence also checks the budget trip.
@@ -4206,6 +4341,17 @@ impl Poison {
         if self.flag.load(Ordering::Relaxed) {
             bail!(ProcessKilled)
         }
+        if self
+            .parent_cancellation
+            .as_ref()
+            .is_some_and(|flag| flag.load(Ordering::Relaxed))
+        {
+            #[derive(Debug, Error, Diagnostic)]
+            #[error("Parent transaction was cancelled")]
+            #[diagnostic(code(eval::killed))]
+            struct TransactionCancelled;
+            bail!(TransactionCancelled)
+        }
 
         // memory budget (mnestic fork): a charge that crossed the limit
         // armed the trip; every check cadence surfaces it as its own error.
@@ -4242,6 +4388,7 @@ impl Poison {
     pub(crate) fn with_deadline(deadline: Option<Instant>) -> Self {
         Poison {
             flag: Arc::new(AtomicBool::new(false)),
+            parent_cancellation: None,
             deadline,
             mem: None,
         }
@@ -4252,6 +4399,7 @@ impl Poison {
     pub(crate) fn with_limits(deadline: Option<Instant>, mem: Option<MemBudget>) -> Self {
         Poison {
             flag: Arc::new(AtomicBool::new(false)),
+            parent_cancellation: None,
             deadline,
             mem,
         }

--- a/cozo-core/src/runtime/governed_transaction.rs
+++ b/cozo-core/src/runtime/governed_transaction.rs
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2026, Shan Rizvi (mnestic fork).
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+//! Bounded, host-owned multi-transaction workers. Native targets only.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crossbeam::channel::{bounded, Receiver, Sender};
+use miette::{bail, Diagnostic, Report, Result};
+use thiserror::Error;
+
+use crate::{DataValue, DbInstance, NamedRows, Poison, TransactionPayload};
+
+/// Limits for one entire multi-transaction, including time queued before its
+/// worker starts and time between queries. Db defaults can only tighten these.
+/// Memory is estimated per statement, not a bound on total allocator RSS or
+/// data retained by the application across statements.
+#[derive(Clone, Copy, Debug)]
+pub struct GovernedTransactionOptions {
+    /// Absolute wall-clock deadline. Required: there is no unlimited worker.
+    pub deadline: Instant,
+    /// Maximum wait between commands. Must be positive. Defaults to 5 seconds.
+    pub idle_timeout: Duration,
+    /// Per-statement estimated memory limit; combined with the Db default and
+    /// each query's `:mem_limit` by taking the minimum.
+    pub mem_limit: Option<usize>,
+}
+
+impl GovernedTransactionOptions {
+    /// Use an existing request deadline; do not re-arm it for every query.
+    pub fn new(deadline: Instant) -> Self {
+        Self {
+            deadline,
+            idle_timeout: Duration::from_secs(5),
+            mem_limit: None,
+        }
+    }
+}
+
+/// A cancellation signal independent of the blocking client. Cancelling is
+/// cooperative: the host must retain worker-owned resources until `run` exits.
+#[derive(Clone)]
+pub struct GovernedTransactionCancellation {
+    flag: Arc<AtomicBool>,
+    wake: Sender<()>,
+}
+
+impl GovernedTransactionCancellation {
+    /// Request rollback and wake an idle worker. A storage commit already in
+    /// progress cannot be undone by cancellation.
+    pub fn cancel(&self) {
+        self.flag.store(true, Ordering::Relaxed);
+        let _ = self.wake.try_send(());
+    }
+}
+
+/// Serialized blocking client. Dropping it cancels the worker; it does not
+/// join it. Every query error terminates and rolls back the transaction.
+/// Private channels and mutable methods prevent response miscorrelation.
+pub struct GovernedTransaction {
+    commands: Sender<TransactionPayload>,
+    results: Receiver<NamedRows>,
+    cancellation: GovernedTransactionCancellation,
+    terminal: Arc<Mutex<Option<Report>>>,
+    deadline: Instant,
+    finished: bool,
+}
+
+impl GovernedTransaction {
+    /// A separately owned signal for cancellation of a blocked client call.
+    pub fn cancellation(&self) -> GovernedTransactionCancellation {
+        self.cancellation.clone()
+    }
+
+    /// Run one query on the transaction's snapshot. Imperative scripts and
+    /// system commands are unsupported, as with the legacy multi-transaction.
+    pub fn run_script(
+        &mut self,
+        script: &str,
+        params: BTreeMap<String, DataValue>,
+    ) -> Result<NamedRows> {
+        self.request(TransactionPayload::Query((script.to_owned(), params)))
+    }
+
+    /// Commit once. A timeout or cancellation concurrent with a storage commit
+    /// does not prove rollback; reconcile using application idempotency keys.
+    pub fn commit(mut self) -> Result<()> {
+        self.request(TransactionPayload::Commit).map(|_| ())
+    }
+
+    /// Roll back once. The worker drops the storage transaction before replying.
+    pub fn abort(mut self) -> Result<()> {
+        self.request(TransactionPayload::Abort).map(|_| ())
+    }
+
+    fn request(&mut self, payload: TransactionPayload) -> Result<NamedRows> {
+        if self.finished {
+            return Err(closed());
+        }
+        let finishing = !matches!(payload, TransactionPayload::Query(_));
+        if self.commands.send_deadline(payload, self.deadline).is_err() {
+            return Err(self.failure());
+        }
+        match self.results.recv_deadline(self.deadline) {
+            Ok(rows) => {
+                self.finished = finishing;
+                Ok(rows)
+            }
+            Err(_) => Err(self.failure()),
+        }
+    }
+
+    fn failure(&mut self) -> Report {
+        self.finished = true;
+        // The worker publishes the original diagnostic before dropping its
+        // channels. In particular, a late call after an idle timeout must not
+        // erase eval::timeout into a generic send/disconnect error.
+        let recorded = self.terminal.lock().unwrap().take();
+        let error = recorded.unwrap_or_else(|| {
+            if Instant::now() >= self.deadline {
+                timeout()
+            } else if self.cancellation.flag.load(Ordering::Relaxed) {
+                cancelled()
+            } else {
+                closed()
+            }
+        });
+        self.cancellation.cancel();
+        error
+    }
+}
+
+impl Drop for GovernedTransaction {
+    fn drop(&mut self) {
+        self.cancellation.cancel();
+    }
+}
+
+/// The actual transaction owner. Move this into a host-managed blocking thread
+/// together with its admission permit and database owner, then call `run`.
+/// No transaction is opened until `run`; dropping an unstarted worker is safe.
+/// Do not park it on a shared query/evaluation thread pool.
+pub struct GovernedTransactionWorker {
+    db: DbInstance,
+    pub(crate) write: bool,
+    pub(crate) options: GovernedTransactionOptions,
+    commands: Receiver<TransactionPayload>,
+    results: Sender<NamedRows>,
+    cancel_wake: Receiver<()>,
+    pub(crate) poison: Poison,
+    terminal: Arc<Mutex<Option<Report>>>,
+}
+
+impl GovernedTransactionWorker {
+    pub(crate) fn pair(
+        db: DbInstance,
+        write: bool,
+        options: GovernedTransactionOptions,
+    ) -> Result<(GovernedTransaction, Self)> {
+        if options.idle_timeout.is_zero() {
+            bail!("governed transaction idle timeout must be positive");
+        }
+        let (commands, command_rx) = bounded(1);
+        let (results, result_rx) = bounded(1);
+        let (wake, cancel_wake) = bounded(1);
+        let poison = Poison::with_deadline(Some(options.deadline));
+        let terminal = Arc::new(Mutex::new(None));
+        let client = GovernedTransaction {
+            commands,
+            results: result_rx,
+            cancellation: GovernedTransactionCancellation {
+                flag: poison.flag.clone(),
+                wake,
+            },
+            terminal: terminal.clone(),
+            deadline: options.deadline,
+            finished: false,
+        };
+        Ok((
+            client,
+            Self {
+                db,
+                write,
+                options,
+                commands: command_rx,
+                results,
+                cancel_wake,
+                poison,
+                terminal,
+            },
+        ))
+    }
+
+    /// Run to termination on the current thread. Returning means the storage
+    /// transaction has been dropped, including on query errors and disconnects.
+    /// Errors are delivered to the client with their original diagnostic codes.
+    pub fn run(self) {
+        let result = match &self.db {
+            DbInstance::Mem(db) => db.run_governed_transaction(&self),
+            #[cfg(feature = "storage-sqlite")]
+            DbInstance::Sqlite(db) => db.run_governed_transaction(&self),
+            #[cfg(feature = "storage-rocksdb")]
+            DbInstance::RocksDb(db) => db.run_governed_transaction(&self),
+            #[cfg(feature = "storage-new-rocksdb")]
+            DbInstance::NewRocksDb(db) => db.run_governed_transaction(&self),
+            #[cfg(feature = "storage-sled")]
+            DbInstance::Sled(db) => db.run_governed_transaction(&self),
+            #[cfg(feature = "storage-tikv")]
+            DbInstance::TiKv(db) => db.run_governed_transaction(&self),
+        };
+        if let Err(error) = result {
+            *self.terminal.lock().unwrap() = Some(error);
+        }
+    }
+
+    pub(crate) fn next(&self) -> Result<TransactionPayload> {
+        self.poison.check()?;
+        let idle_deadline = Instant::now()
+            .checked_add(self.options.idle_timeout)
+            .unwrap_or(self.options.deadline)
+            .min(self.options.deadline);
+        let payload = crossbeam::select! {
+            recv(self.commands) -> command => command.map_err(|_| cancelled()),
+            recv(self.cancel_wake) -> _ => Err(cancelled()),
+            default(idle_deadline.saturating_duration_since(Instant::now())) => Err(timeout()),
+        }?;
+        self.poison.check()?;
+        Ok(payload)
+    }
+
+    pub(crate) fn reply(&self, rows: NamedRows) -> Result<()> {
+        // One request at a time, hence at most one response. Never block while
+        // retaining a snapshot if the caller abandons or violates the protocol.
+        self.results.try_send(rows).map_err(|_| closed())
+    }
+
+    pub(crate) fn sleep(&self, duration: Duration, block_deadline: Option<Instant>) -> Result<()> {
+        self.poison.check()?;
+        let deadline = block_deadline
+            .unwrap_or(self.options.deadline)
+            .min(self.options.deadline);
+        let end = Instant::now()
+            .checked_add(duration)
+            .unwrap_or(deadline)
+            .min(deadline);
+        crossbeam::select! {
+            recv(self.cancel_wake) -> _ => return Err(cancelled()),
+            default(end.saturating_duration_since(Instant::now())) => {},
+        }
+        self.poison.check()?;
+        if Instant::now() >= deadline {
+            return Err(timeout());
+        }
+        Ok(())
+    }
+}
+
+fn timeout() -> Report {
+    #[derive(Debug, Error, Diagnostic)]
+    #[error("Governed transaction exceeded its deadline or inter-query idle limit")]
+    #[diagnostic(code(eval::timeout))]
+    struct TransactionTimeout;
+    TransactionTimeout.into()
+}
+
+fn cancelled() -> Report {
+    #[derive(Debug, Error, Diagnostic)]
+    #[error("Governed transaction was cancelled")]
+    #[diagnostic(code(eval::killed))]
+    struct TransactionCancelled;
+    TransactionCancelled.into()
+}
+
+fn closed() -> Report {
+    #[derive(Debug, Error, Diagnostic)]
+    #[error("Governed transaction is closed")]
+    #[diagnostic(code(transaction::closed))]
+    struct TransactionClosed;
+    TransactionClosed.into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn warnings_flush_on_success_parse_failure_and_evaluation_failure() {
+        for script in ["?[x] <- [[1]]", "invalid query [", "?[x] := *missing[x]"] {
+            let db = DbInstance::default();
+            let (mut client, worker) = db
+                .governed_transaction(
+                    false,
+                    GovernedTransactionOptions::new(Instant::now() + Duration::from_secs(5)),
+                )
+                .unwrap();
+            let thread = std::thread::spawn(move || {
+                // Models a warning emitted earlier on this worker by an
+                // extension. Even a subsequent parse failure must flush it.
+                crate::runtime::diagnostics::emit(
+                    "test.worker_warning",
+                    "worker warning".into(),
+                    "test fixture",
+                );
+                worker.run();
+            });
+            let result = client.run_script(script, BTreeMap::new());
+            let warnings = db.run_default("::warnings").unwrap();
+            assert_eq!(warnings.rows.len(), 1, "{script}");
+            assert_eq!(warnings.rows[0][1].get_str(), Some("test.worker_warning"));
+            if result.is_ok() {
+                client.abort().unwrap();
+            }
+            thread.join().unwrap();
+        }
+    }
+}

--- a/cozo-core/src/runtime/mod.rs
+++ b/cozo-core/src/runtime/mod.rs
@@ -11,6 +11,8 @@ pub(crate) mod callback;
 pub(crate) mod columnar;
 pub(crate) mod db;
 pub(crate) mod diagnostics;
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) mod governed_transaction;
 pub(crate) mod graph_projection;
 pub(crate) mod hnsw;
 pub(crate) mod hnsw_build;

--- a/cozo-core/src/runtime/transact.rs
+++ b/cozo-core/src/runtime/transact.rs
@@ -7,7 +7,7 @@
  */
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::atomic::{AtomicU32, AtomicU64};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
@@ -72,6 +72,9 @@ pub struct SessionTx<'a> {
     /// trigger) shares one tx, every statement it drives inherits the same
     /// budget — a multi-statement script is bounded as a whole, not per block.
     pub(crate) script_deadline: Option<Instant>,
+    /// Parent cancellation for governed multi-transactions. Query cleanup
+    /// kills only its own poison; it must not cancel subsequent queries.
+    pub(crate) script_cancellation: Option<Arc<AtomicBool>>,
     /// Whole-script memory budget in estimated bytes (mnestic fork; spec
     /// `docs/specs/memory-budget.md`): the minimum of any per-call limit
     /// (`run_script_with_options`) and the Db default

--- a/cozo-core/tests/governed_transaction.rs
+++ b/cozo-core/tests/governed_transaction.rs
@@ -1,0 +1,519 @@
+/*
+ * Copyright 2026, Shan Rizvi (mnestic fork).
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
+ * If a copy of the MPL was not distributed with this file,
+ * You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use cozo::{
+    DataValue, DbInstance, GovernedTransaction, GovernedTransactionOptions, NamedRows,
+    ScriptMutability, SimpleFixedRule,
+};
+use crossbeam::channel::bounded;
+use serde_json::json;
+
+fn fixture(engine: &str) -> (tempfile::TempDir, DbInstance) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = DbInstance::new(engine, dir.path().join("db").to_str().unwrap(), "").unwrap();
+    run(&db, ":create items { id: Int => value: Int }");
+    run(&db, "?[id, value] <- [[1, 10]] :put items {id => value}");
+    (dir, db)
+}
+
+fn run(db: &DbInstance, script: &str) -> NamedRows {
+    db.run_script(script, BTreeMap::new(), ScriptMutability::Mutable)
+        .unwrap()
+}
+
+fn options() -> GovernedTransactionOptions {
+    GovernedTransactionOptions::new(Instant::now() + Duration::from_secs(10))
+}
+
+fn start(
+    db: &DbInstance,
+    write: bool,
+    options: GovernedTransactionOptions,
+) -> (GovernedTransaction, JoinHandle<()>) {
+    let (client, worker) = db.governed_transaction(write, options).unwrap();
+    (client, thread::spawn(move || worker.run()))
+}
+
+fn code(error: miette::Report) -> String {
+    error.code().expect("typed diagnostic").to_string()
+}
+
+fn committed_and_aborted_writes(engine: &str) {
+    let (_dir, db) = fixture(engine);
+    let (mut tx, worker) = start(&db, true, options());
+    tx.run_script(
+        "?[id, value] <- [[2, 20]] :put items {id => value}",
+        BTreeMap::new(),
+    )
+    .unwrap();
+    // Running-query cleanup must not kill the parent after the first query.
+    tx.run_script(
+        "?[id, value] <- [[3, 30]] :put items {id => value}",
+        BTreeMap::new(),
+    )
+    .unwrap();
+    tx.commit().unwrap();
+    worker.join().unwrap();
+    assert_eq!(
+        run(&db, "?[id, value] := *items{id, value}").into_json()["rows"],
+        json!([[1, 10], [2, 20], [3, 30]])
+    );
+
+    let (mut tx, worker) = start(&db, true, options());
+    tx.run_script(
+        "?[id, value] <- [[4, 40]] :put items {id => value}",
+        BTreeMap::new(),
+    )
+    .unwrap();
+    tx.abort().unwrap();
+    worker.join().unwrap();
+    assert_eq!(run(&db, "?[id] := *items{id}, id == 4").rows.len(), 0);
+}
+
+fn read_only_and_error_abort(engine: &str) {
+    let (_dir, db) = fixture(engine);
+    let (mut tx, worker) = start(&db, false, options());
+    let error = tx
+        .run_script(
+            "?[id, value] <- [[2, 20]] :put items {id => value}",
+            BTreeMap::new(),
+        )
+        .unwrap_err();
+    assert!(error.to_string().contains("read-only transaction"));
+    worker.join().unwrap();
+    assert_eq!(
+        code(tx.run_script("?[x] <- [[1]]", BTreeMap::new()).unwrap_err()),
+        "transaction::closed"
+    );
+
+    let (mut tx, worker) = start(&db, true, options());
+    tx.run_script(
+        "?[id, value] <- [[2, 20]] :put items {id => value}",
+        BTreeMap::new(),
+    )
+    .unwrap();
+    assert!(tx.run_script("invalid query [", BTreeMap::new()).is_err());
+    worker.join().unwrap();
+    assert!(tx.commit().is_err());
+    assert_eq!(
+        run(&db, "?[id, value] := *items{id, value}").into_json()["rows"],
+        json!([[1, 10]])
+    );
+}
+
+fn memory_minimum_and_rollback(engine: &str) {
+    let (_dir, db) = fixture(engine);
+    run(&db, ":create base { x: Int }");
+    db.import_relations(BTreeMap::from([(
+        "base".into(),
+        NamedRows::new(
+            vec!["x".into()],
+            (0..200).map(|i| vec![DataValue::from(i)]).collect(),
+        ),
+    )]))
+    .unwrap();
+    // Each source must independently tighten the others; no single-setting
+    // test can distinguish accidental ignoring of the Db or per-call limit.
+    for tight in 0..3 {
+        db.set_default_query_mem_limit(Some(if tight == 0 { 100_000 } else { 100_000_000 }));
+        let mut opts = options();
+        opts.mem_limit = Some(if tight == 1 { 100_000 } else { 100_000_000 });
+        let (mut tx, worker) = start(&db, true, opts);
+        tx.run_script(
+            "?[id, value] <- [[2, 20]] :put items {id => value}",
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let block_limit = if tight == 2 { 100_000 } else { 100_000_000 };
+        let error = tx.run_script(&format!("tmp[a,b,c] := *base[a], *base[b], *base[c]\n?[count(a)] := tmp[a,_,_] :mem_limit {block_limit}"), BTreeMap::new()).unwrap_err();
+        assert_eq!(
+            code(error),
+            "eval::mem_budget_exceeded",
+            "{engine} limit source {tight}"
+        );
+        worker.join().unwrap();
+        assert!(tx.commit().is_err());
+        assert_eq!(
+            run(&db, "?[id, value] := *items{id, value}").into_json()["rows"],
+            json!([[1, 10]])
+        );
+    }
+    let warnings = run(&db, "::warnings");
+    assert!(
+        warnings
+            .rows
+            .iter()
+            .any(|row| row[1].get_str().is_some_and(|c| c.contains("cartesian"))),
+        "warnings from failed evaluation must be visible"
+    );
+}
+
+fn idle_timeout_retains_diagnostic_and_rolls_back(engine: &str) {
+    let (_dir, db) = fixture(engine);
+    let mut opts = options();
+    opts.idle_timeout = Duration::from_millis(100);
+    let (mut tx, worker) = start(&db, true, opts);
+    tx.run_script(
+        "?[id, value] <- [[2, 20]] :put items {id => value}",
+        BTreeMap::new(),
+    )
+    .unwrap();
+    worker.join().unwrap();
+    // A failed command send after the worker exited still exposes its timeout.
+    assert_eq!(
+        code(tx.run_script("?[x] <- [[1]]", BTreeMap::new()).unwrap_err()),
+        "eval::timeout"
+    );
+    assert_eq!(
+        run(&db, "?[id, value] := *items{id, value}").into_json()["rows"],
+        json!([[1, 10]])
+    );
+}
+
+fn whole_deadline_and_bounded_sleep(engine: &str) {
+    let (_dir, db) = fixture(engine);
+    for source in 0..3 {
+        let mut opts = options();
+        if source == 0 {
+            opts.deadline = Instant::now() + Duration::from_millis(100);
+        }
+        db.set_default_query_timeout((source == 1).then_some(0.1));
+        let (mut tx, worker) = start(&db, true, opts);
+        tx.run_script(
+            "?[id, value] <- [[2, 20]] :put items {id => value}",
+            BTreeMap::new(),
+        )
+        .unwrap();
+        let started = Instant::now();
+        let query = if source == 2 {
+            "?[x] <- [[1]] :sleep 5 :timeout 0.1"
+        } else {
+            "?[x] <- [[1]] :sleep 5"
+        };
+        assert_eq!(
+            code(tx.run_script(query, BTreeMap::new()).unwrap_err()),
+            "eval::timeout"
+        );
+        worker.join().unwrap();
+        assert!(
+            started.elapsed() < Duration::from_secs(3),
+            "sleep must not retain a worker for five seconds"
+        );
+        assert_eq!(
+            run(&db, "?[id, value] := *items{id, value}").into_json()["rows"],
+            json!([[1, 10]])
+        );
+    }
+}
+
+fn disconnect_rolls_back(engine: &str) {
+    let (_dir, db) = fixture(engine);
+    let (mut tx, worker) = start(&db, true, options());
+    tx.run_script(
+        "?[id, value] <- [[2, 20]] :put items {id => value}",
+        BTreeMap::new(),
+    )
+    .unwrap();
+    drop(tx);
+    worker.join().unwrap();
+    assert_eq!(
+        run(&db, "?[id, value] := *items{id, value}").into_json()["rows"],
+        json!([[1, 10]])
+    );
+}
+
+fn warnings_visible_before_write_transaction_closes(engine: &str) {
+    let (_dir, db) = fixture(engine);
+    let (mut tx, worker) = start(&db, true, options());
+    tx.run_script(
+        "?[a,b,c] := *items{id:a}, *items{id:b}, *items{id:c}",
+        BTreeMap::new(),
+    )
+    .unwrap();
+    assert!(run(&db, "::warnings")
+        .rows
+        .iter()
+        .any(|row| row[1].get_str() == Some("query.cartesian_step")));
+    run(&db, "::warnings clear");
+    assert!(run(&db, "::warnings").rows.is_empty());
+    // These sysops must not wait for the active transaction's idle timeout.
+    tx.run_script("?[x] <- [[1]]", BTreeMap::new()).unwrap();
+    tx.abort().unwrap();
+    worker.join().unwrap();
+}
+
+#[cfg(feature = "test-hooks")]
+fn commit_failure_publishes_no_changes(engine: &str) {
+    let (_dir, db) = fixture(engine);
+    let (_, callback) = db.register_callback("items", None);
+    let (mut tx, worker) = start(&db, true, options());
+    tx.run_script(
+        "?[id, value] <- [[2, 20]] :put items {id => value}",
+        BTreeMap::new(),
+    )
+    .unwrap();
+    db.fail_next_commit_for_tests();
+    assert!(tx
+        .commit()
+        .unwrap_err()
+        .to_string()
+        .contains("injected commit failure"));
+    worker.join().unwrap();
+    assert!(callback.try_recv().is_err());
+    assert_eq!(
+        run(&db, "?[id, value] := *items{id, value}").into_json()["rows"],
+        json!([[1, 10]])
+    );
+}
+
+fn snapshot_survives_concurrent_write(engine: &str) {
+    let (_dir, db) = fixture(engine);
+    let (mut tx, worker) = start(&db, false, options());
+    let before = tx
+        .run_script("?[id, value] := *items{id, value}", BTreeMap::new())
+        .unwrap()
+        .into_json();
+    let db2 = db.clone();
+    let (attempt_tx, attempt_rx) = bounded(1);
+    let (done_tx, done_rx) = bounded(1);
+    let writer = thread::spawn(move || {
+        attempt_tx.send(()).unwrap();
+        run(&db2, "?[id, value] <- [[1, 99]] :put items {id => value}");
+        done_tx.send(()).unwrap();
+    });
+    attempt_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+    if engine == "rocksdb" {
+        done_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+    } else {
+        // SQLite holds a store-wide read guard. The concurrent writer waits
+        // until this reader closes instead of committing alongside it.
+        assert!(done_rx.recv_timeout(Duration::from_millis(100)).is_err());
+    }
+    assert_eq!(
+        tx.run_script("?[id, value] := *items{id, value}", BTreeMap::new())
+            .unwrap()
+            .into_json(),
+        before
+    );
+    tx.abort().unwrap();
+    worker.join().unwrap();
+    writer.join().unwrap();
+    assert_eq!(
+        run(&db, "?[id, value] := *items{id, value}").into_json()["rows"],
+        json!([[1, 99]])
+    );
+}
+
+macro_rules! matrix {
+    ($module:ident, $engine:literal) => {
+        mod $module {
+            use super::*;
+            #[test]
+            fn commit_and_abort() {
+                committed_and_aborted_writes($engine);
+            }
+            #[test]
+            fn read_only_and_failure() {
+                read_only_and_error_abort($engine);
+            }
+            #[test]
+            fn memory() {
+                memory_minimum_and_rollback($engine);
+            }
+            #[test]
+            fn idle() {
+                idle_timeout_retains_diagnostic_and_rolls_back($engine);
+            }
+            #[test]
+            fn deadlines() {
+                whole_deadline_and_bounded_sleep($engine);
+            }
+            #[test]
+            fn disconnect() {
+                disconnect_rolls_back($engine);
+            }
+            #[test]
+            fn warnings_while_open() {
+                warnings_visible_before_write_transaction_closes($engine);
+            }
+            #[cfg(feature = "test-hooks")]
+            #[test]
+            fn failed_commit() {
+                commit_failure_publishes_no_changes($engine);
+            }
+        }
+    };
+}
+
+matrix!(mem, "mem");
+#[cfg(feature = "storage-sqlite")]
+matrix!(sqlite, "sqlite");
+#[cfg(feature = "storage-rocksdb")]
+matrix!(rocks, "rocksdb");
+
+#[cfg(feature = "storage-sqlite")]
+#[test]
+fn sqlite_snapshot() {
+    snapshot_survives_concurrent_write("sqlite");
+}
+
+#[cfg(feature = "storage-rocksdb")]
+#[test]
+fn rocks_snapshot() {
+    snapshot_survives_concurrent_write("rocksdb");
+}
+
+#[test]
+fn cancellation_keeps_permit_on_actual_worker_until_uncooperative_code_exits() {
+    let (_dir, db) = fixture("mem");
+    let (entered_tx, entered_rx) = bounded(1);
+    let (release_tx, release_rx) = bounded(1);
+    db.register_fixed_rule(
+        "Hold".into(),
+        SimpleFixedRule::new(1, move |_, _| {
+            entered_tx.send(()).unwrap();
+            release_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            Ok(NamedRows::new(
+                vec!["x".into()],
+                vec![vec![DataValue::from(1)]],
+            ))
+        }),
+    )
+    .unwrap();
+    struct Permit(Arc<AtomicBool>);
+    impl Drop for Permit {
+        fn drop(&mut self) {
+            self.0.store(false, Ordering::SeqCst);
+        }
+    }
+    let held = Arc::new(AtomicBool::new(true));
+    let permit = Permit(held.clone());
+    let mut opts = options();
+    opts.deadline = Instant::now() + Duration::from_secs(1);
+    let (mut client, worker) = db.governed_transaction(false, opts).unwrap();
+    let cancellation = client.cancellation();
+    let worker = thread::spawn(move || {
+        worker.run();
+        drop(permit);
+    });
+    let caller = thread::spawn(move || client.run_script("?[x] <~ Hold()", BTreeMap::new()));
+    entered_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+    cancellation.cancel();
+    assert!(caller.join().unwrap().is_err());
+    assert!(
+        held.load(Ordering::SeqCst),
+        "the client returned but its worker is still in host code"
+    );
+    release_tx.send(()).unwrap();
+    worker.join().unwrap();
+    assert!(!held.load(Ordering::SeqCst));
+}
+
+#[test]
+fn scheduling_delay_counts_and_zero_idle_is_rejected() {
+    let (_dir, db) = fixture("mem");
+    let mut opts = options();
+    opts.idle_timeout = Duration::ZERO;
+    assert!(db.governed_transaction(false, opts).is_err());
+    let opts = GovernedTransactionOptions::new(Instant::now() - Duration::from_millis(1));
+    let (mut tx, worker) = start(&db, false, opts);
+    assert_eq!(
+        code(tx.run_script("?[x] <- [[1]]", BTreeMap::new()).unwrap_err()),
+        "eval::timeout"
+    );
+    worker.join().unwrap();
+}
+
+#[test]
+fn stalled_callback_does_not_hold_committed_worker_forever() {
+    let (_dir, db) = fixture("mem");
+    let (_, callback) = db.register_callback("items", Some(0));
+    let mut opts = options();
+    opts.deadline = Instant::now() + Duration::from_secs(1);
+    let (mut tx, worker) = start(&db, true, opts);
+    tx.run_script(
+        "?[id, value] <- [[2, 20]] :put items {id => value}",
+        BTreeMap::new(),
+    )
+    .unwrap();
+    tx.commit().unwrap();
+    worker.join().unwrap();
+    assert!(
+        callback.recv().is_err(),
+        "stalled subscription must disconnect for reconciliation"
+    );
+    assert_eq!(run(&db, "?[id] := *items{id}, id == 2").rows.len(), 1);
+    assert!(run(&db, "::warnings")
+        .rows
+        .iter()
+        .any(|row| row[1].get_str() == Some("callback.delivery_timeout")));
+}
+
+#[test]
+fn whole_deadline_expires_during_idle_before_longer_idle_limit() {
+    let (_dir, db) = fixture("mem");
+    let opts = GovernedTransactionOptions::new(Instant::now() + Duration::from_secs(1));
+    let (mut tx, worker) = start(&db, false, opts);
+    tx.run_script("?[x] <- [[1]]", BTreeMap::new()).unwrap();
+    worker.join().unwrap();
+    assert_eq!(
+        code(tx.run_script("?[x] <- [[2]]", BTreeMap::new()).unwrap_err()),
+        "eval::timeout"
+    );
+}
+
+#[test]
+fn explicit_kill_aborts_prior_writes_even_when_custom_rule_returns_late() {
+    let (_dir, db) = fixture("mem");
+    let (entered_tx, entered_rx) = bounded(1);
+    let (release_tx, release_rx) = bounded(1);
+    db.register_fixed_rule(
+        "Hold".into(),
+        SimpleFixedRule::new(1, move |_, _| {
+            entered_tx.send(()).unwrap();
+            release_rx.recv_timeout(Duration::from_secs(5)).unwrap();
+            Ok(NamedRows::new(
+                vec!["x".into()],
+                vec![vec![DataValue::from(1)]],
+            ))
+        }),
+    )
+    .unwrap();
+    let (mut tx, worker) = start(&db, true, options());
+    tx.run_script(
+        "?[id, value] <- [[2, 20]] :put items {id => value}",
+        BTreeMap::new(),
+    )
+    .unwrap();
+    let caller = thread::spawn(move || {
+        let result = tx.run_script("?[x] <~ Hold()", BTreeMap::new());
+        assert!(tx.commit().is_err());
+        result
+    });
+    entered_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+    let running = run(&db, "::running");
+    assert_eq!(running.rows.len(), 1);
+    let id = running.rows[0][0].get_int().unwrap();
+    run(&db, &format!("::kill {id}"));
+    release_tx.send(()).unwrap();
+    assert_eq!(code(caller.join().unwrap().unwrap_err()), "eval::killed");
+    worker.join().unwrap();
+    assert!(run(&db, "::running").rows.is_empty());
+    assert_eq!(
+        run(&db, "?[id, value] := *items{id, value}").into_json()["rows"],
+        json!([[1, 10]])
+    );
+}

--- a/docs/specs/governed-transactions.md
+++ b/docs/specs/governed-transactions.md
@@ -1,0 +1,115 @@
+# Governed multi-transactions
+
+Status: implemented in the B-L0 engine branch; unreleased. The legacy
+`multi_transaction` and `run_multi_transaction` APIs remain compatible.
+
+## Host API and ownership
+
+On native targets, `DbInstance::governed_transaction(write, options)` returns
+`(GovernedTransaction, GovernedTransactionWorker)`. The worker opens the storage
+transaction only when the host calls `worker.run()` on its dedicated blocking
+thread. Moving the worker does not start an engine-owned background thread.
+
+The host must acquire admission once, then move its permit and database owner
+into the actual worker closure. It must keep them until that closure exits,
+including when an async waiter is cancelled. Do not park a transaction on
+Rayon's shared query pool. For example, the ownership boundary can be:
+
+```rust
+fn run_admitted<P: Send + 'static>(
+    worker: cozo::GovernedTransactionWorker,
+    permit: P,
+) -> std::thread::JoinHandle<()> {
+    std::thread::spawn(move || {
+        worker.run();
+        drop(permit);
+    })
+}
+```
+
+The client has private channels, mutable query methods and consuming
+`commit`/`abort` methods. Each command/result channel holds at most one item.
+Response delivery never blocks the worker. Dropping the client cancels the
+worker; `client.cancellation()` supplies a separate, cloneable signal for hosts
+whose client is inside a blocking call. Cancellation wakes inter-query waiting
+and propagates into every query's poison without allowing ordinary per-query
+cleanup to kill the parent transaction.
+
+## Budgets and errors
+
+`GovernedTransactionOptions::new(request_deadline)` requires an absolute
+`Instant`. Its default inter-query idle limit is five seconds; zero is rejected.
+The optional `mem_limit` is estimated bytes per statement.
+
+- Capture the minimum of the supplied deadline and the Db default timeout when
+  preparing the pair, before worker scheduling. Never re-arm it between queries.
+- Copy the minimum of the per-call and Db memory limits onto the storage
+  transaction. Each query's `:mem_limit` and `:timeout` can tighten its limits.
+  Triggers inherit the transaction's limits and cancellation signal.
+- Bound command waiting by the earlier of the absolute deadline and idle limit.
+  Bound `:sleep` and relation-lock polling by the transaction deadline too.
+- Flush the worker's structured warnings after every query, including parser,
+  compiler and evaluation errors. `::warnings` remains a separate Db operation.
+  Reads and clears access the in-memory ring directly, so they can inspect an
+  active read or write transaction without waiting on its storage locks.
+- Reject write queries in read-only mode. As with the legacy API, each command
+  is one query program; imperative scripts and system commands are unsupported.
+- **Every query error terminates and rolls back the governed transaction.**
+  This stricter contract prevents committing earlier mutations after a failure.
+  The first error retains the original diagnostic, including
+  `eval::mem_budget_exceeded`, `eval::timeout` and `eval::killed`. A late command
+  after idle expiry still receives `eval::timeout`, rather than a channel error.
+  Subsequent use of an already failed client returns `transaction::closed`.
+- Explicit abort drops the storage transaction before acknowledging completion.
+  Commit errors propagate and publish no change-feed events. A successful commit
+  is acknowledged only after the storage commit returns successfully.
+
+Deadline and cancellation checks are cooperative. They do not preempt blocking
+storage calls or arbitrary host fixed-rule code. The client can time out while
+that code is still running; admission must remain with the worker. A cancellation
+or timeout concurrent with a storage commit does **not** prove rollback. Hosts
+must reconcile uncertain write outcomes using their idempotency contract.
+
+Statement accounting is not a total RSS bound, nor a bound on retained transaction
+state or application candidates across queries. MindGraph additionally requires
+its own candidate-carrier bound and process admission; this API does not activate
+those controls.
+
+## Snapshots and callbacks
+
+RocksDB readers pin a snapshot while other writers can commit. The current
+SQLite backend holds a store-wide read guard: it preserves the snapshot by
+holding concurrent writers until the reader closes. Both therefore give stable
+reads, with different concurrency costs. The governed deadline and idle limit
+also apply to these read transactions.
+
+After a successful commit, callback delivery uses the remaining transaction
+deadline. A bounded subscriber that stalls past it is disconnected and emits
+`callback.delivery_timeout`, with a resubscribe/reconcile hint. Already committed
+data stays committed. An unavailable consumer cannot retain the worker forever;
+a disconnected change feed must reconcile against stored data. Legacy callback
+delivery retains its existing behavior.
+
+The channel choices use Crossbeam's documented
+[bounded channels](https://docs.rs/crossbeam-channel/0.5.15/crossbeam_channel/fn.bounded.html),
+[deadline sends](https://docs.rs/crossbeam-channel/0.5.15/crossbeam_channel/struct.Sender.html#method.send_deadline)
+and nonblocking response delivery. The terminal diagnostic is published before
+the worker disconnects its response channel, so connection teardown cannot erase
+an already recorded query error.
+
+## Acceptance and downstream gate
+
+`cozo-core/tests/governed_transaction.rs` exercises memory/SQLite/RocksDB read-only
+rejection, successful writes, abort, parse-failure rollback, all three memory
+limit sources, deadlines, idle expiry and disconnect rollback. SQLite and RocksDB
+have distinct concurrent-writer snapshot tests. Additional tests hold a host
+fixed rule beyond client cancellation to prove actual worker permit ownership,
+kill an active query after prior writes, inject commit failure and check the
+absence of callbacks, and stall a callback subscriber after commit. The library
+suite checks warning flushes on success, parse failure and evaluation failure.
+
+CI runs the new integration suite in both the default/SQLite job and the RocksDB
+job, including the commit-failure seam with `test-hooks`. Downstream MindGraph
+must use a released or explicit immutable compatibility pin after engine
+validation, migrate its existing mutable transaction callers as well as new read
+snapshots, and complete host admission tests before governance activation.


### PR DESCRIPTION
The legacy multi-transaction worker bypasses statement memory limits, has no whole-transaction deadline, waits indefinitely between commands, and omits warning flushes. Add a native governed entry point that returns a serialized client and a host-owned worker, so MindGraph can retain admission on the actual worker through cancellation and storage teardown.

The new path combines Db, per-call and block limits, bounds command waiting and response delivery, aborts the entire transaction on every query error, and preserves the first terminal diagnostic. Read-only mode rejects writes; commit failure publishes no changes. Cancellation and explicit query kills propagate through nested evaluation, and governed sleep cannot retain the worker past its deadline. A stalled bounded callback is disconnected with a warning after a successful commit.

Warning inspection also now bypasses storage transactions. A new regression exposed that `::warnings` could wait behind the active memory/SQLite transaction being inspected; direct ring access resolves that deadlock.

Validation: 379 library tests and 67 focused integration tests passed locally, including 31 governed transaction tests across memory, SQLite and RocksDB. The existing callback, memory-budget, timeout and RocksDB projection-interleaving suites passed. Strict all-target Clippy and focused RocksDB/test-hooks Clippy passed, as did the build without default features, formatting and all eight version checks. CI runs the governed suite on both SQLite and RocksDB with the commit-failure seam.

The contract documents SQLite's writer blocking versus RocksDB's concurrent snapshots, cooperative cancellation of host/storage code, and uncertain outcomes when cancellation races a commit. This is the B-L0 engine prerequisite: application admission, migration of existing MindGraph write callers, lexical read adapters, publication and production activation remain separate work. The legacy API and durable-write setting remain compatible.
