### PR TITLE
docs: record the demand-gated system-versioning proposal

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -47,18 +47,28 @@ existing script literals and newly constructed JSON can change.
 Implementation evidence remains in the [string/JSON review](docs/reviews/2026-09-05-string-json.md)
 and [FTS review](docs/reviews/2026-09-05-fts-prefix.md); these are historical implementation
 snapshots, separate from release evidence. Consumer compatibility changes are merged in core
-PR #80. Engine publication does not establish downstream release or site deployment status.
+PR #80; core adoption of `v0.18.0` merged in
+[PR #81](https://github.com/shuruheel/mindgraph-rs/pull/81). The
+[documentation update](https://github.com/shuruheel/mnestic-site/pull/3) is deployed.
+These are separately verified delivery states; no cloud deployment is implied.
+
+### 0.19 planning
+
+The [0.19 planning record](docs/plans/0.19-planning.md) separates the existing warning-removal
+commitment from proposed maintenance, investigation and demand-gated work. Reconciliation on
+September 6 establishes current status; it does not select a final feature scope or release date.
 
 | Work | State | Gate |
 |---|---|---|
 | Remove temporary `parser.string_decoding_changed` warning | Scheduled for 0.19.0 | Keep the migration guidance after removing the diagnostic |
-| [HNSW verification/repair #56](https://github.com/shuruheel/mnestic/issues/56) | Investigation only | Reproduce a current failure before committing repair; confirmed corruption takes priority |
+| [HNSW integrity #56](https://github.com/shuruheel/mnestic/issues/56) | Proposed first investigation | Failure fixtures and verified invariants before a read-only verifier; reproduce a current failure before committing repair |
+| [Temporary-relation diagnostics #12](https://github.com/shuruheel/mnestic/issues/12) | Proposed maintenance candidate | Agree warning behavior and preserve legitimate transaction-scoped relations |
+| [SQLite WITHOUT ROWID #6](https://github.com/shuruheel/mnestic/issues/6) | Conditional benchmark candidate | Demonstrate benefit across representative row sizes and workloads; preserve existing databases |
 
 Broader HNSW, Arrow export and quantization work remains subject to the evidence gates below.
 
-[Columnar I/O #11](https://github.com/shuruheel/mnestic/issues/11) combines two different states:
-import shipped in 0.17.0; export is unimplemented and demand-gated. Treat only export as remaining
-scope. The tracker has not yet been split.
+[Arrow export #11](https://github.com/shuruheel/mnestic/issues/11) tracks the unimplemented,
+demand-gated export work. Its import half shipped in 0.17.0 and is retained as completed history.
 
 ## Adoption work
 
@@ -77,6 +87,7 @@ scope. The tracker has not yet been split.
 | Plan cache | Repeated planning cost on a real high-frequency workload |
 | Filtered-vector redesign | A measured low-selectivity failure beyond bounded widening |
 | FTS scale work | User-visible latency or documented corpus-scale pressure |
+| Phrase-prefix / phrases inside NEAR | Concrete demand beyond current named errors and workarounds; agree matching and resource-limit contracts |
 | Vector quantization | Corpus-scale storage pressure plus accepted recall bounds |
 | Shared-cache expansion | Multi-instance memory evidence |
 | Extended Cypher read | Observed evaluator friction |

--- a/docs/plans/0.19-planning.md
+++ b/docs/plans/0.19-planning.md
@@ -1,0 +1,69 @@
+# Mnestic 0.19 planning
+
+Reconciled September 6, 2026 against main, the live issue tracker and published 0.18.0.
+This is a planning record. The owner authorized backlog reconciliation; the proposed
+implementation candidates below have not been selected as a final release scope.
+No release date or milestone is set by this pass.
+
+## Released baseline
+
+- [0.18.0](https://github.com/shuruheel/mnestic/releases/tag/v0.18.0) ships #53 string
+  decoding, #54 canonical nested JSON, #55 single-term FTS prefix normalization and
+  the integer FTS-boost panic fix. The three issues are closed.
+- 0.17.0 shipped atomic Parquet/Arrow import and candidate-aware FTS. Arrow export
+  remains unimplemented; the existence of an isolated export branch is not delivery.
+- Exact phrases and named errors for unsupported phrase-prefix / phrases inside NEAR
+  shipped in 0.14.0. The two compositions remain unsupported in 0.18.0.
+- Sled deletion shipped fixed in 0.12.1. Its remaining issue concerns valid-time scans.
+- `rand_ulid()` and `ulid_timestamp()` shipped in 0.8.0; further ULID key ergonomics remain open.
+
+## Existing 0.19 commitment
+
+Remove the temporary `parser.string_decoding_changed` warning as promised in the
+[0.18 migration notes](../../CHANGELOG-FORK.md) and
+[string-literal contract](../specs/string-literals.md). Preserve the decoding semantics,
+regression tests and migration guidance. This is not a new parser redesign.
+
+## Proposed selection order
+
+1. Investigate #56 with a deterministic HNSW failure corpus and explicit invariants.
+   A read-only verifier is the proposed first feature slice, subject to API review and
+   useful diagnostics on healthy and damaged indexes. Targeted repair requires a
+   reproduced failure and a state derivable without guessing; `::reindex` remains
+   the existing full-rebuild recovery path.
+2. Consider #12 as a bounded warning diagnostic. Preserve transaction-temporary semantics
+   and legitimate multi-operation scripts; a blanket rejection previously broke tests.
+3. Evaluate #6 before selecting a storage-layout change. Compare new databases across
+   point reads, scans, writes, disk size and representative small/large values. Adoption
+   depends on measured benefit and continued compatibility with existing files.
+
+The warning removal can accompany these slices. No targeted repair or performance gain
+is promised before its evidence gate. If a current corruption or security defect is
+confirmed, it takes priority over this proposed order.
+
+## Remaining issue inventory
+
+| Issue | Actual remaining scope | Planning state / gate |
+|---|---|---|
+| [#5](https://github.com/shuruheel/mnestic/issues/5) | Sled valid-time scans (`range_skip_scan_tuple`) | Lower-priority backend compatibility; deletion is already fixed |
+| [#6](https://github.com/shuruheel/mnestic/issues/6) | SQLite `WITHOUT ROWID` for new databases | Benchmark first; prepared-statement caching already exists |
+| [#8](https://github.com/shuruheel/mnestic/issues/8) | Additional ULID type / key-default ergonomics | Low priority; settle representation and compatibility before implementation |
+| [#10](https://github.com/shuruheel/mnestic/issues/10) | Official schema snapshot, diff and rollback workflow | Design first; split into bounded deliverables |
+| [#11](https://github.com/shuruheel/mnestic/issues/11) | Arrow query-result export and potential Python handoff | Demand-gated; import shipped in 0.17.0 |
+| [#12](https://github.com/shuruheel/mnestic/issues/12) | Diagnostic for surprising top-level temporary relations | Proposed small maintenance candidate; warning behavior still needs agreement |
+| [#19](https://github.com/shuruheel/mnestic/issues/19) | Multi-token phrase-prefix queries | Demand-gated; specify analyzer semantics and bounded expansion |
+| [#20](https://github.com/shuruheel/mnestic/issues/20) | Phrases inside NEAR | Demand-gated; specify distance and returned-span semantics |
+| [#56](https://github.com/shuruheel/mnestic/issues/56) | HNSW failure corpus, integrity verification, conditional repair | Proposed first investigation; old upstream report is not a confirmed current defect |
+| [#57](https://github.com/shuruheel/mnestic/issues/57) | Vector quantization with float rescore | Corpus-scale pressure and accepted recall/latency/storage evidence |
+
+Plan caching, filtered-vector redesign, FTS scaling, shared-cache expansion and extended
+Cypher reads retain the [public roadmap's evidence gates](../../ROADMAP.md#evidence-gated-work).
+Improved examples, actionable errors and qualification of existing integrations remain valid
+adoption work. Larger query-language or storage breadth is not part of this proposal.
+
+## Selection and delivery
+
+Select and size a bounded slice before assigning it to a release milestone. Each chosen
+implementation needs a contract, acceptance tests and the relevant compatibility/upgrade
+checks. Reuse the strengthened 0.18 package gates when releasing; do not count the earlier
+release's green checks as validation of future changes.

--- a/docs/plans/0.19-planning.md
+++ b/docs/plans/0.19-planning.md
@@ -61,6 +61,22 @@ Cypher reads retain the [public roadmap's evidence gates](../../ROADMAP.md#evide
 Improved examples, actionable errors and qualification of existing integrations remain valid
 adoption work. Larger query-language or storage breadth is not part of this proposal.
 
+## Demand-gated system-versioning integration
+
+Recorded 2026-09-07 under MindGraph adoption B-T2 / D2. Evaluate an indexed
+current-state view alongside commit-stamped history, with defined current-side
+trigger/projection behavior, history retention access paths, a history-preserving
+supported backup/restore contract, and reversible enable/disable semantics.
+Preserve snapshot consistency, crash recovery, erasure and existing non-temporal
+query behavior.
+
+Activation: a MindGraph pilot relation in production for at least 30 days with
+system-time reads answering a named customer question, or a named external TxTime
+user requiring indexed current reads. This is a feasibility proposal, not a 0.19
+build commitment. Current/history separation is an option to evaluate, not a
+prescribed engine architecture. No MindGraph pilot is authorized by recording
+this item: a named consumer and accepted recovery contract are prerequisites.
+
 ## Selection and delivery
 
 Select and size a bounded slice before assigning it to a release milestone. Each chosen


### PR DESCRIPTION
Record the approved B-T2 system-versioning integration proposal in the existing 0.19 planning record. Evaluate indexed current state plus commit-stamped history, trigger/projection behavior, retention, original-history recovery and reversible enable/disable semantics. Activation requires a named external indexed-TxTime user, or a MindGraph pilot that answers a named customer question in production for at least 30 days. This is not a 0.19 build commitment or pilot authorization.

The planning file is absent from remote main. This branch preserves the existing local planning baseline commit `83179c2a73ea911b7b92eb98ce155b97033f0b93` (the September 6 backlog reconciliation, including its ROADMAP.md update), then adds only the 16-line demand-gated proposal in a separate commit. The original checkout and baseline commit are unchanged. The baseline's dated issue/release inventory has not been reclassified as a fresh audit.

Reviewed against approved adoption D2; diff checks pass. No runtime, schema, package version or release workflow changes are included. The separate B-T1 feasibility clarification is in #63.
