### PR TITLE
Add Layered Storage

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,17 @@
+# Workspace build configuration.
+
+[env]
+# The two vendored copies of RocksDB in this tree — the submodule under `cozorocks/` (8.8.1)
+# and the one bundled by `librocksdb-sys` (8.10) — declare `uint64_t` in their public headers
+# without including <cstdint>, relying on it arriving transitively. GCC 13 tightened that and
+# GCC 15 does not provide it at all, so both fail to compile with:
+#
+#   error: 'uint64_t' does not name a type
+#   note: 'uint64_t' is defined in header '<cstdint>'
+#
+# Upstream RocksDB added the includes in later releases; until the submodule and the crate are
+# both moved forward, force the header in. `cc`/`cxx_build` honour CXXFLAGS, so this reaches
+# every C++ translation unit in the workspace.
+#
+# Not forced: an existing CXXFLAGS in the environment takes precedence over this.
+CXXFLAGS = "-include cstdint"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2705,6 +2705,7 @@ dependencies = [
  "js-sys",
  "lazy_static",
  "log",
+ "memchr",
  "miette",
  "minreq",
  "mnestic-rocks",
@@ -2722,9 +2723,7 @@ dependencies = [
  "rand 0.8.7",
  "rayon",
  "regex",
- "rmp",
  "rmp-serde",
- "rmpv",
  "rocksdb",
  "rust-stemmers",
  "rustc-hash 1.1.0",
@@ -3781,15 +3780,6 @@ checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
 dependencies = [
  "rmp",
  "serde",
-]
-
-[[package]]
-name = "rmpv"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
-dependencies = [
- "rmp",
 ]
 
 [[package]]

--- a/cozo-core/Cargo.toml
+++ b/cozo-core/Cargo.toml
@@ -39,11 +39,16 @@ minimal = ["storage-sqlite", "storage-sqlite-src"]
 storage-sqlite = ["dep:sqlite"]
 storage-sqlite-src = ["dep:sqlite3-src", "sqlite3-src/bundled"]
 ## Enables the [RocksDB](http://rocksdb.org/) backend.
+## Cannot be combined with `storage-new-rocksdb` or `storage-layered`: those link a second,
+## separately built RocksDB, and two static copies in one binary export the same symbols.
 ## RocksDB is hard to compile on some platforms, uses more resources than SQLite,
 ## but is very performant and supports an extremely high level of concurrency.
 ## You can also [fine-tune](https://github.com/cozodb/cozo/blob/main/TUNING_ROCKSDB.md) RocksDB options.
 storage-rocksdb = ["dep:cozorocks"]
 storage-new-rocksdb = ["dep:rocksdb"]
+## Enables the layered RocksDB backend: named storage layers composed into a stack per query,
+## for copy-on-write forks of a database.
+storage-layered = ["dep:rocksdb"]
 ## Enables the graph algorithms.
 graph-algo = ["graph", "rayon"]
 ## Registers CsvReader and JsonReader, which allow queries to read arbitrary
@@ -140,9 +145,7 @@ serde_json = "1.0.116"
 serde = { version = "1.0.199" }
 serde_derive = "1.0.199"
 serde_bytes = "0.11.14"
-rmp = "0.8.14"
 rmp-serde = "1.2.0"
-rmpv = "1.0.2"
 base64 = "0.22.0"
 chrono = "0.4.38"
 chrono-tz = "0.9.0"
@@ -210,6 +213,7 @@ quadrature = "0.1.2"
 # For the FTS feature
 jieba-rs = "0.7.0"
 aho-corasick = "1.1.3"
+memchr = "2.7.2"
 rust-stemmers = "1.2.0"
 fast2s = "0.3.1"
 swapvec = "0.3.0"

--- a/cozo-core/benches/pokec.rs
+++ b/cozo-core/benches/pokec.rs
@@ -22,7 +22,7 @@ use rand::Rng;
 use rayon::prelude::*;
 use regex::Regex;
 
-use cozo::{DataValue, DbInstance, NamedRows};
+use cozo::{DataValue, DbInstance, NamedRows, ScriptMutability};
 
 lazy_static! {
     static ref ITERATIONS: usize = {
@@ -54,7 +54,7 @@ lazy_static! {
         let path_exists = Path::exists(&db_path);
         let db = DbInstance::new(&db_kind, db_path.to_str().unwrap(), "").unwrap();
         if path_exists {
-            db.run_script("::compact", Default::default()).unwrap();
+            db.run_script("::compact", Default::default(), ScriptMutability::Mutable).unwrap();
             return db
         }
 
@@ -84,6 +84,7 @@ lazy_static! {
             {:create friends.rev {to: Int, fr: Int}}
             "#,
                 Default::default(),
+                ScriptMutability::Mutable,
             ).is_err() {
                 return db
             }
@@ -237,6 +238,7 @@ fn single_vertex_read() {
         .run_script(
             "?[cmpl_pct, gender, age] := *user{uid: $id, cmpl_pct, gender, age}",
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -248,6 +250,7 @@ fn single_vertex_write() {
             .run_script(
                 "?[uid, cmpl_pct, gender, age] <- [[$id, 0, null, null]] :put user {uid => cmpl_pct, gender, age}",
                 BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+                ScriptMutability::Mutable,
             )
             .is_ok() {
             return;
@@ -270,6 +273,7 @@ fn single_edge_write() {
             {?[fr, to] <- [[$i, $j]] :put friends.rev {fr, to}}
             "#,
                 BTreeMap::from([("i".to_string(), DataValue::from(i as i64)), ("j".to_string(), DataValue::from(j as i64))]),
+                ScriptMutability::Mutable,
             )
             .is_ok()
         {
@@ -286,6 +290,7 @@ fn pagerank() {
             ?[] <~ PageRank(*friends[])
             "#,
             Default::default(),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -300,6 +305,7 @@ fn single_vertex_update() {
             :put user {uid => cmpl_pct, age, gender}
             "#,
                 BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+                ScriptMutability::Mutable,
             )
             .is_ok()
         {
@@ -311,7 +317,7 @@ fn single_vertex_update() {
 
 fn aggregation_group() {
     TEST_DB
-        .run_script("?[age, count(uid)] := *user{uid, age}", Default::default())
+        .run_script("?[age, count(uid)] := *user{uid, age}", Default::default(), ScriptMutability::Immutable)
         .unwrap();
 }
 
@@ -320,6 +326,7 @@ fn aggregation_count() {
         .run_script(
             "?[count(uid), count(age)] := *user{uid, age}",
             Default::default(),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -329,6 +336,7 @@ fn aggregation_filter() {
         .run_script(
             "?[age, count(age)] := *user{age}, age ~ 0 >= 18",
             Default::default(),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -338,6 +346,7 @@ fn aggregation_min_max() {
         .run_script(
             "?[min(uid), max(uid), mean(uid)] := *user{uid, age}",
             Default::default(),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -349,6 +358,7 @@ fn expansion_1_plain() {
         .run_script(
             "?[to] := *friends{fr: $id, to}",
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -360,6 +370,7 @@ fn expansion_1_filter() {
         .run_script(
             "?[to] := *friends{fr: $id, to}, *user{uid: to, age}, age ~ 0 >= 18",
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -371,6 +382,7 @@ fn expansion_2_plain() {
         .run_script(
             "?[to] := *friends{fr: $id, to: a}, *friends{fr: a, to}",
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -382,6 +394,7 @@ fn expansion_2_filter() {
         .run_script(
             "?[to] := *friends{fr: $id, to: a}, *friends{fr: a, to}, *user{uid: to, age}, age ~ 0 >= 18",
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -397,6 +410,7 @@ fn expansion_3_plain() {
             ?[to] := l2[fr], *friends{fr, to}
             "#,
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -411,6 +425,7 @@ fn expansion_3_filter() {
                         ?[to] := l2[fr], *friends{fr, to}, *user{uid: to, age}, age ~ 0 >= 18
                         "#,
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -426,6 +441,7 @@ fn expansion_4_plain() {
                         ?[to] := l3[fr], *friends{fr, to}
                         "#,
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -441,6 +457,7 @@ fn expansion_4_filter() {
                         ?[to] := l3[fr], *friends{fr, to}
                         "#,
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -456,6 +473,7 @@ fn neighbours_2_plain() {
             ?[to] := l1[fr], *friends{fr, to}
             "#,
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -471,6 +489,7 @@ fn neighbours_2_filter_only() {
             ?[to] := l1[fr], *friends{fr, to}, *user{uid: to, age}, age ~ 0 >= 18
             "#,
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -486,6 +505,7 @@ fn neighbours_2_data_only() {
             ?[to, age, cmpl_pct, gender] := l1[fr], *friends{fr, to}, *user{uid: to, age, cmpl_pct, gender}
             "#,
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -501,6 +521,7 @@ fn neighbours_2_filter_data() {
             ?[to] := l1[fr], *friends{fr, to}, *user{uid: to, age, cmpl_pct, gender}, age ~ 0 >= 18
             "#,
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -514,6 +535,7 @@ fn pattern_cycle() {
             ?[n, m] := n = $id, *friends{fr: n, to: m}, *friends.rev{fr: m, to: n}
             "#,
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -532,6 +554,7 @@ fn pattern_long() {
                 :limit 1
             "#,
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }
@@ -547,6 +570,7 @@ fn pattern_short() {
             :limit 1
             "#,
             BTreeMap::from([("id".to_string(), DataValue::from(i as i64))]),
+            ScriptMutability::Immutable,
         )
         .unwrap();
 }

--- a/cozo-core/benches/wiki_pagerank.rs
+++ b/cozo-core/benches/wiki_pagerank.rs
@@ -20,7 +20,7 @@ use test::Bencher;
 
 use lazy_static::{initialize, lazy_static};
 
-use cozo::{DbInstance, NamedRows, DataValue};
+use cozo::{DbInstance, NamedRows, DataValue, ScriptMutability};
 
 lazy_static! {
     static ref TEST_DB: DbInstance = {
@@ -38,6 +38,7 @@ lazy_static! {
 
         db.run_script(":create article {fr: Int, to: Int}",
             Default::default(),
+            ScriptMutability::Mutable,
         ).unwrap();
 
         let file = File::open(&file_path).unwrap();
@@ -72,7 +73,7 @@ fn wikipedia_pagerank(b: &mut Bencher) {
     initialize(&TEST_DB);
     b.iter(|| {
         TEST_DB
-            .run_script("?[id, rank] <~ PageRank(*article[])", Default::default())
+            .run_script("?[id, rank] <~ PageRank(*article[])", Default::default(), ScriptMutability::Immutable)
             .unwrap()
     });
 }
@@ -86,6 +87,7 @@ fn wikipedia_louvain(b: &mut Bencher) {
             .run_script(
                 "?[grp, idx] <~ CommunityDetectionLouvain(*article[])",
                 Default::default(),
+                ScriptMutability::Immutable,
             )
             .unwrap();
         dbg!(start.elapsed());

--- a/cozo-core/src/data/memcmp.rs
+++ b/cozo-core/src/data/memcmp.rs
@@ -39,6 +39,144 @@ const BOT_TAG: u8 = 0xFF;
 const VEC_F32: u8 = 0x01;
 const VEC_F64: u8 = 0x02;
 
+/// The encoded width of a [`DataValue::Validity`]: tag byte, order-encoded timestamp,
+/// assertion byte.
+pub(crate) const VLD_ENCODED_LEN: usize = 1 + 8 + 1;
+
+/// Read the validity that terminates an encoded key, if the key ends in one.
+///
+/// This is a byte-level probe rather than a decode: it recognises the fixed ten-byte
+/// tail that [`MemCmpEncoder::encode_datavalue`] writes for a validity. A key whose final
+/// component is *not* a validity can in principle end in the same shape. See
+/// [`key_ends_in_validity`] for the exact check that debug builds assert against.
+pub(crate) fn tail_validity(key: &[u8]) -> Option<Validity> {
+    if key.len() < VLD_ENCODED_LEN {
+        return None;
+    }
+    let tail = &key[key.len() - VLD_ENCODED_LEN..];
+    if tail[0] != VLD_TAG {
+        return None;
+    }
+    // The stored form is the order-encoded timestamp with every bit complemented, which is
+    // what sorts it descending. Neither step is a byte-order change; that is the read itself.
+    let complemented = BigEndian::read_u64(&tail[1..9]);
+    let ts = order_decode_i64(!complemented);
+    Some(Validity {
+        timestamp: ValidityTs(Reverse(ts)),
+        is_assert: Reverse(tail[9] == 0),
+    })
+}
+
+/// The identity of an encoded key: everything before the trailing validity.
+pub(crate) fn validity_identity(key: &[u8]) -> &[u8] {
+    debug_assert!(key.len() >= VLD_ENCODED_LEN);
+    &key[..key.len() - VLD_ENCODED_LEN]
+}
+
+/// A reusable buffer holding the scan range that covers every version of one key's identity.
+///
+/// A validity is always the last key component of the relation that has one, so
+/// `[identity ++ VLD_TAG, identity ++ VLD_TAG+1)` is exactly that key's version chain.
+///
+/// The two bounds are packed end to end in one allocation rather than held in a vector each:
+/// they are always the same length, so the whole range is sized and reserved once per fill.
+/// Refilling reuses the buffer, so a caller walking many keys allocates only while it grows to
+/// the longest identity it has seen.
+#[derive(Default)]
+pub(crate) struct KeyBounds {
+    /// `[lower][upper]`, each `identity + 1` bytes long.
+    buf: Vec<u8>,
+    /// Where the lower bound ends and the upper begins.
+    split: usize,
+}
+
+impl KeyBounds {
+    /// Point the buffer at `key`'s identity, reusing whatever capacity it already holds.
+    pub(crate) fn fill(&mut self, key: &[u8]) {
+        let identity = validity_identity(key);
+        self.split = identity.len() + 1;
+        self.buf.clear();
+        // Both bounds up front, so neither half can trigger a growth part way through.
+        self.buf.reserve(self.split * 2);
+        self.buf.extend_from_slice(identity);
+        self.buf.push(VLD_TAG);
+        self.buf.extend_from_slice(identity);
+        self.buf.push(VLD_TAG + 1);
+    }
+
+    pub(crate) fn lower(&self) -> &[u8] {
+        &self.buf[..self.split]
+    }
+
+    pub(crate) fn upper(&self) -> &[u8] {
+        &self.buf[self.split..]
+    }
+}
+
+/// The nine bytes an encoded validity with timestamp `ts` begins with: the tag and the
+/// order-encoded timestamp. The tenth byte, the assertion bit, is not part of the marker.
+fn validity_marker(ts: i64) -> [u8; 9] {
+    let mut marker = [0u8; 9];
+    marker[0] = VLD_TAG;
+    BigEndian::write_u64(&mut marker[1..9], !order_encode_i64(ts));
+    marker
+}
+
+/// Whether a buffer contains an encoded validity stamped `ts`, anywhere.
+///
+/// Cozo's derived structures, an HNSW index's neighbour lists for one, embed the key of the
+/// row they describe, validity included, rather than referring to it. A stamp assigned at
+/// commit therefore has to be rewritten wherever it was copied to, not only where the row's own
+/// key ends.
+pub(crate) fn contains_validity_ts(buf: &[u8], ts: i64) -> bool {
+    let marker = validity_marker(ts);
+    find_marker(buf, &marker, 0).is_some()
+}
+
+/// Rewrite every encoded validity stamped `from` to be stamped `to`, in place. Returns how many
+/// were rewritten. Assertion bits are left alone.
+pub(crate) fn restamp_all_validity(buf: &mut [u8], from: i64, to: i64) -> usize {
+    let old = validity_marker(from);
+    let new = validity_marker(to);
+    let mut rewritten = 0;
+    let mut at = 0;
+    while let Some(found) = find_marker(buf, &old, at) {
+        buf[found..found + old.len()].copy_from_slice(&new);
+        at = found + old.len();
+        rewritten += 1;
+    }
+    rewritten
+}
+
+/// The first offset at or after `from` where `marker` occurs in `buf`.
+///
+/// A marker always begins with `VLD_TAG`, so candidate offsets are found by searching for that
+/// byte rather than by comparing at every position.
+fn find_marker(buf: &[u8], marker: &[u8; 9], from: usize) -> Option<usize> {
+    let last = buf.len().checked_sub(marker.len())?;
+    let mut at = from;
+    while at <= last {
+        let found = at + memchr::memchr(VLD_TAG, &buf[at..=last])?;
+        if buf[found..found + marker.len()] == *marker {
+            return Some(found);
+        }
+        at = found + 1;
+    }
+    None
+}
+
+/// Overwrite the timestamp of the validity that terminates an encoded key.
+///
+/// The caller must have established that the key does end in a validity, normally by way of
+/// [`tail_validity`]. Only the timestamp moves; the assertion bit is left alone.
+pub(crate) fn restamp_tail_validity(key: &mut [u8], ts: i64) {
+    debug_assert!(key.len() >= VLD_ENCODED_LEN);
+    let at = key.len() - VLD_ENCODED_LEN;
+    debug_assert_eq!(key[at], VLD_TAG);
+    let ts_flipped = !order_encode_i64(ts);
+    BigEndian::write_u64(&mut key[at + 1..at + 9], ts_flipped);
+}
+
 const IS_FLOAT: u8 = 0b00010000;
 const IS_APPROX_INT: u8 = 0b00000100;
 const IS_EXACT_INT: u8 = 0b00000000;

--- a/cozo-core/src/data/program.rs
+++ b/cozo-core/src/data/program.rs
@@ -19,7 +19,7 @@ use thiserror::Error;
 
 use crate::data::aggr::Aggregation;
 use crate::data::expr::Expr;
-use crate::data::relation::StoredRelationMetadata;
+use crate::data::relation::{ColType, StoredRelationMetadata};
 use crate::data::symb::{Symbol, PROG_ENTRY};
 use crate::data::tuple::Tuple;
 use crate::data::value::{DataValue, ValidityTs};
@@ -1148,6 +1148,10 @@ pub(crate) struct HnswSearch {
     pub(crate) bind_distance: Option<Symbol>,
     pub(crate) bind_vector: Option<Symbol>,
     pub(crate) radius: Option<f64>,
+    /// Restrict results to the version of each record that is live at this point. Only
+    /// meaningful for a relation whose last key column is a validity, and required there for a
+    /// search to mean "nearest records" rather than "nearest versions of records".
+    pub(crate) validity: Option<ValidityTs>,
     pub(crate) filter: Option<Expr>,
     pub(crate) span: SourceSpan,
 }
@@ -1742,6 +1746,34 @@ impl SearchInput {
             None => None,
         };
 
+        let validity = match self.parameters.remove("validity") {
+            None => None,
+            Some(expr) => {
+                #[derive(Debug, Error, Diagnostic)]
+                #[error("Relation `{0}` has no validity column, so `validity` does not apply")]
+                #[diagnostic(code(parser::hnsw_validity_not_applicable))]
+                struct HnswValidityNotApplicable(String, #[label] SourceSpan);
+
+                ensure!(
+                    matches!(
+                        base_handle.metadata.keys.last().map(|c| &c.typing.coltype),
+                        Some(ColType::Validity)
+                    ),
+                    HnswValidityNotApplicable(base_handle.name.to_string(), self.span)
+                );
+
+                #[derive(Debug, Error, Diagnostic)]
+                #[error("Expected a validity for `validity`")]
+                #[diagnostic(code(parser::expected_validity_for_hnsw))]
+                struct ExpectedValidityForHnsw(#[label] SourceSpan);
+
+                match expr.eval_to_const()? {
+                    DataValue::Validity(vld) => Some(vld.timestamp),
+                    _ => bail!(ExpectedValidityForHnsw(self.span)),
+                }
+            }
+        };
+
         let filter = self.parameters.remove("filter");
 
         let bind_field = match self.parameters.remove("bind_field") {
@@ -1829,6 +1861,7 @@ impl SearchInput {
             bind_distance,
             bind_vector,
             radius,
+            validity,
             filter,
             span: self.span,
         }));

--- a/cozo-core/src/data/tests/memcmp.rs
+++ b/cozo-core/src/data/tests/memcmp.rs
@@ -135,3 +135,73 @@ fn encode_decode_datavalues() {
     assert!(remaining.is_empty());
     assert_eq!(decoded, v);
 }
+
+/// An encoded validity, ten bytes: tag, order-encoded timestamp, assertion byte.
+fn encoded_validity(ts: i64) -> Vec<u8> {
+    use crate::data::value::{Validity, ValidityTs};
+    use std::cmp::Reverse;
+    let mut out = vec![];
+    out.encode_datavalue(&DataValue::Validity(Validity {
+        timestamp: ValidityTs(Reverse(ts)),
+        is_assert: Reverse(true),
+    }));
+    out
+}
+
+#[test]
+fn validity_markers_are_found_wherever_they_sit() {
+    use crate::data::memcmp::contains_validity_ts;
+
+    let vld = encoded_validity(7);
+    assert!(contains_validity_ts(&vld, 7));
+    assert!(!contains_validity_ts(&vld, 8), "a different stamp matched");
+
+    // At the very start, at the very end, and surrounded.
+    let mut at_end = vec![0xAA; 5];
+    at_end.extend_from_slice(&vld);
+    assert!(contains_validity_ts(&at_end, 7));
+
+    let mut surrounded = vec![0xAA; 3];
+    surrounded.extend_from_slice(&vld);
+    surrounded.extend_from_slice(&[0xBB; 4]);
+    assert!(contains_validity_ts(&surrounded, 7));
+
+    // Shorter than a marker, and empty.
+    assert!(!contains_validity_ts(&vld[..4], 7));
+    assert!(!contains_validity_ts(&[], 7));
+}
+
+#[test]
+fn a_near_miss_does_not_match() {
+    use crate::data::memcmp::contains_validity_ts;
+
+    // The tag byte is present but the timestamp that follows is a different one, so the
+    // candidate must be rejected and the search must continue past it.
+    let mut buf = encoded_validity(11);
+    buf.extend_from_slice(&encoded_validity(7));
+    assert!(contains_validity_ts(&buf, 7), "the second marker was missed");
+    assert!(contains_validity_ts(&buf, 11));
+    assert!(!contains_validity_ts(&buf, 9));
+}
+
+#[test]
+fn restamping_rewrites_every_occurrence() {
+    use crate::data::memcmp::{contains_validity_ts, restamp_all_validity};
+
+    // Three markers: at the start, adjacent to the second, and after a gap.
+    let mut buf = encoded_validity(7);
+    buf.extend_from_slice(&encoded_validity(7));
+    buf.extend_from_slice(&[0xAA; 6]);
+    buf.extend_from_slice(&encoded_validity(7));
+    let before = buf.clone();
+
+    assert_eq!(restamp_all_validity(&mut buf, 7, 42), 3);
+    assert!(!contains_validity_ts(&buf, 7), "an old stamp survived");
+    assert!(contains_validity_ts(&buf, 42));
+    assert_eq!(buf.len(), before.len(), "restamping changed the length");
+
+    // Restamping a stamp that is not there rewrites nothing and changes nothing.
+    let untouched = buf.clone();
+    assert_eq!(restamp_all_validity(&mut buf, 7, 99), 0);
+    assert_eq!(buf, untouched);
+}

--- a/cozo-core/src/data/tuple.rs
+++ b/cozo-core/src/data/tuple.rs
@@ -51,6 +51,17 @@ pub fn decode_tuple_from_key(key: &[u8], size_hint: usize) -> Tuple {
 
 pub(crate) const DEFAULT_SIZE_HINT: usize = 16;
 
+/// Whether the last component of an encoded key is a validity, determined by decoding the
+/// whole key. The layered storage engine uses a byte-level probe for this in the hot path;
+/// this is the slow, exact version it asserts against in debug builds.
+#[allow(dead_code)]
+pub(crate) fn key_ends_in_validity(key: &[u8]) -> bool {
+    matches!(
+        decode_tuple_from_key(key, DEFAULT_SIZE_HINT).last(),
+        Some(DataValue::Validity(_))
+    )
+}
+
 /// Check if the tuple key passed in should be a valid return for a validity query.
 ///
 /// Returns two elements, the first element contains `Some(tuple)` if the key should be included

--- a/cozo-core/src/lib.rs
+++ b/cozo-core/src/lib.rs
@@ -97,6 +97,14 @@ pub use runtime::temp_store::RegularTempStore;
 pub use storage::mem::{new_cozo_mem, MemStorage};
 #[cfg(feature = "storage-new-rocksdb")]
 pub use storage::newrocks::{new_cozo_newrocksdb, NewRocksDbStorage};
+#[cfg(feature = "storage-layered")]
+pub use storage::layered::flatten::{
+    Claim, FlattenConflict, FlattenCursor, FlattenItem, FlattenPage, FlattenPlan, FlattenStats,
+};
+#[cfg(feature = "storage-layered")]
+pub use storage::layered::{
+    new_cozo_layered, LayerId, LayerRef, LayeredStorage, Seq, Stack, DEFAULT_LAYER,
+};
 #[cfg(feature = "storage-rocksdb")]
 pub use storage::rocks::{
     new_cozo_rocksdb, new_cozo_rocksdb_with_memory, process_default_rocks_memory, RocksDbStorage,

--- a/cozo-core/src/parse/query.rs
+++ b/cozo-core/src/parse/query.rs
@@ -31,7 +31,7 @@ use crate::data::program::{
 };
 use crate::data::relation::{ColType, ColumnDef, NullableColType, StoredRelationMetadata};
 use crate::data::symb::{Symbol, PROG_ENTRY};
-use crate::data::value::{DataValue, ValidityTs};
+use crate::data::value::{DataValue, Validity, ValidityTs};
 use crate::fixed_rule::utilities::constant::Constant;
 use crate::fixed_rule::{FixedRuleHandle, FixedRuleNotFoundError};
 use crate::parse::expr::build_expr;
@@ -774,9 +774,27 @@ fn parse_atom(
                 .into_inner()
                 .map(|arg| extract_named_apply_arg(arg, param_pool))
                 .try_collect()?;
-            let parameters: BTreeMap<SmartString<LazyCompact>, Expr> = src
+            let mut parameters: BTreeMap<SmartString<LazyCompact>, Expr> = src
                 .map(|arg| extract_named_apply_arg(arg, param_pool))
                 .try_collect()?;
+
+            // `validity` takes the same spellings as the `@` clause on a stored relation,
+            // including `'NOW'`, which only this stage knows how to resolve.
+            if let Entry::Occupied(entry) = parameters.entry(SmartString::from("validity")) {
+                let (name, expr) = entry.remove_entry();
+                let expr_span = expr.span();
+                let timestamp = expr2vld_spec(expr, cur_vld)?;
+                parameters.insert(
+                    name,
+                    Expr::Const {
+                        val: DataValue::Validity(Validity {
+                            timestamp,
+                            is_assert: Reverse(true),
+                        }),
+                        span: expr_span,
+                    },
+                );
+            }
 
             let opts = SearchInput {
                 relation,

--- a/cozo-core/src/query/ra.rs
+++ b/cozo-core/src/query/ra.rs
@@ -1371,7 +1371,6 @@ impl HnswSearchRA {
         }
         let config = self.hnsw_search.clone();
         let filter_code = self.filter_bytecode.clone();
-        let mut stack = vec![];
         let it = self
             .parent
             .iter(tx, delta_rule, stores, poison)?
@@ -1381,7 +1380,7 @@ impl HnswSearchRA {
                     d => bail!("Expected vector, got {:?}", d),
                 };
 
-                let res = tx.hnsw_knn(v, &config, &filter_code, &mut stack)?;
+                let res = tx.hnsw_knn(v, &config, &filter_code)?;
                 Ok(res.into_iter().map(move |t| {
                     let mut r = tuple.clone();
                     r.extend(t);

--- a/cozo-core/src/runtime/columnar.rs
+++ b/cozo-core/src/runtime/columnar.rs
@@ -42,7 +42,6 @@ use smartstring::SmartString;
 use thiserror::Error;
 use uuid::Uuid;
 
-use crate::data::functions::current_validity;
 use crate::data::relation::{ColType, ColumnDef, NullableColType, VecElementType};
 use crate::data::value::{DataValue, JsonData, UuidWrapper};
 use crate::runtime::db::{stranded_index_names, warn_if_indexes_stranded, write_import_tuple, Db};
@@ -389,7 +388,7 @@ impl<'s, S: Storage<'s>> Db<S> {
         let mut reader = source.build(options, &mut bindings)?;
         let stale_indexes = stranded_index_names(&handle);
         tx.mark_dirty(&handle);
-        let cur_vld = current_validity();
+        let cur_vld = self.db.now_validity();
 
         let mut rows_processed = 0_u64;
         let mut batches_processed = 0_u64;

--- a/cozo-core/src/runtime/db.rs
+++ b/cozo-core/src/runtime/db.rs
@@ -32,7 +32,6 @@ use serde_json::json;
 use smartstring::{LazyCompact, SmartString};
 use thiserror::Error;
 
-use crate::data::functions::current_validity;
 use crate::data::json::JsonValue;
 use crate::data::memsize::est_tuple_bytes;
 use crate::data::program::{InputProgram, QueryAssertion, RelationOp, ReturnMutation};
@@ -397,6 +396,18 @@ pub enum TransactionPayload {
     Query(Payload),
 }
 
+impl<S: Clone> Db<S> {
+    /// The same database, reached through a different storage handle. Everything else
+    /// (relation locks, callbacks, running queries, the temp store) is shared, so the two
+    /// handles are the same database in every respect except how storage is addressed.
+    #[allow(dead_code)]
+    pub(crate) fn with_storage(&self, db: S) -> Self {
+        let mut ret = self.clone();
+        ret.db = db;
+        ret
+    }
+}
+
 impl<'s, S: Storage<'s>> Db<S> {
     /// Create a new database object with the given storage.
     /// You must call [`initialize`](Self::initialize) immediately after creation.
@@ -470,7 +481,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             }
         };
 
-        let ts = current_validity();
+        let ts = self.db.now_validity();
         let callback_targets = self.current_callback_targets();
         let mut callback_collector = BTreeMap::new();
         let mut write_locks = BTreeMap::new();
@@ -628,7 +639,7 @@ impl<'s, S: Storage<'s>> Db<S> {
         mutability: ScriptMutability,
         options: ScriptRunOptions,
     ) -> Result<NamedRows> {
-        let cur_vld = current_validity();
+        let cur_vld = self.db.now_validity();
         let parsed = parse_script(
             payload,
             &params,
@@ -850,7 +861,7 @@ impl<'s, S: Storage<'s>> Db<S> {
         tx.script_deadline = Some(worker.options.deadline);
         tx.script_mem_limit = worker.options.mem_limit;
         tx.script_cancellation = Some(worker.poison.flag.clone());
-        let ts = current_validity();
+        let ts = self.db.now_validity();
         let callback_targets = self.current_callback_targets();
         let mut callback_collector = BTreeMap::new();
         let mut cleanups: Vec<(Vec<u8>, Vec<u8>)> = vec![];
@@ -1326,7 +1337,7 @@ impl<'s, S: Storage<'s>> Db<S> {
         let locks = self.obtain_relation_locks(rel_names.iter());
         let _guards = locks.iter().map(|l| l.read().unwrap()).collect_vec();
 
-        let cur_vld = current_validity();
+        let cur_vld = self.db.now_validity();
 
         let mut tx = self.transact_write()?;
 
@@ -2583,7 +2594,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                         meet: &custom_aggrs,
                         bounded: &custom_bounded,
                     },
-                    current_validity(),
+                    self.db.now_validity(),
                 )?;
                 let (normalized_program, _) = prog.into_normalized_program(tx)?;
                 // mnestic fork (query factorization): show the rewritten plan

--- a/cozo-core/src/runtime/db.rs
+++ b/cozo-core/src/runtime/db.rs
@@ -1991,8 +1991,13 @@ impl<'s, S: Storage<'s>> Db<S> {
         // struct-literal field would be evaluated in source order, which is
         // too easy to reorder by accident — hence the separate binding.
         let watermark = self.graph_projections.watermark();
+        // The pin happens here, after the watermark capture above. The view is read off the
+        // pinned transaction: it says which content this transaction will see, which is the
+        // other half of what a cache needs to key an entry.
+        let store_tx = self.db.transact(false)?;
+        let storage_view = crate::storage::StoreTx::storage_view(&store_tx);
         let ret = SessionTx {
-            store_tx: Box::new(self.db.transact(false)?),
+            store_tx: Box::new(store_tx),
             temp_store_tx: self.temp_db.transact(true)?,
             relation_store_id: self.relation_store_id.clone(),
             temp_store_id: Default::default(),
@@ -2008,6 +2013,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             script_mem_limit: None,
             projections: self.graph_projections.clone(),
             watermark,
+            storage_view,
             dirty_relations: Default::default(),
             commit_inflight: false,
         };
@@ -2016,8 +2022,13 @@ impl<'s, S: Storage<'s>> Db<S> {
     pub(crate) fn transact_write(&'s self) -> Result<SessionTx<'s>> {
         // See `transact`: the watermark capture must precede the pin.
         let watermark = self.graph_projections.watermark();
+        // The pin happens here, after the watermark capture above. The view is read off the
+        // pinned transaction: it says which content this transaction will see, which is the
+        // other half of what a cache needs to key an entry.
+        let store_tx = self.db.transact(true)?;
+        let storage_view = crate::storage::StoreTx::storage_view(&store_tx);
         let ret = SessionTx {
-            store_tx: Box::new(self.db.transact(true)?),
+            store_tx: Box::new(store_tx),
             temp_store_tx: self.temp_db.transact(true)?,
             relation_store_id: self.relation_store_id.clone(),
             temp_store_id: Default::default(),
@@ -2033,6 +2044,7 @@ impl<'s, S: Storage<'s>> Db<S> {
             script_mem_limit: None,
             projections: self.graph_projections.clone(),
             watermark,
+            storage_view,
             dirty_relations: Default::default(),
             commit_inflight: false,
         };

--- a/cozo-core/src/runtime/graph_projection.rs
+++ b/cozo-core/src/runtime/graph_projection.rs
@@ -99,6 +99,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
 use crate::runtime::relation::RelationId;
+use crate::storage::StorageView;
 
 #[cfg(feature = "graph-algo")]
 use std::sync::atomic::AtomicUsize;
@@ -687,7 +688,7 @@ struct Definition {
     generation: u64,
     edges: SmartString<LazyCompact>,
     nodes: Option<SmartString<LazyCompact>>,
-    variants: BTreeMap<VariantKey, Entry>,
+    variants: BTreeMap<EntryKey, Entry>,
 }
 
 /// A cached variant, bound to the exact relation ids and content versions it
@@ -739,10 +740,14 @@ impl Registry {
         self.defs.values().map(|d| d.variants.len()).sum()
     }
 
-    fn lru_victim(&self) -> Option<(SmartString<LazyCompact>, VariantKey)> {
+    fn lru_victim(&self) -> Option<(SmartString<LazyCompact>, EntryKey)> {
         self.defs
             .iter()
-            .flat_map(|(name, def)| def.variants.iter().map(move |(k, e)| (name, *k, e.lru_seq)))
+            .flat_map(|(name, def)| {
+                def.variants
+                    .iter()
+                    .map(move |(k, e)| (name, k.clone(), e.lru_seq))
+            })
             .min_by_key(|(_, _, seq)| *seq)
             .map(|(name, k, _)| (name.clone(), k))
     }
@@ -768,6 +773,21 @@ impl Registry {
     }
 }
 
+/// What distinguishes one cached CSR from another inside a projection: the shape it was built
+/// in, and the view of the store it was built from.
+///
+/// The view is part of the key because the freshness protocol reasons entirely about
+/// *mutation*, and mutation is not the only thing that can make two transactions disagree. A
+/// backend that composes views (`StorageView::Composed`) has readers seeing different content
+/// for one relation with no write between them; keying on the view is what keeps the
+/// always-fresh guarantee true there.
+#[cfg(feature = "graph-algo")]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct EntryKey {
+    view: StorageView,
+    variant: VariantKey,
+}
+
 /// The single-flight key. Includes the generation, so a `::graph drop` +
 /// re-create never shares a build slot with the projection it replaced.
 #[cfg(feature = "graph-algo")]
@@ -775,7 +795,7 @@ impl Registry {
 struct BuildKey {
     name: SmartString<LazyCompact>,
     generation: u64,
-    variant: VariantKey,
+    key: EntryKey,
 }
 
 /// One row of `::graph list` (§3.1): one per built variant, or a single row
@@ -1028,7 +1048,7 @@ impl ProjectionCache {
                     name: name.to_string(),
                     edges: def.edges.to_string(),
                     nodes: def.nodes.as_ref().map(|n| n.to_string()),
-                    variant: Some(key.label()),
+                    variant: Some(key.variant.label()),
                     est_bytes: Some(entry.est_bytes),
                     built_at: Some(entry.built_at),
                     last_used: Some(entry.last_used_at),
@@ -1051,7 +1071,7 @@ impl ProjectionCache {
         &self,
         name: &str,
         generation: u64,
-        key: VariantKey,
+        key: &EntryKey,
         edges_id: RelationId,
         nodes_id: Option<RelationId>,
         watermark: u64,
@@ -1062,7 +1082,7 @@ impl ProjectionCache {
             if def.generation != generation {
                 return None;
             }
-            let entry = def.variants.get(&key)?;
+            let entry = def.variants.get(key)?;
             if entry.edges_id != edges_id || entry.nodes_id != nodes_id {
                 return None;
             }
@@ -1088,7 +1108,7 @@ impl ProjectionCache {
         if let Some(entry) = reg
             .defs
             .get_mut(name)
-            .and_then(|d| d.variants.get_mut(&key))
+            .and_then(|d| d.variants.get_mut(key))
         {
             entry.lru_seq = seq;
             entry.last_used_at = now;
@@ -1107,7 +1127,7 @@ impl ProjectionCache {
         &self,
         name: &str,
         generation: u64,
-        key: VariantKey,
+        key: &EntryKey,
         edges_id: RelationId,
         nodes_id: Option<RelationId>,
         watermark: u64,
@@ -1161,7 +1181,7 @@ impl ProjectionCache {
                             "graph projection '{name}' variant {} needs ~{est_bytes} bytes, over the \
                              whole {} byte cache ceiling; building it fresh for every query. Raise \
                              the ceiling with `Db::set_graph_projection_capacity`.",
-                            key.label(),
+                            key.variant.label(),
                             reg.capacity
                         ),
                         "raise the ceiling with `Db::set_graph_projection_capacity`",
@@ -1191,7 +1211,7 @@ impl ProjectionCache {
         &self,
         reg: &mut Registry,
         name: &str,
-        key: VariantKey,
+        key: &EntryKey,
         edges_id: RelationId,
         nodes_id: Option<RelationId>,
         edges_token: u64,
@@ -1201,7 +1221,7 @@ impl ProjectionCache {
     ) {
         // Replace any older entry for this exact variant before making room,
         // so its bytes are not counted twice.
-        if let Some(old) = reg.defs.get_mut(name).and_then(|d| d.variants.remove(&key)) {
+        if let Some(old) = reg.defs.get_mut(name).and_then(|d| d.variants.remove(key)) {
             reg.used_bytes = reg.used_bytes.saturating_sub(old.est_bytes);
         }
         let target = reg.capacity - est_bytes;
@@ -1214,7 +1234,7 @@ impl ProjectionCache {
             return;
         };
         def.variants.insert(
-            key,
+            key.clone(),
             Entry {
                 source: source.clone(),
                 edges_id,
@@ -1515,7 +1535,12 @@ pub(crate) fn graph_source(
         return build();
     }
 
-    if let Some(hit) = cache.consume(name, generation, key, edges_id, nodes_id, tx.watermark) {
+    let entry_key = EntryKey {
+        view: tx.storage_view.clone(),
+        variant: key,
+    };
+    if let Some(hit) = cache.consume(name, generation, &entry_key, edges_id, nodes_id, tx.watermark)
+    {
         return Ok(hit);
     }
 
@@ -1541,7 +1566,7 @@ pub(crate) fn graph_source(
     let build_key = BuildKey {
         name: name.into(),
         generation,
-        variant: key,
+        key: entry_key.clone(),
     };
     let slot = cache.acquire_slot(&build_key);
     let outcome = {
@@ -1550,7 +1575,7 @@ pub(crate) fn graph_source(
             cache,
             name,
             generation,
-            key,
+            &entry_key,
             edges_id,
             nodes_id,
             &sources,
@@ -1566,7 +1591,7 @@ pub(crate) fn graph_source(
                 cache.produce(
                     name,
                     generation,
-                    key,
+                    &entry_key,
                     edges_id,
                     nodes_id,
                     tx.watermark,
@@ -1610,7 +1635,7 @@ fn slot_action(
     cache: &ProjectionCache,
     name: &str,
     generation: u64,
-    key: VariantKey,
+    key: &EntryKey,
     edges_id: RelationId,
     nodes_id: Option<RelationId>,
     sources: &[RelationId],
@@ -2406,13 +2431,23 @@ mod cache_tests {
 
     use graph::prelude::Graph;
 
-    use super::{create_projection, graph_source, GraphSource, GraphVariant, VariantKey};
+    use super::{create_projection, graph_source, EntryKey, GraphSource, GraphVariant, VariantKey};
+    use crate::storage::StorageView;
     use crate::data::value::DataValue;
     use crate::parse::SourceSpan;
     use crate::runtime::db::Poison;
     use crate::runtime::relation::RelationId;
     use crate::storage::mem::MemStorage;
     use crate::{new_cozo_mem, Db, NamedRows, ScriptMutability};
+
+    /// These tests exercise the mutation axis of the key; the view axis is held at the one
+    /// value every single-view backend reports.
+    fn global(variant: VariantKey) -> EntryKey {
+        EntryKey {
+            view: StorageView::undivided(),
+            variant,
+        }
+    }
 
     const DIRECTED: VariantKey = VariantKey {
         undirected: false,
@@ -2671,7 +2706,7 @@ mod cache_tests {
     ///
     /// The isolate must take the **highest** dense id, which is why `person`
     /// lists every edge endpoint before `99`. Interned earlier, it would sit
-    /// below some edge endpoint, `max_edge_endpoint + 1` would happen to equal
+    /// below some edge endpoint, `max_edge_endpoint + 1` would happen to equaso it can downcast infalliblyl
     /// the true vertex count, and the plain `.edges()` sizing would cover it by
     /// accident — leaving the test green against a builder that had dropped the
     /// `node_values` route entirely.
@@ -3074,7 +3109,7 @@ mod cache_tests {
         );
         assert!(
             cache
-                .consume("g", generation, DIRECTED, edges, None, watermark)
+                .consume("g", generation, &global(DIRECTED), edges, None, watermark)
                 .is_none(),
             "yet the entry's token no longer names the relation's content"
         );
@@ -3147,13 +3182,13 @@ mod cache_tests {
 
         assert!(
             cache
-                .consume("g", generation, DIRECTED, edges, None, token)
+                .consume("g", generation, &global(DIRECTED), edges, None, token)
                 .is_some(),
             "a reader that pinned at or after the entry's token hits"
         );
         assert!(
             cache
-                .consume("g", generation, DIRECTED, edges, None, token - 1)
+                .consume("g", generation, &global(DIRECTED), edges, None, token - 1)
                 .is_none(),
             "a reader that pinned before it must miss and rebuild"
         );
@@ -3173,10 +3208,10 @@ mod cache_tests {
         assert!(token > 0, "the fixture's writes gave `knows` a token");
         assert_eq!(cached(&db), 1);
 
-        cache.produce("h", h_generation, DIRECTED, edges, None, token - 1, &source);
+        cache.produce("h", h_generation, &global(DIRECTED), edges, None, token - 1, &source);
         assert_eq!(cached(&db), 1, "an unfresh producer must not publish");
 
-        cache.produce("h", h_generation, DIRECTED, edges, None, token, &source);
+        cache.produce("h", h_generation, &global(DIRECTED), edges, None, token, &source);
         assert_eq!(cached(&db), 2, "a fresh one may");
     }
 
@@ -3199,7 +3234,7 @@ mod cache_tests {
         let (new_generation, ..) = cache.definition("g").unwrap();
         assert_ne!(old_generation, new_generation);
 
-        cache.produce("g", old_generation, DIRECTED, edges, None, token, &source);
+        cache.produce("g", old_generation, &global(DIRECTED), edges, None, token, &source);
         assert_eq!(cached(&db), 0, "the stale generation must not publish");
 
         // Now let the new definition populate, and check the stale reader is
@@ -3208,13 +3243,13 @@ mod cache_tests {
         assert_eq!(cached(&db), 1);
         assert!(
             cache
-                .consume("g", new_generation, DIRECTED, edges, None, token)
+                .consume("g", new_generation, &global(DIRECTED), edges, None, token)
                 .is_some(),
             "the live generation reads it"
         );
         assert!(
             cache
-                .consume("g", old_generation, DIRECTED, edges, None, token)
+                .consume("g", old_generation, &global(DIRECTED), edges, None, token)
                 .is_none(),
             "the stale one does not"
         );
@@ -3294,7 +3329,7 @@ mod cache_tests {
 
         assert!(
             cache
-                .consume("g", generation, DIRECTED, edges, None, reader_watermark)
+                .consume("g", generation, &global(DIRECTED), edges, None, reader_watermark)
                 .is_some(),
             "the entry is servable before the writer starts"
         );
@@ -3321,7 +3356,7 @@ mod cache_tests {
         assert_eq!(cached(&db), 1);
         assert!(
             cache
-                .consume("g", generation, DIRECTED, edges, None, reader_watermark)
+                .consume("g", generation, &global(DIRECTED), edges, None, reader_watermark)
                 .is_none(),
             "`inflight` alone must deny the hit"
         );
@@ -3332,7 +3367,7 @@ mod cache_tests {
         cache.produce(
             "h",
             h_generation,
-            DIRECTED,
+            &global(DIRECTED),
             edges,
             None,
             reader_watermark,
@@ -3376,14 +3411,14 @@ mod cache_tests {
 
         // Cold and fresh: the winner's case.
         assert!(matches!(
-            slot_action(cache, "g", generation, DIRECTED, edges, None, &sources, watermark),
+            slot_action(cache, "g", generation, &global(DIRECTED), edges, None, &sources, watermark),
             SlotAction::BuildAndPublish
         ));
 
         // An entry landed while queued, still fresh for us: the payoff case.
         fetch(&db, "g", DIRECTED).unwrap();
         assert!(matches!(
-            slot_action(cache, "g", generation, DIRECTED, edges, None, &sources, watermark),
+            slot_action(cache, "g", generation, &global(DIRECTED), edges, None, &sources, watermark),
             SlotAction::Hit(_)
         ));
 
@@ -3392,7 +3427,7 @@ mod cache_tests {
         // everyone's way and build outside.
         cache.bump_token_leaving_entries(edges);
         assert!(matches!(
-            slot_action(cache, "g", generation, DIRECTED, edges, None, &sources, watermark),
+            slot_action(cache, "g", generation, &global(DIRECTED), edges, None, &sources, watermark),
             SlotAction::BuildOutsideTheSlot
         ));
     }
@@ -3592,7 +3627,7 @@ mod cache_tests {
         let edges = rel_id(&db, "knows");
         let token = cache.rel_state(edges).token;
         let source = fetch(&db, "g", DIRECTED).unwrap();
-        cache.produce("g", generation, DIRECTED, edges, None, token, &source);
+        cache.produce("g", generation, &global(DIRECTED), edges, None, token, &source);
 
         assert_eq!(cached(&db), 1);
         assert_eq!(

--- a/cozo-core/src/runtime/hnsw.rs
+++ b/cozo-core/src/runtime/hnsw.rs
@@ -10,7 +10,7 @@ use crate::data::expr::{eval_bytecode_pred, Bytecode};
 use crate::data::program::HnswSearch;
 use crate::data::relation::VecElementType;
 use crate::data::tuple::Tuple;
-use crate::data::value::Vector;
+use crate::data::value::{ValidityTs, Vector};
 use crate::parse::sys::HnswDistance;
 use crate::runtime::relation::{try_decode_val_only, RelationHandle};
 use crate::runtime::transact::SessionTx;
@@ -91,6 +91,19 @@ mod distance_order_tests {
 
 struct VectorCache {
     cache: FxHashMap<CompoundKey, Vector>,
+    /// Base rows for records already fetched, keyed by the record key so the several compound
+    /// keys of one row share an entry. Populated only when a search predicate needs the row.
+    rows: FxHashMap<Vec<DataValue>, Tuple>,
+    /// Record keys this transaction cannot read.
+    missing: FxHashSet<Vec<DataValue>>,
+    /// Whether an unreadable record is fatal. Index maintenance says yes: it is writing the
+    /// graph against rows that must be there, and a miss means the two have diverged. Search
+    /// says no: the graph and the records it names are read independently, so a node the
+    /// reader cannot resolve is a visibility outcome rather than damage, and the traversal
+    /// steps over it.
+    lenient: bool,
+    /// Whether to retain fetched rows in `rows`.
+    keep_rows: bool,
     distance: HnswDistance,
 }
 
@@ -154,19 +167,56 @@ impl VectorCache {
     fn get_key(&self, key: &CompoundKey) -> &Vector {
         self.cache.get(key).unwrap()
     }
+    /// Whether `key` names a record this transaction could not read. Always false unless the
+    /// cache is lenient, because otherwise the miss would have been an error.
+    #[inline]
+    fn is_missing(&self, key: &CompoundKey) -> bool {
+        !self.missing.is_empty() && self.missing.contains(&key.0)
+    }
+
+    /// Record a fetched row: extract its vector, and retain the row itself if asked.
+    fn accept(&mut self, key: &CompoundKey, tuple: Tuple) -> Result<()> {
+        self.insert_from_tuple(key, &tuple)?;
+        if self.keep_rows {
+            self.rows.insert(key.0.clone(), tuple);
+        }
+        Ok(())
+    }
+
+    /// Record a row that was not there.
+    fn reject(&mut self, key: &CompoundKey) -> Result<()> {
+        if !self.lenient {
+            bail!("Cannot find compound key for HNSW: {:?}", key);
+        }
+        self.missing.insert(key.0.clone());
+        Ok(())
+    }
+
+    /// Whether `key` still needs fetching: not already cached, and not already known absent.
+    fn wanted(&self, key: &CompoundKey) -> bool {
+        !self.cache.contains_key(key) && !self.is_missing(key)
+    }
+
     fn ensure_key(
         &mut self,
         key: &CompoundKey,
         handle: &RelationHandle,
         tx: &SessionTx<'_>,
     ) -> Result<()> {
-        if !self.cache.contains_key(key) {
-            match handle.get(tx, &key.0)? {
-                Some(tuple) => self.insert_from_tuple(key, &tuple)?,
-                None => bail!("Cannot find compound key for HNSW: {:?}", key),
+        if !self.wanted(key) {
+            return Ok(());
+        }
+        // A sibling compound key of the same record may already have brought the row in.
+        if self.keep_rows {
+            if let Some(tuple) = self.rows.get(&key.0) {
+                let tuple = tuple.clone();
+                return self.insert_from_tuple(key, &tuple);
             }
         }
-        Ok(())
+        match handle.get(tx, &key.0)? {
+            Some(tuple) => self.accept(key, tuple),
+            None => self.reject(key),
+        }
     }
 
     /// Batch `ensure_key` (mnestic fork): one storage `multi_get` covers every
@@ -179,22 +229,19 @@ impl VectorCache {
         handle: &RelationHandle,
         tx: &SessionTx<'_>,
     ) -> Result<()> {
-        let missing: Vec<&CompoundKey> = keys
-            .iter()
-            .filter(|k| !self.cache.contains_key(*k))
-            .collect();
-        if missing.is_empty() {
+        let wanted: Vec<&CompoundKey> = keys.iter().filter(|k| self.wanted(k)).collect();
+        if wanted.is_empty() {
             return Ok(());
         }
-        if missing.len() == 1 {
-            return self.ensure_key(missing[0], handle, tx);
+        if wanted.len() == 1 {
+            return self.ensure_key(wanted[0], handle, tx);
         }
-        let key_slices: Vec<&[DataValue]> = missing.iter().map(|k| k.0.as_slice()).collect();
+        let key_slices: Vec<&[DataValue]> = wanted.iter().map(|k| k.0.as_slice()).collect();
         let tuples = handle.get_batch(tx, &key_slices)?;
-        for (key, tuple) in missing.iter().zip(tuples) {
+        for (&key, tuple) in wanted.iter().zip(tuples) {
             match tuple {
-                Some(tuple) => self.insert_from_tuple(key, &tuple)?,
-                None => bail!("Cannot find compound key for HNSW: {:?}", key),
+                Some(tuple) => self.accept(key, tuple)?,
+                None => self.reject(key)?,
             }
         }
         Ok(())
@@ -218,6 +265,182 @@ impl VectorCache {
         }
         Ok(())
     }
+}
+
+/// Whether a node at `distance` is worth expanding: the result set is not yet full, or the
+/// node beats its furthest member.
+///
+/// An unfilled set admits without comparing, which matters for a distance that is not a
+/// number: `OrderedFloat` sorts NaN above every real distance, so comparing would drop such a
+/// node from the traversal entirely and cut the graph around it.
+fn may_expand(
+    found_nn: &PriorityQueue<CompoundKey, OrderedFloat<f64>>,
+    ef: usize,
+    distance: f64,
+) -> bool {
+    match found_nn.peek() {
+        Some((_, OrderedFloat(furthest))) if found_nn.len() >= ef => {
+            distance_is_closer(distance, *furthest)
+        }
+        _ => true,
+    }
+}
+
+/// Whether the walk is done: the result set is full and the nearest candidate left is further
+/// away than everything in it. An unfilled set never stops the walk, which is what keeps a
+/// selective search going instead of returning short.
+fn is_exhausted(
+    found_nn: &PriorityQueue<CompoundKey, OrderedFloat<f64>>,
+    ef: usize,
+    distance: f64,
+) -> bool {
+    match found_nn.peek() {
+        Some((_, OrderedFloat(furthest))) if found_nn.len() >= ef => {
+            distance_is_farther(distance, *furthest)
+        }
+        _ => false,
+    }
+}
+
+/// The conditions a node must meet to be returned by a search, applied during the traversal.
+///
+/// These were once a pass over the finished result set, which silently capped a search at
+/// however many of its first `ef` nodes happened to qualify. Asking here instead means `k`
+/// results come back whenever `k` qualifying nodes are reachable at all.
+///
+/// `radius` is not among them, and stays a cut over the finished set. It bounds distance, and
+/// the result set is ordered by distance, so the nearest `k` are the nearest `k` within any
+/// radius that holds `k` of them: there is no shortfall to fix. Asking it during the walk would
+/// also strand a search whose entry point happens to lie outside the radius.
+struct HnswAdmit<'a> {
+    config: &'a HnswSearch,
+    filter: &'a Option<(Vec<Bytecode>, SourceSpan)>,
+    /// Scratch for filter evaluation, both reused across candidates.
+    stack: Vec<DataValue>,
+    tuple: Tuple,
+    /// Per record, the version of it live at the query point, or `None` where it has none.
+    ///
+    /// Every version of a record is its own node, so a walk reaches the same record through
+    /// several of them and would otherwise ask the store the same question once per version.
+    live: FxHashMap<Tuple, Option<DataValue>>,
+}
+
+impl<'a> HnswAdmit<'a> {
+    fn new(config: &'a HnswSearch, filter: &'a Option<(Vec<Bytecode>, SourceSpan)>) -> Self {
+        HnswAdmit {
+            config,
+            filter,
+            stack: vec![],
+            tuple: vec![],
+            live: FxHashMap::default(),
+        }
+    }
+
+    /// Whether anything is actually asked of a candidate. When nothing is, the search reverts
+    /// to the plain nearest-neighbour walk.
+    fn is_trivial(&self) -> bool {
+        self.config.validity.is_none() && self.filter.is_none()
+    }
+
+    /// Whether `key` names the version of its record that is live at `valid_at`: an assertion,
+    /// and the newest one no later than that point.
+    fn is_live(
+        &mut self,
+        tx: &SessionTx<'_>,
+        key: &CompoundKey,
+        valid_at: ValidityTs,
+    ) -> Result<bool> {
+        let n_keys = self.config.base_handle.metadata.keys.len();
+        let DataValue::Validity(vld) = &key.0[n_keys - 1] else {
+            bail!(
+                "relation '{}' has no validity column",
+                self.config.base_handle.name
+            );
+        };
+        // Both of these are decidable from the key alone, so they never reach the store: a
+        // retraction is never live, and neither is a version later than the query point.
+        // Validity sorts newest first, so a later one compares less.
+        if !vld.is_assert.0 || vld.timestamp < valid_at {
+            return Ok(false);
+        }
+        let prefix = &key.0[..n_keys - 1];
+        if let Some(live) = self.live.get(prefix) {
+            return Ok(live.as_ref() == Some(&key.0[n_keys - 1]));
+        }
+        let live = tx.hnsw_live_version(self.config, prefix, valid_at)?;
+        let matched = live.as_ref() == Some(&key.0[n_keys - 1]);
+        self.live.insert(prefix.to_vec(), live);
+        Ok(matched)
+    }
+
+    fn admits(
+        &mut self,
+        tx: &SessionTx<'_>,
+        key: &CompoundKey,
+        distance: f64,
+        vec_cache: &VectorCache,
+    ) -> Result<bool> {
+        if let Some(valid_at) = self.config.validity {
+            if !self.is_live(tx, key, valid_at)? {
+                return Ok(false);
+            }
+        }
+        let Some((code, span)) = self.filter else {
+            return Ok(true);
+        };
+        let Some(row) = vec_cache.rows.get(&key.0) else {
+            return Ok(false);
+        };
+        // Refilled rather than rebuilt, so a wide selective walk does not allocate a tuple
+        // per candidate it tests.
+        self.tuple.clear();
+        self.tuple.extend_from_slice(row);
+        push_search_bindings(&mut self.tuple, key, self.config, distance)?;
+        eval_bytecode_pred(code, &self.tuple, &mut self.stack, *span)
+    }
+}
+
+/// Append the optional bindings a query asked for to a base row, turning it into the tuple a
+/// search returns for that node. The order has to match `HnswSearch::all_bindings`.
+fn push_search_bindings(
+    tuple: &mut Tuple,
+    key: &CompoundKey,
+    config: &HnswSearch,
+    distance: f64,
+) -> Result<()> {
+    let n_keys = config.base_handle.metadata.keys.len();
+    if config.bind_field.is_some() {
+        let field = if key.1 < n_keys {
+            config.base_handle.metadata.keys[key.1].name.clone()
+        } else {
+            config.base_handle.metadata.non_keys[key.1 - n_keys]
+                .name
+                .clone()
+        };
+        tuple.push(DataValue::Str(field));
+    }
+    if config.bind_field_idx.is_some() {
+        tuple.push(if key.2 < 0 {
+            DataValue::Null
+        } else {
+            DataValue::from(key.2 as i64)
+        });
+    }
+    if config.bind_distance.is_some() {
+        tuple.push(DataValue::from(distance));
+    }
+    if config.bind_vector.is_some() {
+        let vec = if key.2 < 0 {
+            tuple[key.1].clone()
+        } else {
+            match &tuple[key.1] {
+                DataValue::List(v) => v[key.2 as usize].clone(),
+                v => bail!("corrupted index value {:?}", v),
+            }
+        };
+        tuple.push(vec);
+    }
+    Ok(())
 }
 
 impl<'a> SessionTx<'a> {
@@ -335,6 +558,7 @@ impl<'a> SessionTx<'a> {
                     idx_table,
                     &mut found_nn,
                     vec_cache,
+                    None,
                 )?;
             }
             let mut self_tuple_key = Vec::with_capacity(orig_table.metadata.keys.len() * 2 + 5);
@@ -363,6 +587,7 @@ impl<'a> SessionTx<'a> {
                     idx_table,
                     &mut found_nn,
                     vec_cache,
+                    None,
                 )?;
                 // add bidirectional links to the nearest neighbors
                 let neighbours = self.hnsw_select_neighbours_heuristic(
@@ -655,6 +880,17 @@ impl<'a> SessionTx<'a> {
         }
         Ok(ret)
     }
+    /// One level of the greedy search.
+    ///
+    /// `admit` separates the two jobs the traversal does. Routing is unconditional: every
+    /// neighbour close enough to be worth expanding is expanded, whatever else is true of it.
+    /// Qualifying as a *result* is what `admit` governs, and only nodes that reach `found_nn`
+    /// are ever returned. Keeping the two apart is what makes a selective predicate widen the
+    /// search rather than truncate it: while fewer than `ef` nodes qualify the stopping bound
+    /// stays at infinity, so the walk keeps going instead of returning short.
+    ///
+    /// `None` means every node qualifies, which is what the descent through the upper levels
+    /// wants: those levels exist to find an entry point, not to produce answers.
     fn hnsw_search_level(
         &self,
         q: &Vector,
@@ -664,6 +900,7 @@ impl<'a> SessionTx<'a> {
         idx_table: &RelationHandle,
         found_nn: &mut PriorityQueue<CompoundKey, OrderedFloat<f64>>,
         vec_cache: &mut VectorCache,
+        mut admit: Option<&mut HnswAdmit<'_>>,
     ) -> Result<()> {
         let mut visited: FxHashSet<CompoundKey> = FxHashSet::default();
         // min queue
@@ -675,9 +912,24 @@ impl<'a> SessionTx<'a> {
             candidates.push(item.0.clone(), Reverse(*item.1));
         }
 
+        // The entry points arrive as results of the level above, where nothing was asked of
+        // them but proximity. Re-test them here, so that a level whose job is to produce
+        // answers starts from an answer set it actually vouches for.
+        if let Some(admit) = admit.as_deref_mut() {
+            let seeds = found_nn
+                .iter()
+                .map(|(k, d)| (k.clone(), *d))
+                .collect::<Vec<_>>();
+            found_nn.clear();
+            for (key, OrderedFloat(dist)) in seeds {
+                if !vec_cache.is_missing(&key) && admit.admits(self, &key, dist, vec_cache)? {
+                    found_nn.push(key, OrderedFloat(dist));
+                }
+            }
+        }
+
         while let Some((candidate, Reverse(OrderedFloat(candidate_dist)))) = candidates.pop() {
-            let (_, OrderedFloat(furthest_dist)) = found_nn.peek().unwrap();
-            if distance_is_farther(candidate_dist, *furthest_dist) {
+            if is_exhausted(found_nn, ef, candidate_dist) {
                 break;
             }
             // Fetch all unvisited neighbours' vectors in one batched read
@@ -692,15 +944,27 @@ impl<'a> SessionTx<'a> {
                 if visited.contains(&neighbour_key) {
                     continue;
                 }
-                let neighbour_dist = vec_cache.v_dist(q, &neighbour_key);
-                let (_, OrderedFloat(candidate_furthest_dist)) = found_nn.peek().unwrap();
-                if found_nn.len() < ef
-                    || distance_is_closer(neighbour_dist, *candidate_furthest_dist)
-                {
-                    candidates.push(neighbour_key.clone(), Reverse(OrderedFloat(neighbour_dist)));
-                    found_nn.push(neighbour_key.clone(), OrderedFloat(neighbour_dist));
-                    if found_nn.len() > ef {
-                        found_nn.pop();
+                // A node with no row has no vector, so it can neither be measured nor
+                // returned, and its own edges are unreachable from here.
+                if !vec_cache.is_missing(&neighbour_key) {
+                    let neighbour_dist = vec_cache.v_dist(q, &neighbour_key);
+                    if may_expand(found_nn, ef, neighbour_dist) {
+                        candidates
+                            .push(neighbour_key.clone(), Reverse(OrderedFloat(neighbour_dist)));
+                        // Only nodes that got this far pay for the predicate, so its cost
+                        // tracks the churn of the result set rather than the size of the walk.
+                        let admitted = match admit.as_deref_mut() {
+                            Some(admit) => {
+                                admit.admits(self, &neighbour_key, neighbour_dist, vec_cache)?
+                            }
+                            None => true,
+                        };
+                        if admitted {
+                            found_nn.push(neighbour_key.clone(), OrderedFloat(neighbour_dist));
+                            if found_nn.len() > ef {
+                                found_nn.pop();
+                            }
+                        }
                     }
                 }
                 visited.insert(neighbour_key);
@@ -821,6 +1085,10 @@ impl<'a> SessionTx<'a> {
         // a cache shared across the batch could then serve a stale vector.
         let mut vec_cache = VectorCache {
             cache: FxHashMap::default(),
+            rows: FxHashMap::default(),
+            missing: FxHashSet::default(),
+            lenient: false,
+            keep_rows: false,
             distance: manifest.distance,
         };
         self.hnsw_put_inner(
@@ -1198,7 +1466,6 @@ impl<'a> SessionTx<'a> {
         q: Vector,
         config: &HnswSearch,
         filter_bytecode: &Option<(Vec<Bytecode>, SourceSpan)>,
-        stack: &mut Vec<DataValue>,
     ) -> Result<Vec<Tuple>> {
         if q.len() != config.manifest.vec_dim {
             bail!("query vector dimension mismatch");
@@ -1212,129 +1479,123 @@ impl<'a> SessionTx<'a> {
 
         let mut vec_cache = VectorCache {
             cache: Default::default(),
+            rows: Default::default(),
+            missing: Default::default(),
+            lenient: true,
+            // Only the user filter reads the row itself; radius and liveness work off the key.
+            keep_rows: filter_bytecode.is_some(),
             distance: config.manifest.distance,
         };
 
-        let ep_res = config
-            .idx_handle
-            .scan_bounded_prefix(
-                self,
-                &[],
-                &[DataValue::from(i64::MIN)],
-                &[DataValue::from(1)],
-            )
-            .next();
-        if let Some(ep) = ep_res {
+        // The graph is entered at its highest level. A stack that cannot read the entry
+        // point's record cannot measure it either, so walk on to the next one rather than
+        // giving up on the whole index.
+        let n_keys = config.base_handle.metadata.keys.len();
+        let mut entry = None;
+        for ep in config.idx_handle.scan_bounded_prefix(
+            self,
+            &[],
+            &[DataValue::from(i64::MIN)],
+            &[DataValue::from(1)],
+        ) {
             let ep = ep?;
-            let bottom_level = ep[0].get_int().unwrap();
-            let ep_idx = match ep[config.base_handle.metadata.keys.len() + 1].get_int() {
-                Some(x) => x as usize,
-                None => {
-                    // this occurs if the index is empty
-                    return Ok(vec![]);
-                }
+            let Some(ep_idx) = ep[n_keys + 1].get_int() else {
+                // this occurs if the index is empty
+                return Ok(vec![]);
             };
-            let ep_t_key = ep[1..config.base_handle.metadata.keys.len() + 1].to_vec();
-            let ep_subidx = ep[config.base_handle.metadata.keys.len() + 2]
-                .get_int()
-                .unwrap() as i32;
-            let ep_key = (ep_t_key, ep_idx, ep_subidx);
-            vec_cache.ensure_key(&ep_key, &config.base_handle, self)?;
-            let ep_distance = vec_cache.v_dist(&q, &ep_key);
-            let mut found_nn = PriorityQueue::new();
-            found_nn.push(ep_key, OrderedFloat(ep_distance));
-            for current_level in bottom_level..0 {
-                self.hnsw_search_level(
-                    &q,
-                    1,
-                    current_level,
-                    &config.base_handle,
-                    &config.idx_handle,
-                    &mut found_nn,
-                    &mut vec_cache,
-                )?;
+            let candidate = (
+                ep[1..n_keys + 1].to_vec(),
+                ep_idx as usize,
+                ep[n_keys + 2].get_int().unwrap() as i32,
+            );
+            let bottom_level = ep[0].get_int().unwrap();
+            vec_cache.ensure_key(&candidate, &config.base_handle, self)?;
+            if !vec_cache.is_missing(&candidate) {
+                entry = Some((candidate, bottom_level));
+                break;
             }
+        }
+        let Some((ep_key, bottom_level)) = entry else {
+            return Ok(vec![]);
+        };
+
+        let ep_distance = vec_cache.v_dist(&q, &ep_key);
+        let mut found_nn = PriorityQueue::new();
+        found_nn.push(ep_key, OrderedFloat(ep_distance));
+        // The upper levels only route, so nothing is asked of the nodes they pass through.
+        for current_level in bottom_level..0 {
             self.hnsw_search_level(
                 &q,
-                config.ef,
-                0,
+                1,
+                current_level,
                 &config.base_handle,
                 &config.idx_handle,
                 &mut found_nn,
                 &mut vec_cache,
+                None,
             )?;
-            if found_nn.is_empty() {
-                return Ok(vec![]);
-            }
+        }
+        let mut admit = HnswAdmit::new(config, filter_bytecode);
+        let trivial = admit.is_trivial();
+        self.hnsw_search_level(
+            &q,
+            config.ef,
+            0,
+            &config.base_handle,
+            &config.idx_handle,
+            &mut found_nn,
+            &mut vec_cache,
+            if trivial { None } else { Some(&mut admit) },
+        )?;
+        if found_nn.is_empty() {
+            return Ok(vec![]);
+        }
 
-            if config.filter.is_none() {
-                while found_nn.len() > config.k {
-                    found_nn.pop();
+        // Everything still here already qualifies, so all but the nearest `k` are about to be
+        // thrown away. Drop them before paying to read their rows.
+        while found_nn.len() > config.k {
+            found_nn.pop();
+        }
+
+        let mut ret = Vec::with_capacity(found_nn.len());
+        while let Some((cand_key, OrderedFloat(distance))) = found_nn.pop() {
+            if let Some(radius) = config.radius {
+                if distance > radius {
+                    continue;
                 }
             }
-
-            let mut ret = vec![];
-
-            while let Some((cand_key, OrderedFloat(distance))) = found_nn.pop() {
-                if let Some(r) = config.radius {
-                    if distance > r {
-                        continue;
-                    }
-                }
-
-                let mut cand_tuple = config
+            // The row was already read during the traversal whenever a predicate needed it.
+            let mut row = match vec_cache.rows.get(&cand_key.0) {
+                Some(row) => row.clone(),
+                None => config
                     .base_handle
                     .get(self, &cand_key.0)?
-                    .ok_or_else(|| miette!("corrupted index"))?;
+                    .ok_or_else(|| miette!("corrupted index"))?,
+            };
+            push_search_bindings(&mut row, &cand_key, config, distance)?;
+            ret.push(row);
+        }
+        ret.reverse();
+        ret.truncate(config.k);
 
-                // make sure the order is the same as in all_bindings()!!!
-                if config.bind_field.is_some() {
-                    let field = if cand_key.1 < config.base_handle.metadata.keys.len() {
-                        config.base_handle.metadata.keys[cand_key.1].name.clone()
-                    } else {
-                        config.base_handle.metadata.non_keys
-                            [cand_key.1 - config.base_handle.metadata.keys.len()]
-                        .name
-                        .clone()
-                    };
-                    cand_tuple.push(DataValue::Str(field));
-                }
-                if config.bind_field_idx.is_some() {
-                    cand_tuple.push(if cand_key.2 < 0 {
-                        DataValue::Null
-                    } else {
-                        DataValue::from(cand_key.2 as i64)
-                    });
-                }
-                if config.bind_distance.is_some() {
-                    cand_tuple.push(DataValue::from(distance));
-                }
-                if config.bind_vector.is_some() {
-                    let vec = if cand_key.2 < 0 {
-                        cand_tuple[cand_key.1].clone()
-                    } else {
-                        match &cand_tuple[cand_key.1] {
-                            DataValue::List(v) => v[cand_key.2 as usize].clone(),
-                            v => bail!("corrupted index value {:?}", v),
-                        }
-                    };
-                    cand_tuple.push(vec);
-                }
+        Ok(ret)
+    }
 
-                if let Some((code, span)) = filter_bytecode {
-                    if !eval_bytecode_pred(code, &cand_tuple, stack, *span)? {
-                        continue;
-                    }
-                }
-
-                ret.push(cand_tuple);
-            }
-            ret.reverse();
-            ret.truncate(config.k);
-
-            Ok(ret)
-        } else {
-            Ok(vec![])
+    /// The version of the record at `prefix` that is live at `valid_at`, if it has one.
+    fn hnsw_live_version(
+        &self,
+        config: &HnswSearch,
+        prefix: &[DataValue],
+        valid_at: ValidityTs,
+    ) -> Result<Option<DataValue>> {
+        let n_keys = config.base_handle.metadata.keys.len();
+        match config
+            .base_handle
+            .skip_scan_bounded_prefix(self, prefix, &[], &[], valid_at)
+            .next()
+        {
+            None => Ok(None),
+            Some(newest) => Ok(Some(newest?.swap_remove(n_keys - 1))),
         }
     }
 }

--- a/cozo-core/src/runtime/relation.rs
+++ b/cozo-core/src/runtime/relation.rs
@@ -864,14 +864,16 @@ impl RelationHandle {
     pub(crate) fn skip_scan_bounded_prefix<'a>(
         &self,
         tx: &'a SessionTx<'_>,
-        prefix: &Tuple,
+        prefix: &[DataValue],
         lower: &[DataValue],
         upper: &[DataValue],
         valid_at: ValidityTs,
     ) -> impl Iterator<Item = Result<Tuple>> + 'a {
-        let mut lower_t = prefix.clone();
+        let mut lower_t = Vec::with_capacity(prefix.len() + lower.len());
+        lower_t.extend_from_slice(prefix);
         lower_t.extend_from_slice(lower);
-        let mut upper_t = prefix.clone();
+        let mut upper_t = Vec::with_capacity(prefix.len() + upper.len() + 1);
+        upper_t.extend_from_slice(prefix);
         upper_t.extend_from_slice(upper);
         upper_t.push(DataValue::Bot);
         let lower_encoded = lower_t.encode_as_key(self.id);

--- a/cozo-core/src/runtime/tests.rs
+++ b/cozo-core/src/runtime/tests.rs
@@ -17,7 +17,7 @@ use smartstring::{LazyCompact, SmartString};
 
 use crate::data::expr::Expr;
 use crate::data::symb::Symbol;
-use crate::data::value::DataValue;
+use crate::data::value::{DataValue, Vector};
 use crate::fixed_rule::FixedRulePayload;
 use crate::fts::{TokenizerCache, TokenizerConfig};
 use crate::parse::SourceSpan;
@@ -25,6 +25,7 @@ use crate::runtime::callback::CallbackOp;
 use crate::runtime::db::Poison;
 use crate::storage::mem::MemStorage;
 use crate::Db;
+use crate::NamedRows;
 use crate::{DbInstance, FixedRule, RegularTempStore, ScriptMutability};
 
 #[test]
@@ -1190,6 +1191,155 @@ fn test_insertions() {
     for row in res.into_json()["rows"].as_array().unwrap() {
         println!("{} {}", row[0], row[1]);
     }
+}
+
+/// Twenty-five points along a diagonal, with an HNSW index over them.
+fn line_db() -> DbInstance {
+    let db = DbInstance::new("mem", "", "").unwrap();
+    db.run_default(":create pt {k: Int => v: <F32; 2>}")
+        .unwrap();
+    db.run_default("?[k, v] := k in int_range(25), v = vec([k, k]) :put pt {k => v}")
+        .unwrap();
+    db.run_default(
+        "::hnsw create pt:i {fields: [v], dim: 2, dtype: F32, m: 16, ef_construction: 20}",
+    )
+    .unwrap();
+    db
+}
+
+fn ints(rows: NamedRows) -> Vec<i64> {
+    rows.rows
+        .iter()
+        .map(|r| r[0].get_int().unwrap())
+        .collect_vec()
+}
+
+/// A search asked for `k` results returns `k` whenever `k` of them pass the filter, however
+/// few of the nearest `ef` do. The filter selects three points far from the probe, so a search
+/// that only sifts the candidates it happened to collect first comes back empty.
+#[test]
+fn hnsw_filter_does_not_truncate_the_result() {
+    let db = line_db();
+    for ef in [3, 5, 50] {
+        let found = ints(
+            db.run_default(&format!(
+                "?[k] := ~pt:i{{k | query: q, k: 3, ef: {ef}, \
+                 filter: k == 20 || k == 22 || k == 24}}, q = vec([0.0, 0.0])"
+            ))
+            .unwrap(),
+        );
+        assert_eq!(found, vec![20, 22, 24], "ef {ef} returned {found:?}");
+    }
+}
+
+/// A radius still cuts what a search returns, and still does so over results the filter had to
+/// walk past its `ef` nearest nodes to find.
+#[test]
+fn hnsw_radius_and_filter_compose() {
+    let db = line_db();
+    // Squared L2 along the diagonal: point k sits at distance 2*k*k from the origin, so the
+    // radius admits everything up to k = 10 and nothing beyond it.
+    let found = ints(
+        db.run_default(
+            "?[k] := ~pt:i{k | query: q, k: 5, ef: 3, radius: 200.0, \
+             filter: k == 8 || k == 10 || k == 12}, q = vec([0.0, 0.0])",
+        )
+        .unwrap(),
+    );
+    assert_eq!(found, vec![8, 10], "got {found:?}");
+}
+
+/// Without `validity` every version of a record is its own node, so a search over a
+/// time-travelling relation ranks superseded and retracted versions alongside current ones.
+#[test]
+fn hnsw_ranks_every_version_without_a_validity() {
+    let db = DbInstance::new("mem", "", "").unwrap();
+    db.run_default(":create doc {id: String, at: Validity => v: <F32; 2>}")
+        .unwrap();
+    db.run_default(
+        "?[id, at, v] <- [['a', 'ASSERT', [1.0, 1.0]], ['b', 'ASSERT', [2.0, 2.0]]] \
+         :put doc {id, at => v}",
+    )
+    .unwrap();
+    db.run_default(
+        "::hnsw create doc:i {fields: [v], dim: 2, dtype: F32, m: 16, ef_construction: 20}",
+    )
+    .unwrap();
+    // Supersede `a`, then retract `b`.
+    db.run_default("?[id, at, v] <- [['a', 'ASSERT', [1.5, 1.5]]] :put doc {id, at => v}")
+        .unwrap();
+    db.run_default("?[id, at, v] <- [['b', 'RETRACT', [2.0, 2.0]]] :put doc {id, at => v}")
+        .unwrap();
+
+    // Binding the validity as well, because projecting to the id alone would collapse the
+    // versions of one record into a single row and hide exactly what this is measuring.
+    let all = db
+        .run_default("?[id, at] := ~doc:i{id, at | query: q, k: 10, ef: 50}, q = vec([1.0, 1.0])")
+        .unwrap();
+    assert_eq!(all.rows.len(), 4, "expected one node per version");
+
+    // Binding the vector too: `a` has two assertions, and only the later one is live, so this
+    // pins down which version came back and not merely how many did.
+    let live = db
+        .run_default(
+            "?[id, v] := ~doc:i{id, v | query: q, k: 10, ef: 50, validity: 'NOW'}, \
+             q = vec([1.0, 1.0])",
+        )
+        .unwrap();
+    assert_eq!(live.rows.len(), 1, "got {:?}", live.rows);
+    assert_eq!(
+        live.rows[0][0].get_str().unwrap(),
+        "a",
+        "retracted and superseded versions leaked"
+    );
+    assert_eq!(
+        live.rows[0][1],
+        DataValue::Vec(Vector::F32(ndarray::arr1(&[1.5f32, 1.5f32]))),
+        "the superseded version of `a` came back instead of the live one"
+    );
+}
+
+/// Liveness is asked during the walk, so it costs no results: `k` live records come back even
+/// when the nodes nearest the probe are all dead.
+#[test]
+fn hnsw_validity_does_not_truncate_the_result() {
+    let db = DbInstance::new("mem", "", "").unwrap();
+    db.run_default(":create doc {id: Int, at: Validity => v: <F32; 2>}")
+        .unwrap();
+    db.run_default("?[id, at, v] := id in int_range(25), at = 'ASSERT', v = vec([id, id]) :put doc {id, at => v}")
+        .unwrap();
+    db.run_default(
+        "::hnsw create doc:i {fields: [v], dim: 2, dtype: F32, m: 16, ef_construction: 20}",
+    )
+    .unwrap();
+    // Retract everything but the three furthest from the probe.
+    db.run_default(
+        "?[id, at, v] := *doc{id, v @ 'NOW'}, id < 22, at = 'RETRACT' :put doc {id, at => v}",
+    )
+    .unwrap();
+
+    let found = ints(
+        db.run_default(
+            "?[id] := ~doc:i{id | query: q, k: 3, ef: 5, validity: 'NOW'}, q = vec([0.0, 0.0])",
+        )
+        .unwrap(),
+    );
+    assert_eq!(found, vec![22, 23, 24], "got {found:?}");
+}
+
+/// `validity` only means something where there is a validity column to read.
+#[test]
+fn hnsw_validity_needs_a_validity_column() {
+    let db = line_db();
+    let err = db
+        .run_default(
+            "?[k] := ~pt:i{k | query: q, k: 3, ef: 5, validity: 'NOW'}, q = vec([0.0, 0.0])",
+        )
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("no validity column"),
+        "unexpected error: {err:?}"
+    );
 }
 
 #[test]

--- a/cozo-core/src/runtime/transact.rs
+++ b/cozo-core/src/runtime/transact.rs
@@ -88,6 +88,10 @@ pub struct SessionTx<'a> {
     /// A source relation whose token exceeds this was mutated by a commit this
     /// transaction cannot see, so no cached projection over it may be served.
     pub(crate) watermark: u64,
+    /// Which composed view of the store this transaction reads. Paired with
+    /// `watermark`: the watermark says when the content was last written, this says whose
+    /// content it is. Caches need both to key an entry soundly.
+    pub(crate) storage_view: crate::storage::StorageView,
     /// Every persistent relation this transaction has mutated, marked at
     /// mutation-function entry. Drives the commit-time token bump, and marks
     /// the transaction's own uncommitted writes so it never consults or

--- a/cozo-core/src/storage/layered/catalog.rs
+++ b/cozo-core/src/storage/layered/catalog.rs
@@ -1,0 +1,113 @@
+/*
+ * Layered storage: what the global catalog says about a relation.
+ *
+ * Stackability is a property of a relation's schema, fixed when it is created: a relation whose
+ * last key column is a validity can express a cross-layer retraction, and one without cannot.
+ * Nothing here decides policy; it reports what the catalog holds so that the stack gates in
+ * `tx.rs` and the skip rules in `flatten.rs` can decide from the relation alone, before any row
+ * is touched.
+ */
+
+use std::sync::Arc;
+
+use miette::{IntoDiagnostic, Result, WrapErr};
+use smartstring::{LazyCompact, SmartString};
+use rocksdb::BoundColumnFamily;
+
+use crate::data::relation::ColType;
+use crate::data::tuple::TupleT;
+use crate::data::value::{DataValue, LARGEST_UTF_CHAR};
+use crate::runtime::relation::{RelationHandle, RelationId};
+use crate::storage::layered::iter::LayeredTxn;
+
+/// One relation, as the global catalog describes it.
+#[derive(Clone, Debug)]
+pub(crate) struct RelInfo {
+    pub(crate) id: RelationId,
+    pub(crate) name: SmartString<LazyCompact>,
+    /// Whether the relation carries a validity, and so can express a cross-layer retraction.
+    pub(crate) stackable: bool,
+    /// Index relations store their structure as ordinary rows. They compose through a stack but
+    /// are never flattened; the destination's are dropped and rebuilt.
+    pub(crate) is_index: bool,
+    /// How many columns the key holds, for decoding a stored key back into values.
+    pub(crate) n_keys: usize,
+}
+
+/// Every relation in the store, ordered by relation id.
+///
+/// Ids are big-endian at the head of every key, so id order is keyspace order: iterating
+/// visits relations in the order their rows appear on disk, which is what lets a paged scan
+/// resume from a single key. Held contiguously and searched rather than walked as a tree,
+/// since a lookup happens on every operation a stack gates.
+pub(crate) struct Catalog {
+    relations: Vec<RelInfo>,
+}
+
+impl Catalog {
+    /// What the catalog says about one relation, or `None` if it holds no such id.
+    pub(crate) fn get(&self, id: u64) -> Option<&RelInfo> {
+        self.relations
+            .binary_search_by_key(&id, |rel| rel.id.0)
+            .ok()
+            .map(|at| &self.relations[at])
+    }
+
+    /// Every relation, in id order.
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &RelInfo> {
+        self.relations.iter()
+    }
+}
+
+/// Read the catalog.
+///
+/// The catalog is global (one copy, in the default layer), so this is the same answer through
+/// every stack.
+pub(crate) fn catalog_relations(
+    txn: &LayeredTxn<'_>,
+    catalog: &Arc<BoundColumnFamily<'_>>,
+) -> Result<Catalog> {
+    let lower = vec![DataValue::from("")].encode_as_key(RelationId::SYSTEM);
+    let upper =
+        vec![DataValue::from(String::from(LARGEST_UTF_CHAR))].encode_as_key(RelationId::SYSTEM);
+    let mut relations = vec![];
+    let mut it = txn.raw_iterator_cf(catalog);
+    it.seek(&lower);
+    while let Some(k) = it.key() {
+        if k >= upper.as_slice() {
+            break;
+        }
+        let meta = RelationHandle::decode(it.value().unwrap_or_default())?;
+        let stackable = matches!(
+            meta.metadata.keys.last().map(|c| &c.typing.coltype),
+            Some(ColType::Validity)
+        );
+        relations.push(RelInfo {
+            id: meta.id,
+            // Cozo names an index after its parent, `relation:index`; that colon is the
+            // catalog's own marker, and what `::relations` reports on.
+            is_index: meta.name.contains(':'),
+            name: meta.name.clone(),
+            stackable,
+            n_keys: meta.metadata.keys.len(),
+        });
+        it.next();
+    }
+    it.status()
+        .into_diagnostic()
+        .wrap_err("failed to read the catalog")?;
+    // The catalog is stored by name, so ordering by id is this function's job.
+    relations.sort_unstable_by_key(|rel| rel.id.0);
+    Ok(Catalog { relations })
+}
+
+/// The relation a key belongs to, read from its prefix.
+#[inline]
+pub(crate) fn relation_of(key: &[u8]) -> Option<u64> {
+    if key.len() < 8 {
+        return None;
+    }
+    Some(u64::from_be_bytes([
+        key[0], key[1], key[2], key[3], key[4], key[5], key[6], key[7],
+    ]))
+}

--- a/cozo-core/src/storage/layered/flatten.rs
+++ b/cozo-core/src/storage/layered/flatten.rs
@@ -1,0 +1,676 @@
+/*
+ * Flatten: materialize the net effect of a windowed view into a stack's top layer.
+ *
+ * One primitive covers merge-down, changeset extraction and cherry-pick; they differ only in
+ * the windows of the source view.
+ */
+
+use miette::{bail, miette, IntoDiagnostic, Result, WrapErr};
+
+use std::borrow::Cow;
+use std::ops::ControlFlow;
+
+use crate::data::memcmp::{restamp_tail_validity, tail_validity, validity_identity};
+use crate::data::tuple::decode_tuple_from_key;
+use crate::data::value::DataValue;
+use crate::runtime::relation::extend_tuple_from_v;
+use crate::storage::layered::iter::{LayeredTxn, StackMerge};
+use crate::storage::layered::catalog::{catalog_relations, Catalog, RelInfo};
+use crate::storage::layered::tx::{bind_layers, BoundLayer, BoundStack};
+use crate::storage::layered::{LayeredStorage, Seq, Stack, DEFAULT_LAYER};
+use crate::Db;
+
+/// What a flatten did. A consumer recording a merge needs to know which sequences the copied
+/// rows occupy, hence `seq_range`.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct FlattenStats {
+    /// Rows written into the destination's top layer.
+    pub rows_copied: u64,
+    /// Bytes of key and value written.
+    pub bytes_copied: u64,
+    /// Identical re-introductions of a record the destination already holds live.
+    pub rows_deduped: u64,
+    /// Retractions that bit nothing in the destination and were therefore dropped.
+    pub tombstones_dropped: u64,
+    /// The sequences the copied rows occupy. `None` exactly when `restamp` was false.
+    pub seq_range: Option<(Seq, Seq)>,
+}
+
+/// One value claimed for a key, and the layer claiming it.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Claim {
+    /// The value columns.
+    pub value: Vec<DataValue>,
+    /// The layer holding this value.
+    pub layer: String,
+}
+
+/// One key that more than one layer claims a different value for.
+///
+/// Under value immutability a key's value never changes, so this never arises within one
+/// lineage. It arises between lineages: each window predates the other's write, so every claim
+/// was legal where it was made, and none of them is privileged. Choosing between them needs a
+/// policy the storage layer does not have, so it reports every claim and refuses.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FlattenConflict {
+    /// The relation the key belongs to.
+    pub relation: String,
+    /// The key, decoded. Its last element is the validity the view holds the row at.
+    pub key: Vec<DataValue>,
+    /// Every distinct value claimed for this key, with the layer claiming it. Always two or
+    /// more, and always complete: both the source view and the destination are consulted, so
+    /// resolving one claim cannot reveal another that was hidden.
+    pub claims: Vec<Claim>,
+}
+
+/// What a flatten *would* do, computed without writing anything.
+///
+/// This is the same computation [`Db::flatten`] performs before it writes: resolving the
+/// view's net effect and deciding each row against the destination's liveness. A caller
+/// that needs to preview a merge, or to report its conflicts, does not have to reproduce it.
+///
+/// A plan is not a lock. It is subject to the same caveat as the flatten itself: nothing here
+/// is atomic against concurrent writers on either stack, so a plan can be made stale by a write
+/// that lands between planning and acting.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct FlattenPlan {
+    /// What the flatten would report, had it run. `seq_range` is always `None`: a plan occupies
+    /// no sequence because it commits nothing.
+    pub stats: FlattenStats,
+    /// Every collision, not merely the first. Empty exactly when the flatten would succeed.
+    pub conflicts: Vec<FlattenConflict>,
+}
+
+impl FlattenPlan {
+    /// Whether the flatten this plans would succeed.
+    pub fn is_clean(&self) -> bool {
+        self.conflicts.is_empty()
+    }
+}
+
+
+/// A row of a paginated preview, decoded.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FlattenItem {
+    /// A row the flatten would write into the destination's top layer.
+    Copy {
+        /// The relation the row belongs to.
+        relation: String,
+        /// The key, decoded. Its last element is the validity the view holds the row at.
+        key: Vec<DataValue>,
+        /// The value columns. Empty for a retraction.
+        value: Vec<DataValue>,
+        /// Whether the row asserts. A diff reads this as added rather than removed, without
+        /// having to decode the validity back out of the key.
+        asserts: bool,
+    },
+    /// A record the destination already holds live, identically.
+    Dedupe {
+        /// The relation the row belongs to.
+        relation: String,
+        /// The key, decoded.
+        key: Vec<DataValue>,
+    },
+    /// A retraction that bites nothing in the destination.
+    TombstoneDropped {
+        /// The relation the row belongs to.
+        relation: String,
+        /// The key, decoded.
+        key: Vec<DataValue>,
+    },
+    /// A key the two lineages gave different values.
+    Conflict(FlattenConflict),
+}
+
+/// Where a paginated scan left off. Opaque, and meaningful only to the same `(src, dst)` pair.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FlattenCursor(Vec<u8>);
+
+impl FlattenCursor {
+    /// The token's bytes, for a caller that needs to carry it across a process boundary.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+    /// Rebuild a cursor from [`FlattenCursor::as_bytes`].
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        FlattenCursor(bytes)
+    }
+}
+
+/// One page of a preview.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FlattenPage {
+    /// The items in this page, in key order.
+    pub items: Vec<FlattenItem>,
+    /// Where to resume, or `None` at the end of the scan.
+    pub next: Option<FlattenCursor>,
+}
+
+/// What one resolved source row means against the destination, borrowed from the scan.
+///
+/// Nothing here is owned: a caller that counts rows allocates nothing, and a caller that
+/// renders them chooses what to build. Conflicts are bounded by construction; rows are not.
+enum RowEffect<'r> {
+    /// The destination does not already agree: applying this row would change it.
+    Effective {
+        key: &'r [u8],
+        val: &'r [u8],
+        /// Whether the row asserts. A diff reads this as added versus removed.
+        asserts: bool,
+    },
+    /// The destination already holds this record, identically and live.
+    Redundant { key: &'r [u8] },
+    /// A retraction of a record the destination never held live.
+    Inert { key: &'r [u8] },
+    /// One key with more than one claimed value. Conflicts are bounded by construction, so
+    /// unlike the other arms this one is built rather than borrowed.
+    Divergent(FlattenConflict),
+}
+
+/// The O(1) state one identity accumulates while its versions stream past.
+struct Resolved {
+    identity: Vec<u8>,
+    /// The newest visible version: what the view resolves this identity to.
+    key: Vec<u8>,
+    val: Vec<u8>,
+    asserts: bool,
+    /// The newest assertive value and the layer holding it. Under value immutability every
+    /// assertion under this key should carry the same value.
+    asserted: Option<(Vec<u8>, Option<usize>)>,
+    /// Any assertion carrying a different value, with its layer. Empty unless the source view
+    /// disagrees with itself, so the ordinary path allocates nothing for it.
+    others: Vec<(Vec<u8>, Option<usize>)>,
+}
+
+/// The name of a layer by index, for labelling a claim.
+fn layer_name(layers: &[BoundLayer<'_>], at: Option<usize>) -> String {
+    at.and_then(|i| layers.get(i))
+        .map(|l| l.name.clone())
+        .unwrap_or_else(|| "<unknown>".to_string())
+}
+
+/// Decide one resolved identity against the destination and hand it to the visitor.
+fn emit<F>(
+    txn: &LayeredTxn<'_>,
+    src_layers: &[BoundLayer<'_>],
+    dst: &mut BoundStack<'_>,
+    rel: &RelInfo,
+    done: Resolved,
+    visit: &mut F,
+) -> Result<ControlFlow<Vec<u8>>>
+where
+    F: FnMut(&RelInfo, RowEffect<'_>) -> Result<ControlFlow<()>>,
+{
+    // The destination is consulted whatever the source view says, so a key that both sides
+    // disagree about reports every claim at once rather than one now and one on a retry.
+    let state = dst.key_state(txn, &done.key)?;
+    let dst_disagrees = done.asserts && matches!(&state.asserted, Some(v) if *v != done.val);
+
+    let effect = if !done.others.is_empty() || dst_disagrees {
+        let mut claims = Vec::with_capacity(done.others.len() + 2);
+        if let Some((val, at)) = &done.asserted {
+            claims.push(Claim {
+                value: decode_values(val),
+                layer: layer_name(src_layers, *at),
+            });
+        }
+        for (val, at) in &done.others {
+            claims.push(Claim {
+                value: decode_values(val),
+                layer: layer_name(src_layers, *at),
+            });
+        }
+        if let Some(val) = &state.asserted {
+            let already = done
+                .asserted
+                .iter()
+                .map(|(v, _)| v)
+                .chain(done.others.iter().map(|(v, _)| v))
+                .any(|v| v == val);
+            if !already {
+                claims.push(Claim {
+                    value: decode_values(val),
+                    layer: layer_name(&dst.layers, state.asserted_layer),
+                });
+            }
+        }
+        RowEffect::Divergent(FlattenConflict {
+            relation: rel.name.to_string(),
+            key: decode_tuple_from_key(&done.key, rel.n_keys),
+            claims,
+        })
+    } else if done.asserts {
+        if state.asserted.is_some() && state.live {
+            // Already there, identical: the same record cherry-picked into a lineage that
+            // already carries it.
+            RowEffect::Redundant { key: &done.key }
+        } else {
+            RowEffect::Effective {
+                key: &done.key,
+                val: &done.val,
+                asserts: true,
+            }
+        }
+    } else if state.live {
+        RowEffect::Effective {
+            key: &done.key,
+            val: &done.val,
+            asserts: false,
+        }
+    } else {
+        // A tombstone for a record this lineage never saw. Dropping it is what keeps every
+        // flatten simpler than the union of its inputs.
+        RowEffect::Inert { key: &done.key }
+    };
+
+    Ok(match visit(rel, effect)? {
+        ControlFlow::Break(()) => ControlFlow::Break(done.key),
+        ControlFlow::Continue(()) => ControlFlow::Continue(()),
+    })
+}
+
+/// Resolve the source view and decide each row against the destination, one row at a time.
+///
+/// This is the whole of a flatten except the writing. `visit` sees every row in key order and
+/// may stop early; the returned key is where a later call should resume from, and is `None`
+/// when the scan ran to the end.
+///
+/// `relations` is the catalog, every relation the store holds, read once per transaction.
+/// It is the scan's outer loop. Each entry gives the key range for that relation's rows,
+/// the policy for it (`is_index`, `stackable`), and the `RelInfo` passed on to `visit`.
+///
+/// It must be ordered by relation id. Ids sit big-endian at the head of every key, so id
+/// order is keyspace order, which is what lets `after` be a single key: a relation an earlier
+/// page finished is skipped by comparing `after` against its upper bound.
+///
+/// Resolution happens *within the view first*: a record created and retracted inside the
+/// window contributes its tombstone and only that, which is why the merge is drained per
+/// identity rather than per row.
+fn scan<F>(
+    txn: &LayeredTxn<'_>,
+    src_layers: &[BoundLayer<'_>],
+    dst: &mut BoundStack<'_>,
+    relations: &Catalog,
+    after: Option<&[u8]>,
+    mut visit: F,
+) -> Result<Option<Vec<u8>>>
+where
+    F: FnMut(&RelInfo, RowEffect<'_>) -> Result<ControlFlow<()>>,
+{
+    for rel in relations.iter() {
+        if rel.is_index {
+            // Copying index rows would splice two independently evolved graphs into something
+            // structurally invalid, whose only symptom is silent recall loss. The destination's
+            // indexes are dropped and rebuilt instead.
+            continue;
+        }
+        // `raw_encode` yields an array, so these bounds live on the stack.
+        let lower = rel.id.raw_encode();
+        let upper = rel.id.next().raw_encode();
+        if let Some(after) = after {
+            if after >= upper.as_slice() {
+                // A relation an earlier page already finished.
+                continue;
+            }
+        }
+        if !rel.stackable {
+            // A relation with no validity has no retraction mechanism and no stamp, so there is
+            // no net effect to compute. Leaving its rows behind silently would be the worst
+            // outcome, so check that there are none rather than assume it.
+            if holds_rows(txn, &src_layers[0], rel)? {
+                bail!(
+                    "cannot flatten: relation '{}' has no validity column, and the source \
+                     layer holds rows for it",
+                    rel.name
+                );
+            }
+            continue;
+        }
+
+        // Resume past every version of the last key reported, not merely past that key: older
+        // versions of one identity sort *after* the newest, so seeking to the key itself would
+        // re-resolve the identity to a stale version.
+        let iters = src_layers
+            .iter()
+            .map(|l| (txn.raw_iterator_cf(&l.cf), l.window))
+            .collect();
+        let mut merge = StackMerge::new(iters, Some(Cow::Borrowed(&upper[..])));
+        match after {
+            Some(after) if after > lower.as_slice() => merge.seek(dst.range_end(after))?,
+            _ => merge.seek(&lower[..])?,
+        }
+
+        // One identity at a time, and only O(1) of it: the newest version, the newest
+        // assertive value, and one assertion that disagrees with it. Never the chain: a
+        // record asserted and retracted many times has a long one.
+        let mut cur: Option<Resolved> = None;
+        while let Some(row) = merge.next_borrowed() {
+            let (at_layer, key, val) = row?;
+            let Some(vld) = tail_validity(key) else {
+                bail!(
+                    "relation '{}' has no validity but holds rows in a view being flattened; \
+                     a relation without one cannot express a cross-layer retraction",
+                    rel.name
+                );
+            };
+            let asserts = vld.is_assert.0;
+            let identity = validity_identity(key);
+
+            match cur.as_mut() {
+                // An older version of the identity being resolved. It does not change what the
+                // view resolves to, but if it asserts a *different* value than the newest
+                // assertion then two layers of the source disagree, and stamp order is not
+                // entitled to pick between them.
+                Some(c) if c.identity == identity => {
+                    if asserts {
+                        match &c.asserted {
+                            None => c.asserted = Some((val.to_vec(), Some(at_layer))),
+                            Some((newest, _)) if newest != val => {
+                                if !c.others.iter().any(|(seen, _)| seen == val) {
+                                    c.others.push((val.to_vec(), Some(at_layer)));
+                                }
+                            }
+                            Some(_) => {}
+                        }
+                    }
+                }
+                _ => {
+                    if let Some(done) = cur.take() {
+                        if let ControlFlow::Break(at) =
+                            emit(txn, src_layers, dst, rel, done, &mut visit)?
+                        {
+                            return Ok(Some(at));
+                        }
+                    }
+                    cur = Some(Resolved {
+                        identity: identity.to_vec(),
+                        asserted: if asserts {
+                            Some((val.to_vec(), Some(at_layer)))
+                        } else {
+                            None
+                        },
+                        key: key.to_vec(),
+                        val: val.to_vec(),
+                        asserts,
+                        others: vec![],
+                    });
+                }
+            }
+        }
+        if let Some(done) = cur.take() {
+            if let ControlFlow::Break(at) = emit(txn, src_layers, dst, rel, done, &mut visit)? {
+                return Ok(Some(at));
+            }
+        }
+    }
+    Ok(None)
+}
+
+fn decode_values(val: &[u8]) -> Vec<DataValue> {
+    let mut ret = vec![];
+    extend_tuple_from_v(&mut ret, val);
+    ret
+}
+
+/// Everything a scan needs, bound for the life of one call.
+///
+/// Every field borrows from the open database rather than from a sibling, so this is an
+/// ordinary struct. It is returned rather than lent to a callback because
+/// `Transaction::commit` consumes the transaction.
+struct ScanContext<'a> {
+    txn: LayeredTxn<'a>,
+    src_layers: Vec<BoundLayer<'a>>,
+    dst: BoundStack<'a>,
+    relations: Catalog,
+}
+
+impl Db<LayeredStorage> {
+    fn scan_context<'a>(&'a self, src: &Stack, dst: &Stack) -> Result<ScanContext<'a>> {
+        let src_spec = self.db.resolve(src)?;
+        let dst_spec = self.db.resolve(dst)?;
+        let inner = &*self.db.inner;
+        let txn = inner.db.transaction();
+        let src_layers = bind_layers(inner, &src_spec)?;
+        let dst = BoundStack::new(bind_layers(inner, &dst_spec)?);
+        let catalog = inner
+            .db
+            .cf_handle(DEFAULT_LAYER)
+            .ok_or_else(|| miette!("the default layer is missing"))?;
+        let relations = catalog_relations(&txn, &catalog)?;
+        Ok(ScanContext {
+            txn,
+            src_layers,
+            dst,
+            relations,
+        })
+    }
+
+    /// What [`Db::flatten`] would do, without doing it.
+    ///
+    /// Every check a flatten makes runs here: the view's net effect, dedupe, and tombstone
+    /// liveness against the whole destination stack. A merge can be previewed, and its
+    /// conflicts reported in full, without the caller reimplementing any of it.
+    ///
+    /// Memory is proportional to the number of conflicts, not to the size of the view: rows are
+    /// counted as they stream past. Use [`Db::flatten_page`] to see the rows themselves.
+    ///
+    /// A clean plan is not a promise: see [`FlattenPlan`] on staleness.
+    pub fn flatten_plan(&self, src: &Stack, dst: &Stack) -> Result<FlattenPlan> {
+        let mut ctx = self.scan_context(src, dst)?;
+        let mut plan = FlattenPlan::default();
+        scan(
+            &ctx.txn,
+            &ctx.src_layers,
+            &mut ctx.dst,
+            &ctx.relations,
+            None,
+            |_rel, effect| {
+                match effect {
+                    RowEffect::Effective { key, val, .. } => {
+                        plan.stats.rows_copied += 1;
+                        plan.stats.bytes_copied += (key.len() + val.len()) as u64;
+                    }
+                    RowEffect::Redundant { .. } => plan.stats.rows_deduped += 1,
+                    RowEffect::Inert { .. } => plan.stats.tombstones_dropped += 1,
+                    RowEffect::Divergent(conflict) => plan.conflicts.push(conflict),
+                }
+                Ok(ControlFlow::Continue(()))
+            },
+        )?;
+        Ok(plan)
+    }
+
+    /// One page of what [`Db::flatten`] would do, decoded.
+    ///
+    /// Pass `after: None` for the first page and the previous page's `next` thereafter. Each
+    /// call is self-contained (it opens a transaction, reads its page and closes), so no
+    /// snapshot is held while a caller decides what to do with the rows.
+    ///
+    /// Consecutive pages are therefore *not* one snapshot: a write landing between them is
+    /// visible to the later page. Bounding the source stack's layers makes the view immutable
+    /// and the paging repeatable.
+    pub fn flatten_page(
+        &self,
+        src: &Stack,
+        dst: &Stack,
+        after: Option<&FlattenCursor>,
+        limit: usize,
+    ) -> Result<FlattenPage> {
+        let mut ctx = self.scan_context(src, dst)?;
+        let mut items = Vec::with_capacity(limit.min(1024));
+        let next = scan(
+            &ctx.txn,
+            &ctx.src_layers,
+            &mut ctx.dst,
+            &ctx.relations,
+            after.map(|c| c.0.as_slice()),
+            |rel, effect| {
+                if limit == 0 {
+                    return Ok(ControlFlow::Break(()));
+                }
+                let relation = rel.name.to_string();
+                items.push(match effect {
+                    RowEffect::Effective { key, val, asserts } => FlattenItem::Copy {
+                        relation,
+                        key: decode_tuple_from_key(key, rel.n_keys),
+                        value: decode_values(val),
+                        asserts,
+                    },
+                    RowEffect::Redundant { key } => FlattenItem::Dedupe {
+                        relation,
+                        key: decode_tuple_from_key(key, rel.n_keys),
+                    },
+                    RowEffect::Inert { key } => FlattenItem::TombstoneDropped {
+                        relation,
+                        key: decode_tuple_from_key(key, rel.n_keys),
+                    },
+                    RowEffect::Divergent(conflict) => FlattenItem::Conflict(conflict),
+                });
+                Ok(if items.len() >= limit {
+                    ControlFlow::Break(())
+                } else {
+                    ControlFlow::Continue(())
+                })
+            },
+        )?;
+        Ok(FlattenPage {
+            items,
+            next: next.map(FlattenCursor),
+        })
+    }
+
+    /// Materialize the net effect of `src` into `dst`'s top layer.
+    ///
+    /// `src` is any windowed sub-stack: an unwindowed single layer is a merge-down, a windowed
+    /// one a cherry-pick. `dst`'s lower layers are read for the liveness and identity checks
+    /// and never written.
+    ///
+    /// Rows are decided and written as they stream, so memory is proportional to the number of
+    /// conflicts rather than to the size of the view. A collision does not stop the scan: every
+    /// one is collected, and the transaction is then dropped without committing, which is what
+    /// leaves `dst` byte-identical. [`Db::flatten_plan`] reports the same conflicts without
+    /// attempting the write at all.
+    ///
+    /// `dst`'s top layer may not appear in `src`: the scan reads the source while the write
+    /// lands in that layer, and a layer that is both would be read as it is written.
+    ///
+    /// This specifies no atomicity against concurrent writers on either stack: the caller must
+    /// quiesce. The intended pattern, flattening sealed layers into a single-writer head, makes
+    /// that free. The commit lock is held for the whole call, not merely the writes, because
+    /// the stamp is allocated before the first row is decided.
+    pub fn flatten(&self, src: &Stack, dst: &Stack, restamp: bool) -> Result<FlattenStats> {
+        let mut ctx = self.scan_context(src, dst)?;
+        let top = ctx.dst.layers[0].cf.clone();
+        if let Some(clash) = ctx.src_layers.iter().find(|l| l.name == ctx.dst.layers[0].name) {
+            bail!(
+                "cannot flatten: layer '{}' is both the source of this flatten and the \
+                 destination's top layer",
+                clash.name
+            );
+        }
+
+        // The stamp is commit order, so it has to be read where commits are serialized,
+        // and the batch has to land before the next commit proceeds.
+        let _ordered = self
+            .db
+            .inner
+            .commit_lock
+            .lock()
+            .map_err(|_| miette!("commit lock poisoned"))?;
+        let seq = self.db.inner.next_stamp();
+
+        let mut stats = FlattenStats::default();
+        let mut conflicts = vec![];
+        let mut failed = None;
+        scan(
+            &ctx.txn,
+            &ctx.src_layers,
+            &mut ctx.dst,
+            &ctx.relations,
+            None,
+            |_rel, effect| {
+                match effect {
+                    RowEffect::Effective { key, val, .. } => {
+                        let mut key = key.to_vec();
+                        if restamp {
+                            // Without this, a later time-travel read of the destination
+                            // would report the rows as present at sequences they were not.
+                            restamp_tail_validity(&mut key, seq);
+                        }
+                        stats.rows_copied += 1;
+                        stats.bytes_copied += (key.len() + val.len()) as u64;
+                        // Writing as we go is safe because each identity is visited once:
+                        // no later liveness check can read a row this loop just wrote.
+                        if let Err(err) = ctx.txn.put_cf(&top, &key, val) {
+                            failed = Some(err);
+                            return Ok(ControlFlow::Break(()));
+                        }
+                    }
+                    RowEffect::Redundant { .. } => stats.rows_deduped += 1,
+                    RowEffect::Inert { .. } => stats.tombstones_dropped += 1,
+                    RowEffect::Divergent(conflict) => conflicts.push(conflict),
+                }
+                Ok(ControlFlow::Continue(()))
+            },
+        )?;
+        if let Some(err) = failed {
+            return Err(err).into_diagnostic().wrap_err("failed to write a flattened row");
+        }
+        if !conflicts.is_empty() {
+            // Dropping the transaction unwritten is what makes a failed flatten a no-op.
+            bail!("{}", describe_conflicts(&conflicts));
+        }
+        if restamp {
+            // A flatten is one transaction, so it is one point in commit order.
+            stats.seq_range = Some((seq, seq));
+        }
+        ctx.txn.commit()
+            .into_diagnostic()
+            .wrap_err("failed to commit the flatten")?;
+        Ok(stats)
+    }
+}
+
+/// Name every collision in an error, capped so that a merge of a large divergent branch does
+/// not produce an unreadable message. The full list is what [`Db::flatten_plan`] is for.
+fn describe_conflicts(conflicts: &[FlattenConflict]) -> String {
+    const SHOWN: usize = 5;
+    let mut msg = format!(
+        "flatten aborted: {} key(s) are claimed with more than one value",
+        conflicts.len()
+    );
+    for c in conflicts.iter().take(SHOWN) {
+        msg.push_str(&format!("\n  {} {:?}:", c.relation, c.key));
+        for claim in &c.claims {
+            msg.push_str(&format!(" {}={:?}", claim.layer, claim.value));
+        }
+    }
+    if conflicts.len() > SHOWN {
+        msg.push_str(&format!(
+            "\n  ... and {} more; `flatten_plan` reports every one",
+            conflicts.len() - SHOWN
+        ));
+    }
+    msg
+}
+
+/// Whether one layer holds any row of a relation, window included.
+fn holds_rows(txn: &LayeredTxn<'_>, layer: &BoundLayer<'_>, rel: &RelInfo) -> Result<bool> {
+    let lower = rel.id.raw_encode();
+    let upper = rel.id.next().raw_encode();
+    let mut it = txn.raw_iterator_cf(&layer.cf);
+    it.seek(&lower);
+    while let Some(k) = it.key() {
+        if k >= upper.as_slice() {
+            break;
+        }
+        if layer.window.admits(k) {
+            return Ok(true);
+        }
+        it.next();
+    }
+    it.status()
+        .into_diagnostic()
+        .wrap_err("failed to scan a layer")?;
+    Ok(false)
+}

--- a/cozo-core/src/storage/layered/flatten.rs
+++ b/cozo-core/src/storage/layered/flatten.rs
@@ -13,7 +13,7 @@ use std::ops::ControlFlow;
 use crate::data::memcmp::{restamp_tail_validity, tail_validity, validity_identity};
 use crate::data::tuple::decode_tuple_from_key;
 use crate::data::value::DataValue;
-use crate::runtime::relation::extend_tuple_from_v;
+use crate::runtime::relation::try_extend_tuple_from_v;
 use crate::storage::layered::iter::{LayeredTxn, StackMerge};
 use crate::storage::layered::catalog::{catalog_relations, Catalog, RelInfo};
 use crate::storage::layered::tx::{bind_layers, BoundLayer, BoundStack};
@@ -210,13 +210,13 @@ where
         let mut claims = Vec::with_capacity(done.others.len() + 2);
         if let Some((val, at)) = &done.asserted {
             claims.push(Claim {
-                value: decode_values(val),
+                value: decode_values(val)?,
                 layer: layer_name(src_layers, *at),
             });
         }
         for (val, at) in &done.others {
             claims.push(Claim {
-                value: decode_values(val),
+                value: decode_values(val)?,
                 layer: layer_name(src_layers, *at),
             });
         }
@@ -229,7 +229,7 @@ where
                 .any(|v| v == val);
             if !already {
                 claims.push(Claim {
-                    value: decode_values(val),
+                    value: decode_values(val)?,
                     layer: layer_name(&dst.layers, state.asserted_layer),
                 });
             }
@@ -406,10 +406,12 @@ where
     Ok(None)
 }
 
-fn decode_values(val: &[u8]) -> Vec<DataValue> {
+/// A stored value blob, decoded. Fallible for the same reason the read path is: a row that
+/// will not decode must not take the whole scan down with it.
+fn decode_values(val: &[u8]) -> Result<Vec<DataValue>> {
     let mut ret = vec![];
-    extend_tuple_from_v(&mut ret, val);
-    ret
+    try_extend_tuple_from_v(&mut ret, val)?;
+    Ok(ret)
 }
 
 /// Everything a scan needs, bound for the life of one call.
@@ -431,7 +433,7 @@ impl Db<LayeredStorage> {
         let inner = &*self.db.inner;
         let txn = inner.db.transaction();
         let src_layers = bind_layers(inner, &src_spec)?;
-        let dst = BoundStack::new(bind_layers(inner, &dst_spec)?);
+        let dst = BoundStack::new(bind_layers(inner, &dst_spec)?, dst_spec.view.clone());
         let catalog = inner
             .db
             .cf_handle(DEFAULT_LAYER)
@@ -513,7 +515,7 @@ impl Db<LayeredStorage> {
                     RowEffect::Effective { key, val, asserts } => FlattenItem::Copy {
                         relation,
                         key: decode_tuple_from_key(key, rel.n_keys),
-                        value: decode_values(val),
+                        value: decode_values(val)?,
                         asserts,
                     },
                     RowEffect::Redundant { key } => FlattenItem::Dedupe {

--- a/cozo-core/src/storage/layered/iter.rs
+++ b/cozo-core/src/storage/layered/iter.rs
@@ -8,10 +8,10 @@ use rocksdb::{DBRawIteratorWithThreadMode, MultiThreaded, OptimisticTransactionD
 use std::borrow::Cow;
 
 use crate::data::memcmp::tail_validity;
-use crate::data::tuple::{check_key_for_validity, key_ends_in_validity, Tuple};
-use crate::data::value::ValidityTs;
-use crate::runtime::relation::{try_decode_tuple_from_kv, try_extend_tuple_from_v};
+use crate::data::tuple::{key_ends_in_validity, Tuple};
+use crate::runtime::relation::try_decode_tuple_from_kv;
 use crate::storage::layered::Seq;
+use crate::storage::StoreCursor;
 
 pub(crate) type LayeredDb = OptimisticTransactionDB<MultiThreaded>;
 pub(crate) type LayeredTxn<'a> = Transaction<'a, LayeredDb>;
@@ -160,7 +160,7 @@ impl<'a> LayerIter<'a> {
 /// validity, which sorts descending, so every version of a relation key arrives newest-first
 /// across the whole stack, irrespective of which layer holds it.
 ///
-/// Shadowing between layers is therefore not positional. [`StackSkipIter`] applies the
+/// Shadowing between layers is therefore not positional. [`StackCursor`] feeds the
 /// ordinary single-store validity rule to that newest-first stream, so the winner is the
 /// newest version, whichever layer holds it. Stack position decides only which copy of a
 /// byte-identical key is emitted.
@@ -211,7 +211,7 @@ impl<'a> StackMerge<'a> {
                 // Strictly less, so a tie leaves the slot with the earlier (higher) layer.
                 // A tie is byte-identical keys (same relation key *and* same stamp), so this
                 // chooses which copy of one row to emit. It does not decide which version of a
-                // key wins; the stamp does, in `StackSkipIter`.
+                // key wins; the stamp does, in the validity scan above.
                 Some(b) => {
                     if key < self.layers[b].key().unwrap() {
                         best = Some(idx)
@@ -342,40 +342,42 @@ impl<'a> Iterator for StackTupleIter<'a> {
 /// The merge below it already presents each key's versions newest-first across all layers, so
 /// cross-layer shadowing and cross-layer retraction both fall out of running the
 /// single-store validity rule over the merged stream.
-pub(crate) struct StackSkipIter<'a> {
+/// A positioned scan over a layer stack.
+///
+/// The merge is already a lending cursor, so a row the scan declines is never copied: only the
+/// index of the layer holding it is kept, and the key and value stay where the iterators put
+/// them.
+pub(crate) struct StackCursor<'a> {
     pub(crate) merge: StackMerge<'a>,
-    pub(crate) valid_at: ValidityTs,
-    pub(crate) next_bound: Vec<u8>,
+    front: Option<usize>,
 }
 
-impl<'a> Iterator for StackSkipIter<'a> {
-    type Item = Result<Tuple>;
+impl<'a> StackCursor<'a> {
+    pub(crate) fn new(merge: StackMerge<'a>) -> Self {
+        StackCursor { merge, front: None }
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            if let Err(err) = self.merge.seek(&self.next_bound) {
-                return Some(Err(err));
-            }
-            match self.merge.next_borrowed() {
-                None => return None,
-                Some(Err(err)) => return Some(Err(err)),
-                Some(Ok((_, k, v))) => {
-                    // Everything needing the borrows happens first; a skipped row, which is
-                    // the common case here, is never copied.
-                    let (ret, nxt_bound) = check_key_for_validity(k, self.valid_at, None);
-                    let tup = match ret {
-                        Some(mut tup) => match try_extend_tuple_from_v(&mut tup, v) {
-                            Ok(()) => Some(tup),
-                            Err(err) => return Some(Err(err)),
-                        },
-                        None => None,
-                    };
-                    self.next_bound = nxt_bound;
-                    if let Some(tup) = tup {
-                        return Some(Ok(tup));
-                    }
-                }
-            }
-        }
+    fn front(&self) -> &LayerIter<'a> {
+        &self.merge.layers[self.front.expect("cursor read after a successful seek")]
+    }
+}
+
+impl StoreCursor for StackCursor<'_> {
+    fn seek(&mut self, from: &[u8]) -> Result<bool> {
+        self.merge.seek(from)?;
+        self.front = match self.merge.next_borrowed() {
+            None => None,
+            Some(Err(err)) => return Err(err),
+            Some(Ok((front, _, _))) => Some(front),
+        };
+        Ok(self.front.is_some())
+    }
+
+    fn key(&self) -> &[u8] {
+        self.front().key().expect("a positioned layer has a key")
+    }
+
+    fn value(&mut self) -> Result<&[u8]> {
+        Ok(self.front().value().unwrap_or_default())
     }
 }

--- a/cozo-core/src/storage/layered/iter.rs
+++ b/cozo-core/src/storage/layered/iter.rs
@@ -10,7 +10,7 @@ use std::borrow::Cow;
 use crate::data::memcmp::tail_validity;
 use crate::data::tuple::{check_key_for_validity, key_ends_in_validity, Tuple};
 use crate::data::value::ValidityTs;
-use crate::runtime::relation::{decode_tuple_from_kv, extend_tuple_from_v};
+use crate::runtime::relation::{try_decode_tuple_from_kv, try_extend_tuple_from_v};
 use crate::storage::layered::Seq;
 
 pub(crate) type LayeredDb = OptimisticTransactionDB<MultiThreaded>;
@@ -325,9 +325,11 @@ impl<'a> Iterator for StackTupleIter<'a> {
     type Item = Result<Tuple>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Decoding reads through the borrows, so the row is never copied.
+        // Decoding reads through the borrows, so the row is never copied. A value blob that
+        // will not decode is an error, never a panic: a corrupt row must leave the rest of the
+        // history readable.
         match self.inner.next_borrowed() {
-            Some(Ok((k, v))) => Some(Ok(decode_tuple_from_kv(k, v, None))),
+            Some(Ok((k, v))) => Some(try_decode_tuple_from_kv(k, v, None)),
             Some(Err(err)) => Some(Err(err)),
             None => None,
         }
@@ -361,10 +363,13 @@ impl<'a> Iterator for StackSkipIter<'a> {
                     // Everything needing the borrows happens first; a skipped row, which is
                     // the common case here, is never copied.
                     let (ret, nxt_bound) = check_key_for_validity(k, self.valid_at, None);
-                    let tup = ret.map(|mut tup| {
-                        extend_tuple_from_v(&mut tup, v);
-                        tup
-                    });
+                    let tup = match ret {
+                        Some(mut tup) => match try_extend_tuple_from_v(&mut tup, v) {
+                            Ok(()) => Some(tup),
+                            Err(err) => return Some(Err(err)),
+                        },
+                        None => None,
+                    };
                     self.next_bound = nxt_bound;
                     if let Some(tup) = tup {
                         return Some(Ok(tup));

--- a/cozo-core/src/storage/layered/iter.rs
+++ b/cozo-core/src/storage/layered/iter.rs
@@ -1,0 +1,376 @@
+/*
+ * Layered storage: windowed iterators and the k-way stack merge.
+ */
+
+use miette::{miette, Result};
+use rocksdb::{DBRawIteratorWithThreadMode, MultiThreaded, OptimisticTransactionDB, Transaction};
+
+use std::borrow::Cow;
+
+use crate::data::memcmp::tail_validity;
+use crate::data::tuple::{check_key_for_validity, key_ends_in_validity, Tuple};
+use crate::data::value::ValidityTs;
+use crate::runtime::relation::{decode_tuple_from_kv, extend_tuple_from_v};
+use crate::storage::layered::Seq;
+
+pub(crate) type LayeredDb = OptimisticTransactionDB<MultiThreaded>;
+pub(crate) type LayeredTxn<'a> = Transaction<'a, LayeredDb>;
+type RawIter<'a> = DBRawIteratorWithThreadMode<'a, LayeredTxn<'a>>;
+
+/// The visibility window of one layer within one stack.
+///
+/// `since` is an exclusive floor and `bound` an inclusive ceiling, so the window `(fork, head]`
+/// is exactly "everything since the fork" with the fork-point row belonging to the parent.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct Window {
+    /// Rows stamped at or below this sequence are invisible. `None` is an unbounded floor.
+    pub since: Option<Seq>,
+    /// Rows stamped above this sequence are invisible. `None` is an unbounded ceiling.
+    pub bound: Option<Seq>,
+}
+
+impl Window {
+    pub(crate) const OPEN: Window = Window {
+        since: None,
+        bound: None,
+    };
+
+    /// Whether a row's key falls inside this window.
+    ///
+    /// A row with no validity carries no sequence, so no window excludes it: a window selects
+    /// by *when*, and such a row has no when. The relations this applies to are index
+    /// relations (everything else without a validity is refused by a multi-layer stack
+    /// altogether), and it is what makes an index compose through a stack at all:
+    /// a bounded base layer must keep contributing its edges, or traversal from a branch sees
+    /// only the branch's own nodes and silently loses the rest.
+    pub(crate) fn admits(&self, key: &[u8]) -> bool {
+        if self.since.is_none() && self.bound.is_none() {
+            // An open window excludes nothing, so the row's sequence never has to be read.
+            // Every layer of a single-layer stack is open, so this is the common path.
+            return true;
+        }
+        let vld = tail_validity(key);
+        debug_assert_eq!(
+            vld.is_some(),
+            key_ends_in_validity(key),
+            "the cheap validity probe disagreed with a full decode"
+        );
+        match vld {
+            None => true,
+            Some(vld) => {
+                let seq = vld.timestamp.0 .0;
+                if let Some(since) = self.since {
+                    if seq <= since {
+                        return false;
+                    }
+                }
+                if let Some(bound) = self.bound {
+                    if seq > bound {
+                        return false;
+                    }
+                }
+                true
+            }
+        }
+    }
+}
+
+/// One layer's contribution to a scan: a raw RocksDB iterator that only ever rests on a row
+/// inside the layer's window and below the scan's upper bound.
+struct LayerIter<'a> {
+    inner: RawIter<'a>,
+    window: Window,
+    exhausted: bool,
+}
+
+impl<'a> LayerIter<'a> {
+    fn new(inner: RawIter<'a>, window: Window) -> Self {
+        Self {
+            inner,
+            window,
+            exhausted: false,
+        }
+    }
+
+    fn seek(&mut self, from: &[u8], upper: Option<&[u8]>) -> Result<()> {
+        self.exhausted = false;
+        self.inner.seek(from);
+        self.settle(upper)
+    }
+
+    /// Advance past rows that this stack cannot see: those beyond the scan's upper bound, and
+    /// those outside the layer's window.
+    fn settle(&mut self, upper: Option<&[u8]>) -> Result<()> {
+        loop {
+            if self.exhausted {
+                return Ok(());
+            }
+            match self.inner.key() {
+                None => {
+                    self.exhausted = true;
+                    return self
+                        .inner
+                        .status()
+                        .map_err(|err| miette!("layer iteration failed: {}", err));
+                }
+                Some(key) => {
+                    if let Some(upper) = upper {
+                        if key >= upper {
+                            self.exhausted = true;
+                            return Ok(());
+                        }
+                    }
+                    if self.window.admits(key) {
+                        return Ok(());
+                    }
+                    self.inner.next();
+                }
+            }
+        }
+    }
+
+    fn key(&self) -> Option<&[u8]> {
+        if self.exhausted {
+            None
+        } else {
+            self.inner.key()
+        }
+    }
+
+    fn value(&self) -> Option<&[u8]> {
+        if self.exhausted {
+            None
+        } else {
+            self.inner.value()
+        }
+    }
+
+    fn advance(&mut self, upper: Option<&[u8]>) -> Result<()> {
+        if self.exhausted {
+            return Ok(());
+        }
+        self.inner.next();
+        self.settle(upper)
+    }
+}
+
+/// The k-way merge across a stack.
+///
+/// Entries are emitted in *full-key* order. For a stackable relation the key embeds the
+/// validity, which sorts descending, so every version of a relation key arrives newest-first
+/// across the whole stack, irrespective of which layer holds it.
+///
+/// Shadowing between layers is therefore not positional. [`StackSkipIter`] applies the
+/// ordinary single-store validity rule to that newest-first stream, so the winner is the
+/// newest version, whichever layer holds it. Stack position decides only which copy of a
+/// byte-identical key is emitted.
+///
+/// Layers are compared linearly rather than through a heap: a stack is a short-lived divergence
+/// merged down promptly, so depth stays in the single digits and a scan of the array
+/// beats maintaining a heap.
+pub(crate) struct StackMerge<'a> {
+    layers: Vec<LayerIter<'a>>,
+    upper: Option<Cow<'a, [u8]>>,
+    /// The key the merge is currently sitting on, so that every layer holding it can be
+    /// advanced once the row has been handed out. Reused between rows.
+    front_key: Vec<u8>,
+    /// Whether a row has been handed out and not yet advanced past.
+    positioned: bool,
+}
+
+impl<'a> StackMerge<'a> {
+    pub(crate) fn new(iters: Vec<(RawIter<'a>, Window)>, upper: Option<Cow<'a, [u8]>>) -> Self {
+        Self {
+            layers: iters
+                .into_iter()
+                .map(|(it, win)| LayerIter::new(it, win))
+                .collect(),
+            upper,
+            front_key: vec![],
+            positioned: false,
+        }
+    }
+
+    pub(crate) fn seek(&mut self, from: &[u8]) -> Result<()> {
+        // Seeking repositions every layer, so there is nothing left to advance past.
+        self.positioned = false;
+        let upper = self.upper.as_deref();
+        for layer in self.layers.iter_mut() {
+            layer.seek(from, upper)?;
+        }
+        Ok(())
+    }
+
+    /// The index of the layer holding the smallest key, preferring the topmost on a tie.
+    fn front(&self) -> Option<usize> {
+        let mut best: Option<usize> = None;
+        for (idx, layer) in self.layers.iter().enumerate() {
+            let Some(key) = layer.key() else { continue };
+            match best {
+                None => best = Some(idx),
+                // Strictly less, so a tie leaves the slot with the earlier (higher) layer.
+                // A tie is byte-identical keys (same relation key *and* same stamp), so this
+                // chooses which copy of one row to emit. It does not decide which version of a
+                // key wins; the stamp does, in `StackSkipIter`.
+                Some(b) => {
+                    if key < self.layers[b].key().unwrap() {
+                        best = Some(idx)
+                    }
+                }
+            }
+        }
+        best
+    }
+
+    /// The next row, borrowed from the layer holding it, with that layer's index.
+    ///
+    /// The index is returned alongside rather than through an accessor because the row borrows
+    /// the merge, so nothing else can be asked of it while the row is in hand.
+    ///
+    /// The borrow lasts until the next call, which is what the `&mut self` receiver enforces:
+    /// advancing invalidates the underlying iterator's buffer, so nothing may outlive it. A
+    /// caller that needs to keep a row copies it, and one that only inspects it does not.
+    ///
+    /// Advancing happens at the start of the following call rather than before returning,
+    /// which is what lets this stay a single call per row.
+    pub(crate) fn next_borrowed(&mut self) -> Option<Result<(usize, &[u8], &[u8])>> {
+        if self.positioned {
+            if let Err(err) = self.advance_front() {
+                return Some(Err(err));
+            }
+        }
+        let front = self.front()?;
+        // Record the key before handing out borrows: the advance needs it to recognise every
+        // layer sitting on this row, and by then the row itself is gone.
+        self.front_key.clear();
+        self.front_key
+            .extend_from_slice(self.layers[front].key().unwrap());
+        self.positioned = true;
+        let layer = &self.layers[front];
+        Some(Ok((
+            front,
+            layer.key().unwrap(),
+            layer.value().unwrap_or_default(),
+        )))
+    }
+
+    /// Advance every layer sitting on the row just handed out, not only the one it came from:
+    /// that is what collapses a row present identically in several layers into one emission.
+    fn advance_front(&mut self) -> Result<()> {
+        self.positioned = false;
+        let Self {
+            layers,
+            upper,
+            front_key,
+            ..
+        } = self;
+        let upper = upper.as_deref();
+        for layer in layers.iter_mut() {
+            if layer.key() == Some(front_key.as_slice()) {
+                layer.advance(upper)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Raw `(key, value)` scan across a stack.
+pub(crate) struct StackRawIter<'a> {
+    pub(crate) merge: StackMerge<'a>,
+    pub(crate) started: bool,
+    pub(crate) lower: Vec<u8>,
+}
+
+impl<'a> StackRawIter<'a> {
+    /// The next row, borrowed. Performs the initial seek on first use.
+    pub(crate) fn next_borrowed(&mut self) -> Option<Result<(&[u8], &[u8])>> {
+        if !self.started {
+            self.started = true;
+            if let Err(err) = self.merge.seek(&self.lower) {
+                return Some(Err(err));
+            }
+        }
+        match self.merge.next_borrowed()? {
+            Ok((_, key, val)) => Some(Ok((key, val))),
+            Err(err) => Some(Err(err)),
+        }
+    }
+}
+
+impl<'a> Iterator for StackRawIter<'a> {
+    type Item = Result<(Vec<u8>, Vec<u8>)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if !self.started {
+            self.started = true;
+            if let Err(err) = self.merge.seek(&self.lower) {
+                return Some(Err(err));
+            }
+        }
+        match self.next_borrowed()? {
+            // The one place a copy is unavoidable: `Iterator::Item` cannot borrow from the
+            // iterator, and `StoreTx::range_scan` is declared to yield owned pairs.
+            Ok((key, val)) => Some(Ok((key.to_vec(), val.to_vec()))),
+            Err(err) => Some(Err(err)),
+        }
+    }
+}
+
+/// Decoded-tuple scan across a stack.
+pub(crate) struct StackTupleIter<'a> {
+    pub(crate) inner: StackRawIter<'a>,
+}
+
+impl<'a> Iterator for StackTupleIter<'a> {
+    type Item = Result<Tuple>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Decoding reads through the borrows, so the row is never copied.
+        match self.inner.next_borrowed() {
+            Some(Ok((k, v))) => Some(Ok(decode_tuple_from_kv(k, v, None))),
+            Some(Err(err)) => Some(Err(err)),
+            None => None,
+        }
+    }
+}
+
+/// Frontier scan across a stack: for each key, the newest version at or before `valid_at`,
+/// skipped entirely when that version is a retraction.
+///
+/// The merge below it already presents each key's versions newest-first across all layers, so
+/// cross-layer shadowing and cross-layer retraction both fall out of running the
+/// single-store validity rule over the merged stream.
+pub(crate) struct StackSkipIter<'a> {
+    pub(crate) merge: StackMerge<'a>,
+    pub(crate) valid_at: ValidityTs,
+    pub(crate) next_bound: Vec<u8>,
+}
+
+impl<'a> Iterator for StackSkipIter<'a> {
+    type Item = Result<Tuple>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Err(err) = self.merge.seek(&self.next_bound) {
+                return Some(Err(err));
+            }
+            match self.merge.next_borrowed() {
+                None => return None,
+                Some(Err(err)) => return Some(Err(err)),
+                Some(Ok((_, k, v))) => {
+                    // Everything needing the borrows happens first; a skipped row, which is
+                    // the common case here, is never copied.
+                    let (ret, nxt_bound) = check_key_for_validity(k, self.valid_at, None);
+                    let tup = ret.map(|mut tup| {
+                        extend_tuple_from_v(&mut tup, v);
+                        tup
+                    });
+                    self.next_bound = nxt_bound;
+                    if let Some(tup) = tup {
+                        return Some(Ok(tup));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/cozo-core/src/storage/layered/mod.rs
+++ b/cozo-core/src/storage/layered/mod.rs
@@ -1,0 +1,465 @@
+/*
+ * Layered storage for the RocksDB backend.
+ *
+ * A layer is one column family; a stack is an ordered list of layers with visibility windows.
+ * Reads compose the stack, writes land in its top layer.
+ */
+
+use std::cmp::Reverse;
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+use std::fmt::{Display, Formatter};
+use std::fs;
+use std::path::Path;
+use std::sync::{Mutex, RwLock};
+
+use miette::{bail, miette, IntoDiagnostic, Result, WrapErr};
+use rocksdb::{MultiThreaded, OptimisticTransactionDB, Options, WriteBatchWithTransaction, DB};
+
+use crate::data::value::{DataValue, ValidityTs};
+use crate::parse::parse_script;
+use crate::runtime::db::{BadDbInit, DbManifest, ScriptMutability};
+use crate::storage::layered::iter::{LayeredDb, Window};
+use crate::storage::layered::tx::{bind_layers, is_catalog_key, LayeredTx};
+use crate::storage::Storage;
+use crate::{Db, NamedRows};
+
+pub(crate) mod catalog;
+pub(crate) mod flatten;
+pub(crate) mod iter;
+pub(crate) mod tx;
+
+#[cfg(test)]
+mod tests;
+
+/// A storage sequence number. This is RocksDB's own commit-order counter, reinterpreted as
+/// Cozo's validity timestamp. It is not a wall clock, and it is sparse.
+pub type Seq = i64;
+
+/// The stamp a row carries between `put` and `commit`, before commit order is known.
+///
+/// It sorts newer than any real sequence, so a transaction reads its own buffered writes.
+pub const PENDING_SEQ: Seq = i64::MAX - 1;
+
+/// The layer every store starts with. It is a normal layer in every respect except that it
+/// cannot be dropped: the catalog and the existing entry points live on it.
+pub const DEFAULT_LAYER: &str = "default";
+
+/// The name of a layer. Opaque to Cozo: whether it is a branch, a tenant, a draft or a sandbox
+/// is the consumer's business.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct LayerId(pub String);
+
+impl From<&str> for LayerId {
+    fn from(s: &str) -> Self {
+        LayerId(s.to_string())
+    }
+}
+
+impl From<String> for LayerId {
+    fn from(s: String) -> Self {
+        LayerId(s)
+    }
+}
+
+impl Display for LayerId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A layer as it appears in one stack: which layer, and through what window.
+///
+/// Windows are per-stack, not per-layer: the same layer may appear in two stacks at different
+/// windows simultaneously.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LayerRef {
+    /// Which layer.
+    pub id: LayerId,
+    /// Rows stamped at or below this sequence are invisible. `None` for a normal read stack;
+    /// a floor is for changeset views, which answer "what changed", not "what is".
+    pub since: Option<Seq>,
+    /// Rows stamped above this sequence are invisible. `None` leaves the layer unbounded.
+    pub bound: Option<Seq>,
+}
+
+impl LayerRef {
+    /// The whole layer, unwindowed.
+    pub fn new(id: impl Into<LayerId>) -> Self {
+        Self {
+            id: id.into(),
+            since: None,
+            bound: None,
+        }
+    }
+
+    /// The layer as of `bound`, a fork point.
+    pub fn bounded(id: impl Into<LayerId>, bound: Seq) -> Self {
+        Self {
+            id: id.into(),
+            since: None,
+            bound: Some(bound),
+        }
+    }
+
+    /// The layer's changeset over `(since, bound]`.
+    pub fn windowed(id: impl Into<LayerId>, since: Option<Seq>, bound: Option<Seq>) -> Self {
+        Self {
+            id: id.into(),
+            since,
+            bound,
+        }
+    }
+}
+
+/// An ordered list of layers. Index 0 is the top, and the only one written to.
+pub type Stack = Vec<LayerRef>;
+
+/// A stack that has been checked against the open store: layers exist, windows are coherent.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct StackSpec {
+    pub(crate) layers: Vec<LayerSpec>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LayerSpec {
+    pub(crate) name: String,
+    pub(crate) window: Window,
+}
+
+impl StackSpec {
+    fn single(name: &str) -> Self {
+        Self {
+            layers: vec![LayerSpec {
+                name: name.to_string(),
+                window: Window::OPEN,
+            }],
+        }
+    }
+}
+
+const CURRENT_STORAGE_VERSION: u64 = 3;
+
+/// State shared by every handle onto one layered store.
+pub struct LayeredInner {
+    pub(crate) db: LayeredDb,
+    /// Serializes commits so that the sequence read at commit really is commit order.
+    pub(crate) commit_lock: Mutex<()>,
+    pub(crate) layers: RwLock<BTreeSet<String>>,
+}
+
+/// The layered RocksDB storage engine.
+///
+/// A handle carries the stack it reads and writes through. Handles are cheap and independent:
+/// [`Db::run_on_stack`] makes one per call rather than keeping an ambient "current layer",
+/// because ambient state plus concurrent writers is a race.
+#[derive(Clone)]
+pub struct LayeredStorage {
+    inner: std::sync::Arc<LayeredInner>,
+    stack: std::sync::Arc<StackSpec>,
+}
+
+/// Open a layered RocksDB store.
+pub fn new_cozo_layered(path: impl AsRef<Path>) -> Result<Db<LayeredStorage>> {
+    fs::create_dir_all(&path).map_err(|err| {
+        BadDbInit(format!(
+            "cannot create directory {}: {}",
+            path.as_ref().display(),
+            err
+        ))
+    })?;
+    let path_buf = path.as_ref().to_path_buf();
+
+    let manifest_path = path_buf.join("manifest");
+    if manifest_path.exists() {
+        let manifest_bytes = fs::read(&manifest_path)
+            .into_diagnostic()
+            .wrap_err("failed to read manifest")?;
+        let existing: DbManifest = rmp_serde::from_slice(&manifest_bytes)
+            .into_diagnostic()
+            .wrap_err("failed to parse manifest")?;
+        if existing.storage_version != CURRENT_STORAGE_VERSION {
+            bail!(
+                "Unsupported storage version {}",
+                existing.storage_version
+            );
+        }
+    } else {
+        let manifest = DbManifest {
+            storage_version: CURRENT_STORAGE_VERSION,
+        };
+        let manifest_bytes = rmp_serde::to_vec_named(&manifest)
+            .into_diagnostic()
+            .wrap_err("failed to serialize manifest")?;
+        fs::write(&manifest_path, &manifest_bytes)
+            .into_diagnostic()
+            .wrap_err("failed to write manifest")?;
+    }
+
+    let store_path = path_buf.join("data");
+    let store_path_str = store_path.to_str().ok_or_else(|| miette!("bad path name"))?;
+
+    // Every column family must be opened for its layer to be usable; enumerate what is on disk.
+    let existing_cfs = DB::list_cf(&Options::default(), store_path_str)
+        .unwrap_or_else(|_| vec![DEFAULT_LAYER.to_string()]);
+
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+
+    let db = OptimisticTransactionDB::<MultiThreaded>::open_cf(
+        &options,
+        store_path_str,
+        existing_cfs.iter(),
+    )
+    .into_diagnostic()
+    .wrap_err("failed to open RocksDB")?;
+
+    let storage = LayeredStorage {
+        inner: std::sync::Arc::new(LayeredInner {
+            db,
+            commit_lock: Mutex::new(()),
+            layers: RwLock::new(existing_cfs.into_iter().collect()),
+        }),
+        stack: std::sync::Arc::new(StackSpec::single(DEFAULT_LAYER)),
+    };
+
+    let ret = Db::new(storage)?;
+    ret.initialize()?;
+    Ok(ret)
+}
+
+impl LayeredStorage {
+    /// The same store, read and written through a different stack.
+    pub(crate) fn with_stack(&self, stack: StackSpec) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            stack: std::sync::Arc::new(stack),
+        }
+    }
+
+    /// Check a stack against the open store. Errors here are cheap and deterministic, which is
+    /// why the checks live at stack construction rather than mid-query.
+    pub(crate) fn resolve(&self, stack: &Stack) -> Result<StackSpec> {
+        if stack.is_empty() {
+            bail!("a stack must name at least one layer");
+        }
+        let known = self.inner.layers.read().unwrap();
+        let mut seen = BTreeSet::new();
+        let mut layers = Vec::with_capacity(stack.len());
+        for layer in stack {
+            let name = layer.id.0.clone();
+            if !known.contains(&name) {
+                bail!("no such layer: '{}'", name);
+            }
+            if !seen.insert(name.clone()) {
+                bail!("layer '{}' appears twice in the same stack", name);
+            }
+            if let (Some(since), Some(bound)) = (layer.since, layer.bound) {
+                if since > bound {
+                    bail!(
+                        "layer '{}' has an inverted window ({}, {}]",
+                        name,
+                        since,
+                        bound
+                    );
+                }
+            }
+            layers.push(LayerSpec {
+                name,
+                window: Window {
+                    since: layer.since,
+                    bound: layer.bound,
+                },
+            });
+        }
+        Ok(StackSpec { layers })
+    }
+}
+
+impl<'s> Storage<'s> for LayeredStorage {
+    type Tx = LayeredTx<'s>;
+
+    fn storage_kind(&self) -> &'static str {
+        "layered"
+    }
+
+    fn now_validity(&self) -> ValidityTs {
+        // The sequence is assigned by storage at commit, so `'NOW'` is the pending stamp
+        // rather than a clock reading, including for the ordinary entry points, which run
+        // against a single-layer stack on the default layer.
+        vld_at(PENDING_SEQ)
+    }
+
+    fn transact(&'s self, _write: bool) -> Result<Self::Tx> {
+        let inner: &'s LayeredInner = &self.inner;
+        let layers = bind_layers(inner, &self.stack)?;
+        let catalog = inner
+            .db
+            .cf_handle(DEFAULT_LAYER)
+            .ok_or_else(|| miette!("the default layer is missing"))?;
+        Ok(LayeredTx {
+            inner,
+            tx: Some(inner.db.transaction()),
+            stack: crate::storage::layered::tx::BoundStack::new(layers),
+            catalog,
+            pending: vec![],
+            relations: Default::default(),
+        })
+    }
+
+    fn range_compact(&'s self, lower: &[u8], upper: &[u8]) -> Result<()> {
+        for layer in self.stack.layers.iter() {
+            if let Some(cf) = self.inner.db.cf_handle(&layer.name) {
+                self.inner
+                    .db
+                    .compact_range_cf(&cf, Some(lower), Some(upper));
+            }
+        }
+        Ok(())
+    }
+
+    fn batch_put<'a>(
+        &'a self,
+        data: Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>)>> + 'a>,
+    ) -> Result<()> {
+        let top = self
+            .inner
+            .db
+            .cf_handle(&self.stack.layers[0].name)
+            .ok_or_else(|| miette!("the top layer is missing"))?;
+        let catalog = self
+            .inner
+            .db
+            .cf_handle(DEFAULT_LAYER)
+            .ok_or_else(|| miette!("the default layer is missing"))?;
+        let mut batch = WriteBatchWithTransaction::<true>::default();
+        let mut highest_stamp: Option<Seq> = None;
+        for result in data {
+            let (key, val) = result?;
+            // Rows arrive pre-encoded here (this is the restore path) and keep the stamps
+            // they were written with. That is right for reconstructing a store, and wrong the
+            // moment the stamps outrun the instance's own counter, which is checked below.
+            if let Some(vld) = crate::data::memcmp::tail_validity(&key) {
+                let seq = vld.timestamp.0 .0;
+                if seq != PENDING_SEQ {
+                    highest_stamp = Some(highest_stamp.map_or(seq, |h: Seq| h.max(seq)));
+                }
+            }
+            if is_catalog_key(&key) {
+                batch.put_cf(&catalog, &key, &val);
+            } else {
+                batch.put_cf(&top, &key, &val);
+            }
+        }
+        self.inner
+            .db
+            .write(batch)
+            .into_diagnostic()
+            .wrap_err("batch put failed")?;
+
+        // Restoring rows stamped above the instance's own sequence would invert history: the
+        // next commit would be stamped *below* rows that are already here, and a fork point
+        // taken afterwards would not hold. Say so rather than let it happen quietly.
+        if let Some(highest) = highest_stamp {
+            let current = self.inner.db.latest_sequence_number() as Seq;
+            if highest >= current {
+                bail!(
+                    "restored rows carry sequences up to {highest}, at or above this store's \
+                     own sequence ({current}); writing to it would stamp new rows below \
+                     restored ones. Rebuild the store by importing relations instead, which \
+                     restamps."
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The validity a read at `seq` should use.
+pub(crate) fn vld_at(seq: Seq) -> ValidityTs {
+    ValidityTs(Reverse(seq))
+}
+
+impl Db<LayeredStorage> {
+    /// Create a layer. This copies nothing: it is a metadata operation.
+    pub fn create_layer(&self, id: impl Into<LayerId>) -> Result<()> {
+        let id = id.into();
+        let mut known = self.db.inner.layers.write().unwrap();
+        if known.contains(&id.0) {
+            bail!("layer '{}' already exists", id);
+        }
+        self.db
+            .inner
+            .db
+            .create_cf(&id.0, &Options::default())
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to create layer '{}'", id))?;
+        known.insert(id.0);
+        Ok(())
+    }
+
+    /// Drop a layer and reclaim its storage. Stacks naming it will fail to build afterwards.
+    pub fn drop_layer(&self, id: impl Into<LayerId>) -> Result<()> {
+        let id = id.into();
+        if id.0 == DEFAULT_LAYER {
+            bail!("the default layer cannot be dropped: it carries the catalog");
+        }
+        let mut known = self.db.inner.layers.write().unwrap();
+        if !known.contains(&id.0) {
+            bail!("no such layer: '{}'", id);
+        }
+        self.db
+            .inner
+            .db
+            .drop_cf(&id.0)
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to drop layer '{}'", id))?;
+        known.remove(&id.0);
+        Ok(())
+    }
+
+    /// Every layer in the store, in name order.
+    pub fn list_layers(&self) -> Result<Vec<LayerId>> {
+        Ok(self
+            .db
+            .inner
+            .layers
+            .read()
+            .unwrap()
+            .iter()
+            .map(|n| LayerId(n.clone()))
+            .collect())
+    }
+
+    /// The last committed sequence. A fork point taken from here is stable: everything
+    /// committed afterwards is stamped strictly above it.
+    pub fn current_seq(&self) -> Result<Seq> {
+        Ok(self.db.inner.db.latest_sequence_number() as Seq)
+    }
+
+    /// Run a script against a stack.
+    ///
+    /// `at` is a historical read bound composed with each layer's own bound; it is
+    /// meaningless for a write, since a write's sequence is assigned at commit.
+    pub fn run_on_stack(
+        &self,
+        script: &str,
+        params: BTreeMap<String, DataValue>,
+        stack: &Stack,
+        at: Option<Seq>,
+        mutability: ScriptMutability,
+    ) -> Result<NamedRows> {
+        if at.is_some() && mutability == ScriptMutability::Mutable {
+            bail!("a historical read bound cannot be combined with a mutable script");
+        }
+        let spec = self.db.resolve(stack)?;
+        let view = self.with_storage(self.db.with_stack(spec));
+        let cur_vld = match at {
+            Some(seq) => vld_at(seq),
+            None => vld_at(PENDING_SEQ),
+        };
+        let ast = parse_script(script, &params, &view.get_fixed_rules(), cur_vld)?;
+        view.run_script_ast(ast, cur_vld, mutability)
+    }
+}

--- a/cozo-core/src/storage/layered/mod.rs
+++ b/cozo-core/src/storage/layered/mod.rs
@@ -21,7 +21,7 @@ use crate::parse::parse_script;
 use crate::runtime::db::{BadDbInit, DbManifest, ScriptMutability};
 use crate::storage::layered::iter::{LayeredDb, Window};
 use crate::storage::layered::tx::{bind_layers, is_catalog_key, LayeredTx};
-use crate::storage::Storage;
+use crate::storage::{Storage, StorageView};
 use crate::{Db, NamedRows};
 
 pub(crate) mod catalog;
@@ -115,25 +115,49 @@ impl LayerRef {
 /// An ordered list of layers. Index 0 is the top, and the only one written to.
 pub type Stack = Vec<LayerRef>;
 
+/// This engine's identity for a resolved stack: the interned number the stack was assigned.
+///
+/// Opaque to everything above: nothing outside decides what makes two stacks the same, and the
+/// number itself never escapes.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct StackView(u64);
+
+impl crate::storage::ViewIdentity for StackView {
+    fn view_cmp(&self, other: &dyn crate::storage::ViewIdentity) -> Option<std::cmp::Ordering> {
+        (other as &dyn std::any::Any)
+            .downcast_ref::<StackView>()
+            .map(|other| self.0.cmp(&other.0))
+    }
+}
+
 /// A stack that has been checked against the open store: layers exist, windows are coherent.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct StackSpec {
     pub(crate) layers: Vec<LayerSpec>,
+    /// Which view this stack is, for caches that must not serve one stack's work to another.
+    pub(crate) view: StorageView,
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct LayerSpec {
     pub(crate) name: String,
+    /// The incarnation this name resolved to, so a stack resolved before a drop-and-recreate
+    /// is not mistaken for one resolved after it.
+    pub(crate) incarnation: u64,
     pub(crate) window: Window,
 }
 
 impl StackSpec {
+    /// The store read whole: one layer, no window. Every other engine presents exactly this,
+    /// so it reports [`StorageView::undivided`] rather than a view of its own.
     fn single(name: &str) -> Self {
         Self {
             layers: vec![LayerSpec {
                 name: name.to_string(),
+                incarnation: 0,
                 window: Window::OPEN,
             }],
+            view: StorageView::undivided(),
         }
     }
 }
@@ -145,7 +169,18 @@ pub struct LayeredInner {
     pub(crate) db: LayeredDb,
     /// Serializes commits so that the sequence read at commit really is commit order.
     pub(crate) commit_lock: Mutex<()>,
-    pub(crate) layers: RwLock<BTreeSet<String>>,
+    /// Every layer that exists, with the incarnation it was opened or created at. A name is
+    /// reusable after a drop, so the incarnation is what distinguishes the new layer from the
+    /// one it replaced for anything that caches per view.
+    pub(crate) layers: RwLock<BTreeMap<String, u64>>,
+    /// Mints layer incarnations, distinct for every layer this process ever opens or creates.
+    /// In-process uniqueness is the requirement: what reads it is in-memory caching, which does
+    /// not outlive the process.
+    pub(crate) layer_incarnation: std::sync::atomic::AtomicU64,
+    /// Every distinct stack this store has resolved, and the opaque view identity it was given.
+    /// Interned rather than rendered: engine-level caches only ever compare these, so a number
+    /// is both cheaper than a name and impossible to forge by naming a layer after one.
+    pub(crate) views: RwLock<BTreeMap<Vec<(u64, Option<Seq>, Option<Seq>)>, u64>>,
 }
 
 /// The layered RocksDB storage engine.
@@ -203,6 +238,8 @@ pub fn new_cozo_layered(path: impl AsRef<Path>) -> Result<Db<LayeredStorage>> {
     let existing_cfs = DB::list_cf(&Options::default(), store_path_str)
         .unwrap_or_else(|_| vec![DEFAULT_LAYER.to_string()]);
 
+    let existing_len = existing_cfs.len();
+
     let mut options = Options::default();
     options.create_if_missing(true);
     options.create_missing_column_families(true);
@@ -219,7 +256,17 @@ pub fn new_cozo_layered(path: impl AsRef<Path>) -> Result<Db<LayeredStorage>> {
         inner: std::sync::Arc::new(LayeredInner {
             db,
             commit_lock: Mutex::new(()),
-            layers: RwLock::new(existing_cfs.into_iter().collect()),
+            // Every layer gets a distinct incarnation, the ones already on disk included: a
+            // shared value would make two layers indistinguishable to anything keyed on it.
+            layers: RwLock::new(
+                existing_cfs
+                    .into_iter()
+                    .enumerate()
+                    .map(|(at, name)| (name, at as u64))
+                    .collect(),
+            ),
+            layer_incarnation: std::sync::atomic::AtomicU64::new(existing_len as u64),
+            views: RwLock::new(BTreeMap::new()),
         }),
         stack: std::sync::Arc::new(StackSpec::single(DEFAULT_LAYER)),
     };
@@ -240,6 +287,32 @@ impl LayeredStorage {
 
     /// Check a stack against the open store. Errors here are cheap and deterministic, which is
     /// why the checks live at stack construction rather than mid-query.
+    /// The identity of a resolved stack, interned so that two resolutions of the same stack
+    /// compare equal and no two different stacks do.
+    ///
+    /// A lone unwindowed default layer is the store read whole, which is what every other
+    /// engine presents, so it is undivided and shares cache entries with the ordinary path.
+    fn view_of(&self, layers: &[LayerSpec]) -> StorageView {
+        if let [only] = layers {
+            if only.name == DEFAULT_LAYER && only.window == Window::OPEN {
+                return StorageView::undivided();
+            }
+        }
+        let shape: Vec<(u64, Option<Seq>, Option<Seq>)> = layers
+            .iter()
+            .map(|l| (l.incarnation, l.window.since, l.window.bound))
+            .collect();
+        if let Some(&id) = self.inner.views.read().unwrap().get(&shape) {
+            return StorageView::of(std::sync::Arc::new(StackView(id)));
+        }
+        let mut views = self.inner.views.write().unwrap();
+        // Another writer may have interned this shape while the read lock was released, so take
+        // whatever is there rather than minting a second number for one stack.
+        let next = views.len() as u64;
+        let id = *views.entry(shape).or_insert(next);
+        StorageView::of(std::sync::Arc::new(StackView(id)))
+    }
+
     pub(crate) fn resolve(&self, stack: &Stack) -> Result<StackSpec> {
         if stack.is_empty() {
             bail!("a stack must name at least one layer");
@@ -249,9 +322,9 @@ impl LayeredStorage {
         let mut layers = Vec::with_capacity(stack.len());
         for layer in stack {
             let name = layer.id.0.clone();
-            if !known.contains(&name) {
+            let Some(&incarnation) = known.get(&name) else {
                 bail!("no such layer: '{}'", name);
-            }
+            };
             if !seen.insert(name.clone()) {
                 bail!("layer '{}' appears twice in the same stack", name);
             }
@@ -267,13 +340,15 @@ impl LayeredStorage {
             }
             layers.push(LayerSpec {
                 name,
+                incarnation,
                 window: Window {
                     since: layer.since,
                     bound: layer.bound,
                 },
             });
         }
-        Ok(StackSpec { layers })
+        let view = self.view_of(&layers);
+        Ok(StackSpec { layers, view })
     }
 }
 
@@ -301,7 +376,7 @@ impl<'s> Storage<'s> for LayeredStorage {
         Ok(LayeredTx {
             inner,
             tx: Some(inner.db.transaction()),
-            stack: crate::storage::layered::tx::BoundStack::new(layers),
+            stack: crate::storage::layered::tx::BoundStack::new(layers, self.stack.view.clone()),
             catalog,
             pending: vec![],
             relations: Default::default(),
@@ -386,7 +461,7 @@ impl Db<LayeredStorage> {
     pub fn create_layer(&self, id: impl Into<LayerId>) -> Result<()> {
         let id = id.into();
         let mut known = self.db.inner.layers.write().unwrap();
-        if known.contains(&id.0) {
+        if known.contains_key(&id.0) {
             bail!("layer '{}' already exists", id);
         }
         self.db
@@ -395,7 +470,13 @@ impl Db<LayeredStorage> {
             .create_cf(&id.0, &Options::default())
             .into_diagnostic()
             .wrap_err_with(|| format!("failed to create layer '{}'", id))?;
-        known.insert(id.0);
+        known.insert(
+            id.0,
+            self.db
+                .inner
+                .layer_incarnation
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+        );
         Ok(())
     }
 
@@ -406,7 +487,7 @@ impl Db<LayeredStorage> {
             bail!("the default layer cannot be dropped: it carries the catalog");
         }
         let mut known = self.db.inner.layers.write().unwrap();
-        if !known.contains(&id.0) {
+        if !known.contains_key(&id.0) {
             bail!("no such layer: '{}'", id);
         }
         self.db
@@ -428,7 +509,7 @@ impl Db<LayeredStorage> {
             .read()
             .unwrap()
             .iter()
-            .map(|n| LayerId(n.clone()))
+            .map(|(n, _)| LayerId(n.clone()))
             .collect())
     }
 
@@ -459,7 +540,16 @@ impl Db<LayeredStorage> {
             Some(seq) => vld_at(seq),
             None => vld_at(PENDING_SEQ),
         };
-        let ast = parse_script(script, &params, &view.get_fixed_rules(), cur_vld)?;
+        let ast = parse_script(
+            script,
+            &params,
+            &view.get_fixed_rules(),
+            crate::data::aggr::CustomAggrRegistries {
+                meet: &view.get_custom_aggrs(),
+                bounded: &view.get_custom_bounded_meets(),
+            },
+            cur_vld,
+        )?;
         view.run_script_ast(ast, cur_vld, mutability)
     }
 }

--- a/cozo-core/src/storage/layered/tests/concurrency.rs
+++ b/cozo-core/src/storage/layered/tests/concurrency.rs
@@ -1,0 +1,166 @@
+/*
+ * Concurrency.
+ *
+ * Concurrent access to different stacks is the normal case for any consumer that needs layers
+ * at all, so these run real threads rather than interleaving by hand.
+ */
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+
+use miette::Result;
+
+use super::{base, frontier, Fixture};
+use crate::storage::layered::{LayerRef, Stack};
+
+/// Writes hammered through one stack never change what another stack reads, as long as
+/// they do not share a top layer. This is what "writes go to the top layer only" buys.
+#[test]
+fn writes_through_one_stack_do_not_disturb_another() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "seed", "v0")?;
+    let fork = f.seq();
+    f.db.create_layer("writer")?;
+    f.db.create_layer("reader")?;
+
+    let writer: Stack = vec![LayerRef::new("writer"), LayerRef::bounded("default", fork)];
+    let reader: Stack = vec![LayerRef::new("reader"), LayerRef::bounded("default", fork)];
+    let expected = f.live(&reader, None)?;
+
+    let stop = AtomicBool::new(false);
+    thread::scope(|scope| -> Result<()> {
+        let handle = scope.spawn(|| -> Result<()> {
+            for i in 0..40 {
+                f.assert_rec(&writer, &format!("w{i}"), "v")?;
+            }
+            stop.store(true, Ordering::Release);
+            Ok(())
+        });
+
+        while !stop.load(Ordering::Acquire) {
+            assert_eq!(
+                f.live(&reader, None)?,
+                expected,
+                "a concurrent write through another stack changed this one"
+            );
+        }
+        handle.join().unwrap()
+    })?;
+
+    assert_eq!(f.live(&reader, None)?, expected);
+    assert_eq!(f.live(&writer, None)?.len(), 41);
+    Ok(())
+}
+
+/// A branch bounded at a fork point reads the same thing for its whole life, however busy
+/// its parent is. The fork point is the entire mechanism: no snapshot, no copy.
+#[test]
+fn a_bounded_branch_is_repeatable_under_a_busy_parent() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "at-fork", "v0")?;
+    let fork = f.seq();
+    f.db.create_layer("branch")?;
+    let branch: Stack = vec![LayerRef::new("branch"), LayerRef::bounded("default", fork)];
+    let expected = frontier(&[("at-fork", "v0")]);
+
+    let stop = AtomicBool::new(false);
+    thread::scope(|scope| -> Result<()> {
+        let handle = scope.spawn(|| -> Result<()> {
+            for i in 0..40 {
+                f.assert_rec(&base(), &format!("parent{i}"), "v")?;
+            }
+            // The parent also deletes the record the branch is reading.
+            f.retract_rec(&base(), "at-fork")?;
+            stop.store(true, Ordering::Release);
+            Ok(())
+        });
+
+        while !stop.load(Ordering::Acquire) {
+            assert_eq!(f.live(&branch, None)?, expected, "the fork point moved");
+        }
+        handle.join().unwrap()
+    })?;
+
+    assert_eq!(f.live(&branch, None)?, expected);
+    Ok(())
+}
+
+/// Two heads committing concurrently over one base: each head's changeset holds exactly
+/// its own rows and never its sibling's.
+#[test]
+fn concurrent_heads_have_pure_changesets() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "shared", "v0")?;
+    let fork = f.seq();
+    f.db.create_layer("head-a")?;
+    f.db.create_layer("head-b")?;
+
+    let a: Stack = vec![LayerRef::new("head-a"), LayerRef::bounded("default", fork)];
+    let b: Stack = vec![LayerRef::new("head-b"), LayerRef::bounded("default", fork)];
+
+    thread::scope(|scope| -> Result<()> {
+        let ha = scope.spawn(|| -> Result<()> {
+            for i in 0..25 {
+                f.assert_rec(&a, &format!("a{i}"), "v")?;
+            }
+            Ok(())
+        });
+        let hb = scope.spawn(|| -> Result<()> {
+            for i in 0..25 {
+                f.assert_rec(&b, &format!("b{i}"), "v")?;
+            }
+            Ok(())
+        });
+        ha.join().unwrap()?;
+        hb.join().unwrap()
+    })?;
+
+    let changes_a = f.live(&vec![LayerRef::new("head-a")], None)?;
+    let changes_b = f.live(&vec![LayerRef::new("head-b")], None)?;
+    assert_eq!(changes_a.len(), 25);
+    assert_eq!(changes_b.len(), 25);
+    assert!(changes_a.keys().all(|k| k.starts_with('a')));
+    assert!(changes_b.keys().all(|k| k.starts_with('b')));
+    Ok(())
+}
+
+/// Two transactions committing concurrently never share a stamp, and stamp order is commit
+/// order.
+#[test]
+fn concurrent_commits_never_share_a_stamp() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db.create_layer("t1")?;
+    f.db.create_layer("t2")?;
+    let fork = f.seq();
+    let s1: Stack = vec![LayerRef::new("t1"), LayerRef::bounded("default", fork)];
+    let s2: Stack = vec![LayerRef::new("t2"), LayerRef::bounded("default", fork)];
+
+    thread::scope(|scope| -> Result<()> {
+        let h1 = scope.spawn(|| -> Result<()> {
+            for i in 0..30 {
+                f.assert_rec(&s1, &format!("x{i}"), "v")?;
+            }
+            Ok(())
+        });
+        let h2 = scope.spawn(|| -> Result<()> {
+            for i in 0..30 {
+                f.assert_rec(&s2, &format!("y{i}"), "v")?;
+            }
+            Ok(())
+        });
+        h1.join().unwrap()?;
+        h2.join().unwrap()
+    })?;
+
+    let mut stamps: Vec<i64> = f
+        .versions(&vec![LayerRef::new("t1")])?
+        .into_iter()
+        .chain(f.versions(&vec![LayerRef::new("t2")])?)
+        .map(|v| v.seq)
+        .collect();
+    let total = stamps.len();
+    stamps.sort_unstable();
+    stamps.dedup();
+    assert_eq!(stamps.len(), total, "two commits shared a stamp");
+    Ok(())
+}

--- a/cozo-core/src/storage/layered/tests/crash.rs
+++ b/cozo-core/src/storage/layered/tests/crash.rs
@@ -1,0 +1,211 @@
+/*
+ * Crash recovery.
+ *
+ * A crash test needs a real crash, so these re-invoke the test binary as a child process, let
+ * it do its work, and abort it. The child bodies are `#[ignore]`d so a normal run skips them;
+ * the parent runs them by name with `--ignored`.
+ */
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use miette::Result;
+
+use super::{base, frontier};
+use crate::runtime::db::ScriptMutability;
+use crate::storage::layered::{new_cozo_layered, LayerRef, Stack};
+
+const DIR_VAR: &str = "COZO_LAYERED_CRASH_DIR";
+const SCHEMA: &str = ":create rec {id: String, at: Validity => val: String}";
+
+fn child_dir() -> Option<PathBuf> {
+    std::env::var_os(DIR_VAR).map(PathBuf::from)
+}
+
+/// Run one of the `#[ignore]`d child tests below in a fresh process against `dir`, and return
+/// whether it exited normally. A child that aborts as designed reports failure here.
+fn run_child(test: &str, dir: &PathBuf) -> bool {
+    let exe = std::env::current_exe().expect("the test binary must be locatable");
+    Command::new(exe)
+        .args(["--exact", test, "--ignored", "--nocapture", "--test-threads=1"])
+        .env(DIR_VAR, dir)
+        .status()
+        .expect("failed to spawn the child process")
+        .success()
+}
+
+/// Killed after a commit, the rows and their stamps survive recovery intact.
+#[test]
+fn a_commit_survives_a_kill() -> Result<()> {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().to_path_buf();
+
+    let survived = run_child("storage::layered::tests::crash::child_commits_then_aborts", &path);
+    assert!(!survived, "the child was supposed to abort");
+
+    let db = new_cozo_layered(&path)?;
+    let rows = db.run_on_stack(
+        "?[id, val] := *rec{id, val @ 'NOW'}",
+        Default::default(),
+        &base(),
+        None,
+        ScriptMutability::Immutable,
+    )?;
+    assert_eq!(rows.rows.len(), 3, "committed rows did not survive the kill");
+
+    // Recovery must not rewind the sequence: new writes still land above everything persisted.
+    let after = db.current_seq()?;
+    db.run_on_stack(
+        "?[id, at, val] <- [['post', 'ASSERT', 'v']] :put rec {id, at => val}",
+        Default::default(),
+        &base(),
+        None,
+        ScriptMutability::Mutable,
+    )?;
+    let stamps = db.run_on_stack(
+        "?[id, at] := *rec{id, at}",
+        Default::default(),
+        &base(),
+        None,
+        ScriptMutability::Immutable,
+    )?;
+    let newest = stamps
+        .rows
+        .iter()
+        .map(|r| match &r[1] {
+            crate::DataValue::Validity(v) => v.timestamp.0 .0,
+            other => panic!("expected a validity, got {other:?}"),
+        })
+        .max()
+        .unwrap();
+    assert!(newest > after, "a post-recovery stamp did not advance");
+    Ok(())
+}
+
+#[test]
+#[ignore = "child process of a_commit_survives_a_kill"]
+fn child_commits_then_aborts() {
+    let Some(dir) = child_dir() else { return };
+    let db = new_cozo_layered(&dir).unwrap();
+    db.run_script(SCHEMA, Default::default(), ScriptMutability::Mutable)
+        .unwrap();
+    db.run_on_stack(
+        "?[id, at, val] <- [['a', 'ASSERT', 'v'], ['b', 'ASSERT', 'v'], ['c', 'ASSERT', 'v']]
+         :put rec {id, at => val}",
+        Default::default(),
+        &base(),
+        None,
+        ScriptMutability::Mutable,
+    )
+    .unwrap();
+    // The commit returned, so the write-ahead log has it. Die without unwinding.
+    std::process::abort();
+}
+
+/// Killed during a flatten, rerunning the identical flatten converges on the same
+/// destination a clean single run produces. Idempotence is the recovery mechanism, and this is
+/// it under an actual kill.
+///
+/// A flatten is one transaction here, so the crash finds it either wholly applied or not at
+/// all; either way the rerun is what makes the outcome definite.
+#[test]
+fn a_flatten_recovers_by_rerunning() -> Result<()> {
+    let dir = tempfile::TempDir::new().unwrap();
+    let path = dir.path().to_path_buf();
+
+    let survived = run_child(
+        "storage::layered::tests::crash::child_flattens_then_aborts",
+        &path,
+    );
+    assert!(!survived, "the child was supposed to abort");
+
+    let db = new_cozo_layered(&path)?;
+    let view: Stack = vec![LayerRef::new("work")];
+    // Recovery: run the same flatten again. It must succeed whether or not the first landed.
+    db.flatten(&view, &base(), true)?;
+    let recovered = read_frontier(&db)?;
+
+    // What a clean, uninterrupted run produces, in a store built the same way.
+    let clean_dir = tempfile::TempDir::new().unwrap();
+    let clean = new_cozo_layered(clean_dir.path())?;
+    clean.run_script(SCHEMA, Default::default(), ScriptMutability::Mutable)?;
+    seed(&clean)?;
+    clean.flatten(&view, &base(), true)?;
+    assert_eq!(recovered, read_frontier(&clean)?);
+
+    // And it is the frontier the work called for.
+    assert_eq!(
+        recovered,
+        frontier(&[("kept", "v0"), ("added0", "v"), ("added1", "v"), ("added2", "v")])
+    );
+    Ok(())
+}
+
+#[test]
+#[ignore = "child process of a_flatten_recovers_by_rerunning"]
+fn child_flattens_then_aborts() {
+    let Some(dir) = child_dir() else { return };
+    let db = new_cozo_layered(&dir).unwrap();
+    db.run_script(SCHEMA, Default::default(), ScriptMutability::Mutable)
+        .unwrap();
+    seed(&db).unwrap();
+
+    let view: Stack = vec![LayerRef::new("work")];
+    std::thread::scope(|scope| {
+        scope.spawn(|| {
+            let _ = db.flatten(&view, &base(), true);
+        });
+        // Racy on purpose: the abort lands somewhere inside the flatten, and the assertion in
+        // the parent holds wherever that is.
+        std::thread::sleep(std::time::Duration::from_micros(300));
+        std::process::abort();
+    });
+}
+
+fn seed(db: &crate::Db<crate::storage::layered::LayeredStorage>) -> Result<()> {
+    db.run_on_stack(
+        "?[id, at, val] <- [['kept', 'ASSERT', 'v0'], ['doomed', 'ASSERT', 'v1']]
+         :put rec {id, at => val}",
+        Default::default(),
+        &base(),
+        None,
+        ScriptMutability::Mutable,
+    )?;
+    db.create_layer("work")?;
+    let fork = db.current_seq()?;
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+    for i in 0..3 {
+        db.run_on_stack(
+            &format!("?[id, at, val] <- [['added{i}', 'ASSERT', 'v']] :put rec {{id, at => val}}"),
+            Default::default(),
+            &work,
+            None,
+            ScriptMutability::Mutable,
+        )?;
+    }
+    db.run_on_stack(
+        "?[id, at, val] <- [['doomed', 'RETRACT', '']] :put rec {id, at => val}",
+        Default::default(),
+        &work,
+        None,
+        ScriptMutability::Mutable,
+    )?;
+    Ok(())
+}
+
+fn read_frontier(
+    db: &crate::Db<crate::storage::layered::LayeredStorage>,
+) -> Result<std::collections::BTreeMap<String, String>> {
+    let rows = db.run_on_stack(
+        "?[id, val] := *rec{id, val @ 'NOW'}",
+        Default::default(),
+        &base(),
+        None,
+        ScriptMutability::Immutable,
+    )?;
+    Ok(rows
+        .rows
+        .into_iter()
+        .map(|r| (super::as_str(&r[0]), super::as_str(&r[1])))
+        .collect())
+}

--- a/cozo-core/src/storage/layered/tests/flatten.rs
+++ b/cozo-core/src/storage/layered/tests/flatten.rs
@@ -1,0 +1,684 @@
+/*
+ * Flatten: net effect through a view, then dedupe, collision and tombstone liveness
+ * against the destination.
+ */
+
+use miette::Result;
+
+use super::{base, frontier, Fixture};
+use crate::storage::layered::{LayerRef, Stack};
+
+/// The claims on a conflict as `(layer, value)`, sorted so a test can compare them.
+fn claims_of(conflict: &crate::storage::layered::flatten::FlattenConflict) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = conflict
+        .claims
+        .iter()
+        .map(|c| (c.layer.clone(), super::as_str(&c.value[0])))
+        .collect();
+    out.sort();
+    out
+}
+
+/// A branch over the base at the current sequence, plus the whole-layer view of it.
+fn branch(f: &Fixture, name: &str) -> Result<(Stack, Stack)> {
+    f.db.create_layer(name)?;
+    let fork = f.seq();
+    let stack = vec![LayerRef::new(name), LayerRef::bounded("default", fork)];
+    let view = vec![LayerRef::new(name)];
+    Ok((stack, view))
+}
+
+/// A record created and retracted inside the window contributes nothing: its net effect is
+/// a tombstone, and a tombstone for a record the destination never saw is dropped.
+#[test]
+fn a_record_born_and_died_inside_the_view_contributes_nothing() -> Result<()> {
+    let f = Fixture::new()?;
+    let (work, view) = branch(&f, "work")?;
+    f.assert_rec(&work, "ephemeral", "v1")?;
+    f.retract_rec(&work, "ephemeral")?;
+
+    let stats = f.db.flatten(&view, &base(), true)?;
+    assert_eq!(stats.rows_copied, 0);
+    assert_eq!(stats.tombstones_dropped, 1);
+    assert_eq!(f.live(&base(), None)?, frontier(&[]));
+    Ok(())
+}
+
+/// A retraction stamped above the view's ceiling is not in the view, so the live row is
+/// what gets written: a view cannot see its own future.
+#[test]
+fn a_retraction_above_the_ceiling_is_not_in_the_view() -> Result<()> {
+    let f = Fixture::new()?;
+    let (work, _) = branch(&f, "work")?;
+    f.assert_rec(&work, "k", "v1")?;
+    let head = f.seq();
+    f.retract_rec(&work, "k")?;
+
+    let view: Stack = vec![LayerRef::bounded("work", head)];
+    let stats = f.db.flatten(&view, &base(), true)?;
+    assert_eq!(stats.rows_copied, 1);
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "v1")]));
+    Ok(())
+}
+
+/// A record created below the floor and retracted inside the window nets to a tombstone,
+/// which is copied exactly when the destination holds the record live.
+#[test]
+fn a_net_tombstone_is_copied_only_where_it_bites() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    let (work, view) = branch(&f, "work")?;
+    f.retract_rec(&work, "k")?;
+
+    let stats = f.db.flatten(&view, &base(), true)?;
+    assert_eq!(stats.rows_copied, 1);
+    assert_eq!(stats.tombstones_dropped, 0);
+    assert_eq!(f.live(&base(), None)?, frontier(&[]));
+    Ok(())
+}
+
+/// A record the destination already holds live, cherry-picked again: skipped, counted, and
+/// the destination is unchanged.
+#[test]
+fn an_identical_record_dedupes() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    let (work, view) = branch(&f, "work")?;
+    f.assert_rec(&work, "k", "v1")?;
+
+    let before = f.versions(&base())?;
+    let stats = f.db.flatten(&view, &base(), true)?;
+    assert_eq!(stats.rows_copied, 0);
+    assert_eq!(stats.rows_deduped, 1);
+    assert_eq!(f.versions(&base())?, before);
+    Ok(())
+}
+
+/// The view's net assertion over a key the destination has tombstoned: the record returns.
+#[test]
+fn a_re_introduction_revives_a_retracted_record() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    let (work, view) = branch(&f, "work")?;
+    // The base retracts it after the fork; the branch, which cannot see that, still holds it.
+    f.retract_rec(&base(), "k")?;
+    f.assert_rec(&work, "k", "v1")?;
+    assert_eq!(f.live(&base(), None)?, frontier(&[]));
+
+    let stats = f.db.flatten(&view, &base(), true)?;
+    assert_eq!(stats.rows_copied, 1);
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "v1")]));
+    Ok(())
+}
+
+/// The liveness check reads the destination *stack*, not its top layer: a tombstone whose
+/// key is live further down the destination's lineage is still copied.
+#[test]
+fn liveness_is_checked_through_the_whole_destination_stack() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    let fork = f.seq();
+
+    // `dst` is a branch whose own layer is empty: `k` lives one layer down.
+    f.db.create_layer("dst")?;
+    let dst: Stack = vec![LayerRef::new("dst"), LayerRef::bounded("default", fork)];
+
+    f.db.create_layer("src")?;
+    let src_stack: Stack = vec![LayerRef::new("src"), LayerRef::bounded("default", fork)];
+    f.retract_rec(&src_stack, "k")?;
+
+    let stats = f.db.flatten(&vec![LayerRef::new("src")], &dst, true)?;
+    assert_eq!(stats.rows_copied, 1);
+    assert_eq!(stats.tombstones_dropped, 0);
+    assert_eq!(f.live(&dst, None)?, frontier(&[]));
+    // The base still holds it: the tombstone landed in `dst`'s own layer.
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "v1")]));
+    Ok(())
+}
+
+/// Both sides deleted the same record: the second tombstone bites nothing and is dropped.
+#[test]
+fn a_second_tombstone_is_dropped() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    let (work, view) = branch(&f, "work")?;
+    f.retract_rec(&work, "k")?;
+    f.retract_rec(&base(), "k")?;
+
+    let stats = f.db.flatten(&view, &base(), true)?;
+    assert_eq!(stats.rows_copied, 0);
+    assert_eq!(stats.tombstones_dropped, 1);
+    assert_eq!(f.live(&base(), None)?, frontier(&[]));
+    Ok(())
+}
+
+/// With restamping, the destination's history stays true: a read at a sequence captured
+/// before the flatten shows nothing the flatten brought in.
+#[test]
+fn restamping_keeps_the_destination_history_true() -> Result<()> {
+    let f = Fixture::new()?;
+    let (work, view) = branch(&f, "work")?;
+    let authored = f.assert_rec(&work, "k", "v1")?;
+    let before_flatten = f.seq();
+
+    let stats = f.db.flatten(&view, &base(), true)?;
+    let (lo, hi) = stats.seq_range.expect("restamping assigns a sequence range");
+    assert!(lo > before_flatten && hi >= lo);
+
+    assert_eq!(f.live(&base(), Some(before_flatten))?, frontier(&[]));
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "v1")]));
+
+    // The row is in the base at the flatten's sequence, not the one it was authored at.
+    let stamps: Vec<_> = f.versions(&base())?.into_iter().map(|v| v.seq).collect();
+    assert_eq!(stamps, vec![lo]);
+    assert!(lo != authored);
+    Ok(())
+}
+
+/// Without restamping, rows keep their authoring stamps and interleave into the
+/// destination's history where they were written.
+#[test]
+fn without_restamping_the_authoring_stamps_survive() -> Result<()> {
+    let f = Fixture::new()?;
+    let (work, view) = branch(&f, "work")?;
+    let authored = f.assert_rec(&work, "k", "v1")?;
+
+    let stats = f.db.flatten(&view, &base(), false)?;
+    assert_eq!(stats.seq_range, None);
+
+    let stamps: Vec<_> = f.versions(&base())?.into_iter().map(|v| v.seq).collect();
+    assert_eq!(stamps, vec![authored]);
+    // A read of the base as of the authoring sequence now shows the row, which is exactly the
+    // historical inaccuracy restamping exists to avoid.
+    assert_eq!(f.live(&base(), Some(authored))?, frontier(&[("k", "v1")]));
+    Ok(())
+}
+
+/// The identical flatten run twice copies nothing the second time. This is also the
+/// crash-recovery story: recovery is rerunning it.
+#[test]
+fn flatten_is_idempotent() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "kept", "v0")?;
+    let (work, view) = branch(&f, "work")?;
+    f.assert_rec(&work, "added", "v1")?;
+    f.retract_rec(&work, "kept")?;
+
+    let first = f.db.flatten(&view, &base(), true)?;
+    assert_eq!(first.rows_copied, 2);
+    let after_first = f.live(&base(), None)?;
+
+    let second = f.db.flatten(&view, &base(), true)?;
+    assert_eq!(second.rows_copied, 0);
+    assert_eq!(second.rows_deduped, 1);
+    assert_eq!(second.tombstones_dropped, 1);
+    assert_eq!(f.live(&base(), None)?, after_first);
+    Ok(())
+}
+
+/// An empty view writes nothing and leaves the destination alone.
+#[test]
+fn an_empty_view_is_a_no_op() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    let (_work, view) = branch(&f, "work")?;
+
+    let before = f.versions(&base())?;
+    let stats = f.db.flatten(&view, &base(), true)?;
+    assert_eq!(stats.rows_copied, 0);
+    assert_eq!(stats.rows_deduped, 0);
+    assert_eq!(stats.tombstones_dropped, 0);
+    assert_eq!(f.versions(&base())?, before);
+    Ok(())
+}
+
+/// Flattening into a destination whose top layer already holds unmerged work (a
+/// cherry-pick into an active branch) leaves that work alone, and checks against the whole
+/// destination stack.
+#[test]
+fn flattening_into_a_dirty_head_leaves_its_work_alone() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "root", "v0")?;
+    let fork = f.seq();
+
+    f.db.create_layer("target")?;
+    let target: Stack = vec![LayerRef::new("target"), LayerRef::bounded("default", fork)];
+    f.assert_rec(&target, "target-work", "v1")?;
+
+    f.db.create_layer("source")?;
+    let source: Stack = vec![LayerRef::new("source"), LayerRef::bounded("default", fork)];
+    f.assert_rec(&source, "picked", "v2")?;
+
+    let stats = f.db.flatten(&vec![LayerRef::new("source")], &target, true)?;
+    assert_eq!(stats.rows_copied, 1);
+    assert_eq!(
+        f.live(&target, None)?,
+        frontier(&[("root", "v0"), ("target-work", "v1"), ("picked", "v2")])
+    );
+    Ok(())
+}
+
+/// A plan reports what a flatten would do, and does none of it. Running the flatten afterwards
+/// reports the same counts, so a caller can act on a plan without re-deriving anything.
+#[test]
+fn a_plan_predicts_the_flatten_and_writes_nothing() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "shared", "v0")?;
+    let (work, view) = branch(&f, "work")?;
+
+    f.assert_rec(&work, "added", "v1")?;
+    // Identical to what the base already holds: this dedupes rather than copies.
+    f.assert_rec(&work, "shared", "v0")?;
+    // A tombstone for a record the base never saw: this is dropped.
+    f.assert_rec(&work, "ephemeral", "v2")?;
+    f.retract_rec(&work, "ephemeral")?;
+
+    let before = f.versions(&base())?;
+    let plan = f.db.flatten_plan(&view, &base())?;
+    assert!(plan.is_clean());
+    assert_eq!(plan.stats.rows_copied, 1);
+    assert_eq!(plan.stats.rows_deduped, 1);
+    assert_eq!(plan.stats.tombstones_dropped, 1);
+    assert!(plan.stats.bytes_copied > 0);
+    // A plan commits nothing, so it occupies no sequence.
+    assert_eq!(plan.stats.seq_range, None);
+    assert_eq!(f.versions(&base())?, before, "the plan wrote to the base");
+
+    let stats = f.db.flatten(&view, &base(), true)?;
+    assert_eq!(stats.rows_copied, plan.stats.rows_copied);
+    assert_eq!(stats.rows_deduped, plan.stats.rows_deduped);
+    assert_eq!(stats.tombstones_dropped, plan.stats.tombstones_dropped);
+    assert_eq!(stats.bytes_copied, plan.stats.bytes_copied);
+    assert!(stats.seq_range.is_some(), "the flatten did commit");
+    Ok(())
+}
+
+/// A plan reports every collision, not the first one, and identifies each in decoded terms.
+#[test]
+fn a_plan_reports_every_conflict() -> Result<()> {
+    let f = Fixture::new()?;
+    let (work, view) = branch(&f, "work")?;
+
+    for (id, base_val, branch_val) in [
+        ("a", "base-a", "branch-a"),
+        ("b", "base-b", "branch-b"),
+        ("c", "base-c", "branch-c"),
+    ] {
+        // The branch's bound predates these, so it cannot see them and the write is legal
+        // on both sides. The divergence only becomes visible when the two lineages meet.
+        f.assert_rec(&base(), id, base_val)?;
+        f.assert_rec(&work, id, branch_val)?;
+    }
+
+    let plan = f.db.flatten_plan(&view, &base())?;
+    assert!(!plan.is_clean());
+    assert_eq!(plan.conflicts.len(), 3, "{:?}", plan.conflicts);
+
+    let mut seen: Vec<(String, Vec<(String, String)>)> = plan
+        .conflicts
+        .iter()
+        .map(|c| {
+            assert_eq!(c.relation, "rec");
+            // The key decodes to its columns, the identity first and the validity last.
+            (super::as_str(&c.key[0]), claims_of(c))
+        })
+        .collect();
+    seen.sort();
+    let expect = |id: &str, letter: &str| {
+        (
+            id.to_string(),
+            vec![
+                ("default".to_string(), format!("base-{letter}")),
+                ("work".to_string(), format!("branch-{letter}")),
+            ],
+        )
+    };
+    assert_eq!(seen, vec![expect("a", "a"), expect("b", "b"), expect("c", "c")]);
+    Ok(())
+}
+
+/// The flatten that follows a conflicted plan fails, names what collided, and writes nothing.
+#[test]
+fn a_conflicted_flatten_names_what_collided() -> Result<()> {
+    let f = Fixture::new()?;
+    let (work, view) = branch(&f, "work")?;
+    f.assert_rec(&base(), "k", "from-base")?;
+    f.assert_rec(&work, "k", "from-branch")?;
+
+    let before = f.versions(&base())?;
+    let err = f.db.flatten(&view, &base(), true).unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("1 key(s) are claimed with more than one value"),
+        "unexpected error: {msg}"
+    );
+    assert!(msg.contains("rec"), "the relation is not named: {msg}");
+    assert!(msg.contains("from-base"), "the values are not named: {msg}");
+    assert!(msg.contains("from-branch"), "the values are not named: {msg}");
+    assert!(msg.contains("work"), "the layers are not named: {msg}");
+    assert_eq!(f.versions(&base())?, before, "the failed flatten wrote");
+    Ok(())
+}
+
+/// A plan of a view that changes nothing is clean and empty: the same no-op the flatten is.
+#[test]
+fn an_empty_plan_is_clean() -> Result<()> {
+    let f = Fixture::new()?;
+    let (_work, view) = branch(&f, "work")?;
+    let plan = f.db.flatten_plan(&view, &base())?;
+    assert!(plan.is_clean());
+    assert_eq!(plan.stats, Default::default());
+    Ok(())
+}
+
+/// Paging covers exactly what one pass covers: every item, once, in order, with no gap at a
+/// page boundary and none at a relation boundary either.
+#[test]
+fn pages_cover_the_scan_exactly() -> Result<()> {
+    use crate::runtime::db::ScriptMutability;
+    use crate::storage::layered::flatten::FlattenCursor;
+
+    let f = Fixture::new()?;
+    f.db.run_script(
+        ":create rec2 {id: String, at: Validity => val: String}",
+        Default::default(),
+        ScriptMutability::Mutable,
+    )?;
+    f.assert_rec(&base(), "shared", "v0")?;
+    let (work, view) = branch(&f, "work")?;
+
+    for i in 0..7 {
+        f.assert_rec(&work, &format!("k{i}"), "v")?;
+    }
+    // Identical to the base's row: a dedupe, which must still be reported with its key.
+    f.assert_rec(&work, "shared", "v0")?;
+    // A second relation, so the scan has a boundary to cross mid-page.
+    for i in 0..5 {
+        f.db.run_on_stack(
+            &format!("?[id, at, val] <- [['r{i}', 'ASSERT', 'v']] :put rec2 {{id, at => val}}"),
+            Default::default(),
+            &work,
+            None,
+            ScriptMutability::Mutable,
+        )?;
+    }
+
+    let whole = f.db.flatten_page(&view, &base(), None, 1000)?;
+    assert_eq!(whole.next, None, "a page past the end should not resume");
+    assert_eq!(whole.items.len(), 13);
+
+    let mut paged = vec![];
+    let mut cursor: Option<FlattenCursor> = None;
+    let mut pages = 0;
+    loop {
+        let page = f.db.flatten_page(&view, &base(), cursor.as_ref(), 2)?;
+        pages += 1;
+        assert!(page.items.len() <= 2);
+        paged.extend(page.items);
+        match page.next {
+            Some(next) => cursor = Some(next),
+            None => break,
+        }
+        assert!(pages < 50, "paging did not terminate");
+    }
+    assert_eq!(paged, whole.items, "paging saw something a single pass did not");
+
+    // The plan counts the same scan.
+    let plan = f.db.flatten_plan(&view, &base())?;
+    assert!(plan.is_clean());
+    assert_eq!(plan.stats.rows_copied, 12);
+    assert_eq!(plan.stats.rows_deduped, 1);
+    Ok(())
+}
+
+/// A deduped row is reported with its key, not as an anonymous count.
+#[test]
+fn a_paged_dedupe_carries_its_key() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "shared", "v0")?;
+    let (work, view) = branch(&f, "work")?;
+    f.assert_rec(&work, "shared", "v0")?;
+
+    let page = f.db.flatten_page(&view, &base(), None, 10)?;
+    assert_eq!(page.items.len(), 1);
+    match &page.items[0] {
+        crate::storage::layered::flatten::FlattenItem::Dedupe { relation, key } => {
+            assert_eq!(relation, "rec");
+            assert_eq!(super::as_str(&key[0]), "shared");
+        }
+        other => panic!("expected a dedupe, got {other:?}"),
+    }
+    Ok(())
+}
+
+/// Conflicts appear in a page like any other item, so a diff can render them inline.
+#[test]
+fn a_page_reports_conflicts_inline() -> Result<()> {
+    let f = Fixture::new()?;
+    let (work, view) = branch(&f, "work")?;
+    f.assert_rec(&base(), "k", "from-base")?;
+    f.assert_rec(&work, "k", "from-branch")?;
+
+    let page = f.db.flatten_page(&view, &base(), None, 10)?;
+    assert_eq!(page.items.len(), 1);
+    match &page.items[0] {
+        crate::storage::layered::flatten::FlattenItem::Conflict(c) => {
+            assert_eq!(c.relation, "rec");
+            assert_eq!(
+                claims_of(c),
+                vec![
+                    ("default".to_string(), "from-base".to_string()),
+                    ("work".to_string(), "from-branch".to_string()),
+                ]
+            );
+        }
+        other => panic!("expected a conflict, got {other:?}"),
+    }
+    Ok(())
+}
+
+/// Flattening a layer into itself is refused: the scan would read the layer as it is written.
+#[test]
+fn a_layer_cannot_be_flattened_into_itself() -> Result<()> {
+    let f = Fixture::new()?;
+    let (work, view) = branch(&f, "work")?;
+    f.assert_rec(&work, "k", "v")?;
+
+    let err = f.db.flatten(&view, &work, true).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("both the source"),
+        "unexpected error: {err:?}"
+    );
+    Ok(())
+}
+
+
+/// Two sibling layers in one source view, each holding a different value for one key. Neither
+/// could see the other when it wrote, so both writes were legal; stamp order is not entitled to
+/// choose between them, and the disagreement is reported rather than silently resolved.
+#[test]
+fn siblings_in_one_source_view_do_not_resolve_by_stamp() -> Result<()> {
+    let f = Fixture::new()?;
+    let fork = f.seq();
+    f.db.create_layer("a")?;
+    f.db.create_layer("b")?;
+    let a: Stack = vec![LayerRef::new("a"), LayerRef::bounded("default", fork)];
+    let b: Stack = vec![LayerRef::new("b"), LayerRef::bounded("default", fork)];
+
+    f.assert_rec(&a, "k", "from-a")?;
+    f.assert_rec(&b, "k", "from-b")?;
+
+    let both: Stack = vec![LayerRef::new("a"), LayerRef::new("b")];
+    let plan = f.db.flatten_plan(&both, &base())?;
+    assert!(!plan.is_clean(), "the disagreement was resolved silently");
+    assert_eq!(plan.conflicts.len(), 1);
+    assert_eq!(plan.stats.rows_copied, 0, "neither value may be written");
+    assert_eq!(
+        claims_of(&plan.conflicts[0]),
+        vec![
+            ("a".to_string(), "from-a".to_string()),
+            ("b".to_string(), "from-b".to_string()),
+        ],
+        "each claim should name the layer holding it"
+    );
+
+    // And the flatten refuses rather than picking a winner.
+    let before = f.versions(&base())?;
+    let err = f.db.flatten(&both, &base(), true).unwrap_err();
+    let msg = format!("{err:?}");
+    assert!(msg.contains("more than one value"), "{msg}");
+    assert!(msg.contains("a=") && msg.contains("b="), "claims are not labelled: {msg}");
+    assert_eq!(f.versions(&base())?, before);
+    Ok(())
+}
+
+/// Siblings that agree (the same record cherry-picked into both) are not a conflict. One
+/// copy is written and the duplicate authoring is deduped away.
+#[test]
+fn siblings_that_agree_are_not_a_conflict() -> Result<()> {
+    let f = Fixture::new()?;
+    let fork = f.seq();
+    f.db.create_layer("a")?;
+    f.db.create_layer("b")?;
+    let a: Stack = vec![LayerRef::new("a"), LayerRef::bounded("default", fork)];
+    let b: Stack = vec![LayerRef::new("b"), LayerRef::bounded("default", fork)];
+
+    f.assert_rec(&a, "k", "same")?;
+    f.assert_rec(&b, "k", "same")?;
+
+    let both: Stack = vec![LayerRef::new("a"), LayerRef::new("b")];
+    let plan = f.db.flatten_plan(&both, &base())?;
+    assert!(plan.is_clean());
+    assert_eq!(plan.stats.rows_copied, 1, "one copy, not two");
+
+    f.db.flatten(&both, &base(), true)?;
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "same")]));
+    assert_eq!(f.versions(&base())?.len(), 1);
+    Ok(())
+}
+
+/// A record asserted, retracted and re-asserted with the same value is one lineage agreeing
+/// with itself, however long its version chain. The chain is never held in memory, and a
+/// tombstone's value is not compared against an assertion's.
+#[test]
+fn a_long_version_chain_is_not_a_disagreement() -> Result<()> {
+    let f = Fixture::new()?;
+    let (work, view) = branch(&f, "work")?;
+    for _ in 0..20 {
+        f.assert_rec(&work, "k", "v")?;
+        f.retract_rec(&work, "k")?;
+    }
+    f.assert_rec(&work, "k", "v")?;
+
+    let plan = f.db.flatten_plan(&view, &base())?;
+    assert!(plan.is_clean(), "{:?}", plan.conflicts);
+    assert_eq!(plan.stats.rows_copied, 1, "only the net effect is copied");
+    f.db.flatten(&view, &base(), true)?;
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "v")]));
+    Ok(())
+}
+
+
+
+/// A key claimed by two source layers and by the destination reports all three claims at once.
+///
+/// This is what makes the report complete rather than a first-check-wins verdict: the
+/// destination is consulted even after the source view has already disagreed with itself, so
+/// resolving one claim cannot uncover another that was hidden behind it.
+#[test]
+fn every_claim_is_reported_in_one_pass() -> Result<()> {
+    let f = Fixture::new()?;
+    let fork = f.seq();
+    for name in ["a", "b", "c"] {
+        f.db.create_layer(name)?;
+    }
+    let a: Stack = vec![LayerRef::new("a"), LayerRef::bounded("default", fork)];
+    let b: Stack = vec![LayerRef::new("b"), LayerRef::bounded("default", fork)];
+    let c: Stack = vec![LayerRef::new("c"), LayerRef::bounded("default", fork)];
+
+    // Three siblings, none able to see the others, each claiming a different value.
+    f.assert_rec(&a, "k", "from-a")?;
+    f.assert_rec(&b, "k", "from-b")?;
+    f.assert_rec(&c, "k", "from-c")?;
+
+    // The source view holds two of the claims; the destination holds the third.
+    let src: Stack = vec![LayerRef::new("a"), LayerRef::new("b")];
+    let plan = f.db.flatten_plan(&src, &c)?;
+    assert_eq!(plan.conflicts.len(), 1, "{:?}", plan.conflicts);
+    assert_eq!(
+        claims_of(&plan.conflicts[0]),
+        vec![
+            ("a".to_string(), "from-a".to_string()),
+            ("b".to_string(), "from-b".to_string()),
+            ("c".to_string(), "from-c".to_string()),
+        ]
+    );
+    assert_eq!(plan.stats.rows_copied, 0);
+    Ok(())
+}
+
+/// A destination that agrees with the source is not a claim of its own: the same value held on
+/// both sides is one claim, not two.
+#[test]
+fn an_agreeing_destination_adds_no_claim() -> Result<()> {
+    let f = Fixture::new()?;
+    let fork = f.seq();
+    for name in ["a", "b", "c"] {
+        f.db.create_layer(name)?;
+    }
+    let a: Stack = vec![LayerRef::new("a"), LayerRef::bounded("default", fork)];
+    let b: Stack = vec![LayerRef::new("b"), LayerRef::bounded("default", fork)];
+    let c: Stack = vec![LayerRef::new("c"), LayerRef::bounded("default", fork)];
+
+    f.assert_rec(&a, "k", "from-a")?;
+    f.assert_rec(&b, "k", "from-b")?;
+    // The destination happens to hold what one of the source layers holds.
+    f.assert_rec(&c, "k", "from-a")?;
+
+    let src: Stack = vec![LayerRef::new("a"), LayerRef::new("b")];
+    let plan = f.db.flatten_plan(&src, &c)?;
+    assert_eq!(plan.conflicts.len(), 1);
+    let claims = claims_of(&plan.conflicts[0]);
+    assert_eq!(claims.len(), 2, "the agreeing value was counted twice: {claims:?}");
+    assert_eq!(
+        claims,
+        vec![
+            ("a".to_string(), "from-a".to_string()),
+            ("b".to_string(), "from-b".to_string()),
+        ]
+    );
+    Ok(())
+}
+
+/// A paged row says whether it asserts, so a diff can tell an addition from a removal without
+/// decoding the validity back out of the key.
+#[test]
+fn a_paged_row_says_whether_it_asserts() -> Result<()> {
+    use crate::storage::layered::flatten::FlattenItem;
+
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "gone", "v0")?;
+    let (work, view) = branch(&f, "work")?;
+
+    f.assert_rec(&work, "added", "v1")?;
+    f.retract_rec(&work, "gone")?;
+
+    let page = f.db.flatten_page(&view, &base(), None, 10)?;
+    assert_eq!(page.items.len(), 2, "{:?}", page.items);
+
+    let mut seen: Vec<(String, bool)> = page
+        .items
+        .iter()
+        .map(|item| match item {
+            FlattenItem::Copy { key, asserts, .. } => (super::as_str(&key[0]), *asserts),
+            other => panic!("expected a copy, got {other:?}"),
+        })
+        .collect();
+    seen.sort();
+    assert_eq!(
+        seen,
+        vec![("added".to_string(), true), ("gone".to_string(), false)],
+        "the branch added one record and removed another"
+    );
+    Ok(())
+}

--- a/cozo-core/src/storage/layered/tests/functional.rs
+++ b/cozo-core/src/storage/layered/tests/functional.rs
@@ -1,0 +1,482 @@
+/*
+ * Composite scenarios: branch-shaped work built only from the public API, so these double
+ * as documentation of what a consumer is expected to do.
+ */
+
+use miette::Result;
+
+use super::{base, frontier, Fixture};
+use crate::storage::layered::{LayerRef, Stack};
+
+/// The basic branch shape, end to end: a scratch layer over a bounded base.
+///
+/// The isolation is asymmetric on purpose. `work` is blind to `base` by *bound*; `base` is
+/// blind to `work` by *stack membership*, and needs no bound of its own.
+#[test]
+fn forked_reads_are_isolated_in_both_directions() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "established", "v1")?;
+
+    f.db.create_layer("work")?;
+    let fork = f.seq();
+    let branch: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+
+    f.assert_rec(&branch, "scratch", "v2")?;
+
+    // The branch sees the base as of the fork, plus its own work.
+    assert_eq!(
+        f.live(&branch, None)?,
+        frontier(&[("established", "v1"), ("scratch", "v2")])
+    );
+    // The base is unaware the branch exists.
+    assert_eq!(f.live(&base(), None)?, frontier(&[("established", "v1")]));
+    Ok(())
+}
+
+/// The parent keeps moving after the fork, and none of it reaches the branch.
+#[test]
+fn the_bound_seals_the_parent() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "shared", "v1")?;
+
+    f.db.create_layer("work")?;
+    let fork = f.seq();
+    let branch: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+
+    f.assert_rec(&base(), "parent-only", "v2")?;
+
+    assert_eq!(f.live(&branch, None)?, frontier(&[("shared", "v1")]));
+    assert_eq!(
+        f.live(&base(), None)?,
+        frontier(&[("shared", "v1"), ("parent-only", "v2")])
+    );
+    Ok(())
+}
+
+/// The half of P6 that hurts if it regresses: a parent's post-fork *delete* must not delete
+/// the record inside the fork.
+#[test]
+fn a_post_fork_parent_delete_does_not_reach_the_branch() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "shared", "v1")?;
+
+    f.db.create_layer("work")?;
+    let fork = f.seq();
+    let branch: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+
+    f.retract_rec(&base(), "shared")?;
+
+    assert_eq!(f.live(&base(), None)?, frontier(&[]));
+    assert_eq!(f.live(&branch, None)?, frontier(&[("shared", "v1")]));
+    Ok(())
+}
+
+/// A branch deletes a record it does not own. The retraction shadows the base's row through
+/// this stack and only through this stack.
+#[test]
+fn a_branch_deletes_a_record_it_does_not_own() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "doomed", "v1")?;
+    f.assert_rec(&base(), "spared", "v1")?;
+
+    f.db.create_layer("work")?;
+    let fork = f.seq();
+    let branch: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+
+    f.retract_rec(&branch, "doomed")?;
+
+    assert_eq!(f.live(&branch, None)?, frontier(&[("spared", "v1")]));
+    assert_eq!(
+        f.live(&base(), None)?,
+        frontier(&[("doomed", "v1"), ("spared", "v1")])
+    );
+    Ok(())
+}
+
+/// A branch of a branch. Each layer answers only to its own window: a base row written after
+/// the *first* fork stays invisible even though it precedes the second.
+#[test]
+fn a_lineage_bounds_each_ancestor_at_its_own_fork() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "root", "v1")?;
+
+    f.db.create_layer("work")?;
+    let fork1 = f.seq();
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork1)];
+    f.assert_rec(&work, "on-work", "v2")?;
+
+    // The parent moves on between the two forks. `work2` must not acquire this.
+    f.assert_rec(&base(), "after-fork1", "v3")?;
+
+    f.db.create_layer("work2")?;
+    let fork2 = f.seq();
+    let work2: Stack = vec![
+        LayerRef::new("work2"),
+        LayerRef::bounded("work", fork2),
+        LayerRef::bounded("default", fork1),
+    ];
+    f.assert_rec(&work2, "on-work2", "v4")?;
+
+    assert_eq!(
+        f.live(&work2, None)?,
+        frontier(&[("root", "v1"), ("on-work", "v2"), ("on-work2", "v4")])
+    );
+    assert_eq!(
+        f.live(&work, None)?,
+        frontier(&[("root", "v1"), ("on-work", "v2")])
+    );
+    Ok(())
+}
+
+/// A record retracted on a branch and re-introduced above it, identically, is live again.
+#[test]
+fn a_record_can_be_retracted_and_re_introduced_up_the_lineage() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+
+    f.db.create_layer("work")?;
+    let fork1 = f.seq();
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork1)];
+    f.retract_rec(&work, "k")?;
+    assert_eq!(f.live(&work, None)?, frontier(&[]));
+
+    f.db.create_layer("work2")?;
+    let fork2 = f.seq();
+    let work2: Stack = vec![
+        LayerRef::new("work2"),
+        LayerRef::bounded("work", fork2),
+        LayerRef::bounded("default", fork1),
+    ];
+    f.assert_rec(&work2, "k", "v1")?;
+
+    assert_eq!(f.live(&work2, None)?, frontier(&[("k", "v1")]));
+    // Dropping the re-introducing layer from the stack leaves it retracted again.
+    assert_eq!(f.live(&work, None)?, frontier(&[]));
+    Ok(())
+}
+
+/// A changeset is a windowed read of one layer: "what changed", never "what is".
+#[test]
+fn a_changeset_is_a_windowed_read_of_one_layer() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "before", "v1")?;
+    let commit_start = f.seq();
+    f.assert_rec(&base(), "during", "v2")?;
+    let commit_end = f.seq();
+    f.assert_rec(&base(), "after", "v3")?;
+
+    let changeset: Stack = vec![LayerRef::windowed(
+        "default",
+        Some(commit_start),
+        Some(commit_end),
+    )];
+    assert_eq!(f.live(&changeset, None)?, frontier(&[("during", "v2")]));
+
+    // The floor is exclusive and the ceiling inclusive, so consecutive windows tile exactly.
+    let earlier: Stack = vec![LayerRef::bounded("default", commit_start)];
+    assert_eq!(f.live(&earlier, None)?, frontier(&[("before", "v1")]));
+    Ok(())
+}
+
+/// The plain cycle: branch, work, merge down, drop. The base ends up holding exactly the
+/// base plus the work.
+#[test]
+fn a_branch_merges_down_and_is_dropped() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "kept", "v0")?;
+    f.assert_rec(&base(), "doomed", "v1")?;
+
+    f.db.create_layer("work")?;
+    let fork = f.seq();
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+    f.assert_rec(&work, "added", "v2")?;
+    f.retract_rec(&work, "doomed")?;
+
+    let stats = f.db.flatten(&vec![LayerRef::new("work")], &base(), true)?;
+    assert_eq!(stats.rows_copied, 2);
+    f.db.drop_layer("work")?;
+
+    assert_eq!(
+        f.live(&base(), None)?,
+        frontier(&[("kept", "v0"), ("added", "v2")])
+    );
+    assert_eq!(f.db.list_layers()?.len(), 1);
+    Ok(())
+}
+
+/// A three-deep lineage merged leaf-first, verifying every intermediate frontier.
+#[test]
+fn a_lineage_merges_leaf_first() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "root", "v0")?;
+
+    f.db.create_layer("work")?;
+    let fork1 = f.seq();
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork1)];
+    f.assert_rec(&work, "on-work", "v1")?;
+
+    f.db.create_layer("work2")?;
+    let fork2 = f.seq();
+    let work2: Stack = vec![
+        LayerRef::new("work2"),
+        LayerRef::bounded("work", fork2),
+        LayerRef::bounded("default", fork1),
+    ];
+    f.assert_rec(&work2, "on-work2", "v2")?;
+
+    // Leaf into its parent.
+    f.db.flatten(&vec![LayerRef::new("work2")], &work, true)?;
+    f.db.drop_layer("work2")?;
+    assert_eq!(
+        f.live(&work, None)?,
+        frontier(&[("root", "v0"), ("on-work", "v1"), ("on-work2", "v2")])
+    );
+
+    // Parent into the base.
+    f.db.flatten(&vec![LayerRef::new("work")], &base(), true)?;
+    f.db.drop_layer("work")?;
+    assert_eq!(
+        f.live(&base(), None)?,
+        frontier(&[("root", "v0"), ("on-work", "v1"), ("on-work2", "v2")])
+    );
+    Ok(())
+}
+
+/// Merging a layer down and dropping it while a child branch still forks off it. The
+/// child's next stack construction must fail loudly rather than read something wrong.
+#[test]
+fn dropping_a_layer_under_a_live_child_fails_loudly() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db.create_layer("work")?;
+    let fork1 = f.seq();
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork1)];
+    f.assert_rec(&work, "on-work", "v1")?;
+
+    f.db.create_layer("work2")?;
+    let fork2 = f.seq();
+    let work2: Stack = vec![
+        LayerRef::new("work2"),
+        LayerRef::bounded("work", fork2),
+        LayerRef::bounded("default", fork1),
+    ];
+    f.assert_rec(&work2, "on-work2", "v2")?;
+
+    f.db.flatten(&vec![LayerRef::new("work")], &base(), true)?;
+    f.db.drop_layer("work")?;
+
+    let err = f.live(&work2, None).unwrap_err();
+    assert!(format!("{err:?}").contains("no such layer"), "{err:?}");
+    // Re-parenting is the consumer's move, and it is available: the work merged down.
+    assert_eq!(f.live(&base(), None)?, frontier(&[("on-work", "v1")]));
+    Ok(())
+}
+
+/// Cherry-pick one commit (a `(layer, sequence interval)` window) into another branch,
+/// and again, idempotently.
+#[test]
+fn a_commit_can_be_cherry_picked() -> Result<()> {
+    let f = Fixture::new()?;
+    let fork = f.seq();
+    f.db.create_layer("source")?;
+    f.db.create_layer("target")?;
+    let source: Stack = vec![LayerRef::new("source"), LayerRef::bounded("default", fork)];
+    let target: Stack = vec![LayerRef::new("target"), LayerRef::bounded("default", fork)];
+
+    f.assert_rec(&source, "before", "v0")?;
+    let commit_start = f.seq();
+    f.assert_rec(&source, "wanted", "v1")?;
+    let commit_end = f.seq();
+    f.assert_rec(&source, "after", "v2")?;
+
+    let commit: Stack = vec![LayerRef::windowed(
+        "source",
+        Some(commit_start),
+        Some(commit_end),
+    )];
+    let first = f.db.flatten(&commit, &target, true)?;
+    assert_eq!(first.rows_copied, 1);
+    assert_eq!(f.live(&target, None)?, frontier(&[("wanted", "v1")]));
+
+    let second = f.db.flatten(&commit, &target, true)?;
+    assert_eq!(second.rows_copied, 0);
+    assert_eq!(second.rows_deduped, 1);
+    assert_eq!(f.live(&target, None)?, frontier(&[("wanted", "v1")]));
+    Ok(())
+}
+
+/// Cherry-picking a delete: it bites where the target holds the record, and is a clean
+/// no-op where the target never saw it.
+#[test]
+fn a_delete_can_be_cherry_picked() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "shared", "v1")?;
+    let fork = f.seq();
+    f.db.create_layer("source")?;
+    f.db.create_layer("has-it")?;
+    f.db.create_layer("never-saw-it")?;
+
+    let source: Stack = vec![LayerRef::new("source"), LayerRef::bounded("default", fork)];
+    f.retract_rec(&source, "shared")?;
+    let pick: Stack = vec![LayerRef::new("source")];
+
+    let has_it: Stack = vec![LayerRef::new("has-it"), LayerRef::bounded("default", fork)];
+    let bit = f.db.flatten(&pick, &has_it, true)?;
+    assert_eq!(bit.rows_copied, 1);
+    assert_eq!(f.live(&has_it, None)?, frontier(&[]));
+
+    // A branch whose lineage never held the record: nothing to delete, nothing written.
+    let stranger: Stack = vec![LayerRef::new("never-saw-it")];
+    let missed = f.db.flatten(&pick, &stranger, true)?;
+    assert_eq!(missed.rows_copied, 0);
+    assert_eq!(missed.tombstones_dropped, 1);
+    Ok(())
+}
+
+/// Revert: cherry-pick the inverse of a window, retracting what it asserted and re-asserting
+/// what it retracted, and the frontier returns to what it was.
+#[test]
+fn a_window_can_be_reverted() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "existing", "v0")?;
+    let before = f.seq();
+
+    f.assert_rec(&base(), "added", "v1")?;
+    f.retract_rec(&base(), "existing")?;
+    let after = f.seq();
+    assert_eq!(f.live(&base(), None)?, frontier(&[("added", "v1")]));
+
+    // The changeset of the window, with the assertion flags the revert must invert.
+    let window: Stack = vec![LayerRef::windowed("default", Some(before), Some(after))];
+    let changes = f.versions(&window)?;
+    assert_eq!(changes.len(), 2);
+
+    for change in changes {
+        if change.assertive {
+            f.retract_rec(&base(), &change.id)?;
+        } else {
+            // Re-assert from the pre-image: the value is immutable, so the one the record
+            // always had is the only one that could be written back.
+            let pre_image = f
+                .versions(&vec![LayerRef::bounded("default", before)])?
+                .into_iter()
+                .find(|v| v.id == change.id && v.assertive)
+                .expect("a retraction must have had something to retract");
+            f.assert_rec(&base(), &change.id, &pre_image.val)?;
+        }
+    }
+
+    assert_eq!(f.live(&base(), None)?, frontier(&[("existing", "v0")]));
+    assert_eq!(f.live(&base(), Some(before))?, frontier(&[("existing", "v0")]));
+    Ok(())
+}
+
+/// Reset: re-fork at an earlier point. Heads never move backwards; stacks do.
+#[test]
+fn a_branch_can_be_reset_by_re_forking() -> Result<()> {
+    let f = Fixture::new()?;
+    let fork = f.seq();
+    f.db.create_layer("work")?;
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+    f.assert_rec(&work, "keep", "v1")?;
+    let reset_point = f.seq();
+    f.assert_rec(&work, "discard", "v2")?;
+
+    f.db.create_layer("work-reset")?;
+    let reset: Stack = vec![
+        LayerRef::new("work-reset"),
+        LayerRef::bounded("work", reset_point),
+        LayerRef::bounded("default", fork),
+    ];
+    assert_eq!(f.live(&reset, None)?, frontier(&[("keep", "v1")]));
+
+    f.assert_rec(&reset, "redone", "v3")?;
+    assert_eq!(
+        f.live(&reset, None)?,
+        frontier(&[("keep", "v1"), ("redone", "v3")])
+    );
+    Ok(())
+}
+
+/// The same record cherry-picked into two branches, both merged down: one copy survives
+/// and the second merge dedupes.
+#[test]
+fn convergent_picks_merge_to_one_copy() -> Result<()> {
+    let f = Fixture::new()?;
+    let fork = f.seq();
+    f.db.create_layer("a")?;
+    f.db.create_layer("b")?;
+    let a: Stack = vec![LayerRef::new("a"), LayerRef::bounded("default", fork)];
+    let b: Stack = vec![LayerRef::new("b"), LayerRef::bounded("default", fork)];
+
+    f.assert_rec(&a, "shared", "v1")?;
+    f.assert_rec(&b, "shared", "v1")?;
+
+    let first = f.db.flatten(&vec![LayerRef::new("a")], &base(), true)?;
+    assert_eq!(first.rows_copied, 1);
+    let second = f.db.flatten(&vec![LayerRef::new("b")], &base(), true)?;
+    assert_eq!(second.rows_copied, 0);
+    assert_eq!(second.rows_deduped, 1);
+
+    assert_eq!(f.versions(&base())?.len(), 1);
+    assert_eq!(f.live(&base(), None)?, frontier(&[("shared", "v1")]));
+    Ok(())
+}
+
+/// A long chain of fork/merge cycles. The frontier stays correct throughout and the
+/// stack depth returns to one after every merge-down, so the merge-promptly discipline holds
+/// as an invariant rather than an assumption.
+#[test]
+fn a_long_chain_of_cycles_stays_correct() -> Result<()> {
+    let f = Fixture::new()?;
+    let mut expected: Vec<(String, String)> = vec![];
+
+    for round in 0..8 {
+        let name = format!("work{round}");
+        f.db.create_layer(name.as_str())?;
+        let fork = f.seq();
+        let work: Stack = vec![
+            LayerRef::new(name.as_str()),
+            LayerRef::bounded("default", fork),
+        ];
+
+        let id = format!("k{round}");
+        f.assert_rec(&work, &id, "v")?;
+        expected.push((id, "v".to_string()));
+
+        // Every other round also deletes the record the previous round added.
+        if round % 2 == 1 {
+            let doomed = format!("k{}", round - 1);
+            f.retract_rec(&work, &doomed)?;
+            expected.retain(|(k, _)| *k != doomed);
+        }
+
+        f.db.flatten(&vec![LayerRef::new(name.as_str())], &base(), true)?;
+        f.db.drop_layer(name.as_str())?;
+
+        let want: std::collections::BTreeMap<String, String> = expected.iter().cloned().collect();
+        assert_eq!(f.live(&base(), None)?, want, "after round {round}");
+        assert_eq!(f.db.list_layers()?.len(), 1, "after round {round}");
+    }
+    Ok(())
+}
+
+/// Time travel composes with the structural bound rather than fighting it: the effective
+/// ceiling is the smaller of the two.
+#[test]
+fn a_query_bound_composes_with_a_layer_bound() -> Result<()> {
+    let f = Fixture::new()?;
+    let first = f.assert_rec(&base(), "a", "v1")?;
+    f.assert_rec(&base(), "b", "v2")?;
+    let fork = f.seq();
+    f.assert_rec(&base(), "c", "v3")?;
+
+    let bounded: Stack = vec![LayerRef::bounded("default", fork)];
+    // `at` above the bound: the bound wins.
+    assert_eq!(
+        f.live(&bounded, Some(f.seq()))?,
+        frontier(&[("a", "v1"), ("b", "v2")])
+    );
+    // `at` below the bound: `at` wins.
+    assert_eq!(f.live(&bounded, Some(first))?, frontier(&[("a", "v1")]));
+    Ok(())
+}

--- a/cozo-core/src/storage/layered/tests/immutability.rs
+++ b/cozo-core/src/storage/layered/tests/immutability.rs
@@ -1,0 +1,151 @@
+/*
+ * Value immutability.
+ *
+ * A key's value is immutable; its visibility is not. Everything merge soundness rests on is in
+ * this suite: with values that never change, merging two layers is a set union.
+ */
+
+use miette::Result;
+
+use super::{base, frontier, Fixture};
+use crate::storage::layered::{LayerRef, Stack};
+
+fn branch(f: &Fixture, name: &str) -> Result<Stack> {
+    f.db.create_layer(name)?;
+    let fork = f.seq();
+    Ok(vec![LayerRef::new(name), LayerRef::bounded("default", fork)])
+}
+
+/// Re-asserting the identical value is accepted and changes nothing.
+#[test]
+fn an_identical_re_assert_is_accepted() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    f.assert_rec(&base(), "k", "v1")?;
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "v1")]));
+    Ok(())
+}
+
+/// A different value under a live key in the same layer is rejected.
+#[test]
+fn a_differing_re_assert_is_rejected() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    let err = f.assert_rec(&base(), "k", "v2").unwrap_err();
+    assert!(
+        format!("{err:?}").contains("never updated"),
+        "unexpected error: {err:?}"
+    );
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "v1")]));
+    Ok(())
+}
+
+/// The check traverses the whole stack, not just the top layer: a value held only in a
+/// lower layer still forbids a differing assert above it.
+#[test]
+fn a_differing_re_assert_is_rejected_across_layers() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    let work = branch(&f, "work")?;
+    let err = f.assert_rec(&work, "k", "v2").unwrap_err();
+    assert!(format!("{err:?}").contains("never updated"), "{err:?}");
+    Ok(())
+}
+
+/// Delete-then-recreate is backdoor mutability wherever the tombstone lives, and is
+/// rejected just as an in-place update would be.
+#[test]
+fn recreating_a_retracted_key_with_a_new_value_is_rejected() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    f.retract_rec(&base(), "k")?;
+    let err = f.assert_rec(&base(), "k", "v2").unwrap_err();
+    assert!(format!("{err:?}").contains("never updated"), "{err:?}");
+    assert_eq!(f.live(&base(), None)?, frontier(&[]));
+    Ok(())
+}
+
+/// Undelete: the identical value over a tombstoned key is how a retracted record comes
+/// back, whether by hand or by cherry-pick.
+#[test]
+fn an_identical_value_undeletes() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    f.retract_rec(&base(), "k")?;
+    f.assert_rec(&base(), "k", "v1")?;
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "v1")]));
+    Ok(())
+}
+
+/// The invisible collision. A parent acquires a key above the branch's bound, with a
+/// different value; the branch asserts it too. The write *must* succeed, because the conflicting row
+/// is unknowable through this stack, and the merge must be what fails.
+#[test]
+fn a_collision_invisible_to_the_branch_is_caught_at_the_merge() -> Result<()> {
+    let f = Fixture::new()?;
+    let work = branch(&f, "work")?;
+
+    f.assert_rec(&base(), "k", "from-base")?;
+    // The branch cannot see that row: its bound predates it.
+    f.assert_rec(&work, "k", "from-branch")?;
+
+    assert_eq!(f.live(&work, None)?, frontier(&[("k", "from-branch")]));
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "from-base")]));
+
+    let err = f
+        .db
+        .flatten(&vec![LayerRef::new("work")], &base(), true)
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("more than one value"),
+        "unexpected error: {err:?}"
+    );
+    // Nothing was written: the base is exactly as it was.
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "from-base")]));
+    Ok(())
+}
+
+/// A rejected assert writes nothing and poisons nothing.
+#[test]
+fn a_rejected_assert_leaves_the_session_usable() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    assert!(f.assert_rec(&base(), "k", "v2").is_err());
+
+    f.assert_rec(&base(), "k2", "v3")?;
+    assert_eq!(
+        f.live(&base(), None)?,
+        frontier(&[("k", "v1"), ("k2", "v3")])
+    );
+    Ok(())
+}
+
+/// Relations with no validity keep stock semantics: they never participate in a merge, so
+/// nothing rests on their immutability.
+#[test]
+fn relations_without_validity_are_unaffected() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db.run_script(
+        ":create plain {k: Int => v: Int}",
+        Default::default(),
+        crate::runtime::db::ScriptMutability::Mutable,
+    )?;
+    f.db.run_script(
+        "?[k, v] <- [[1, 10]] :put plain {k => v}",
+        Default::default(),
+        crate::runtime::db::ScriptMutability::Mutable,
+    )?;
+    f.db.run_script(
+        "?[k, v] <- [[1, 20]] :put plain {k => v}",
+        Default::default(),
+        crate::runtime::db::ScriptMutability::Mutable,
+    )?;
+    let rows = f.db.run_script(
+        "?[k, v] := *plain{k, v}",
+        Default::default(),
+        crate::runtime::db::ScriptMutability::Immutable,
+    )?;
+    assert_eq!(rows.rows.len(), 1);
+    assert_eq!(rows.rows[0][1], crate::DataValue::from(20));
+    Ok(())
+}

--- a/cozo-core/src/storage/layered/tests/indexes.rs
+++ b/cozo-core/src/storage/layered/tests/indexes.rs
@@ -102,3 +102,121 @@ fn an_index_survives_a_branch_cycle_by_being_rebuilt() -> Result<()> {
     assert_eq!(neighbours(&f, &base())?, through_stack);
     Ok(())
 }
+
+/// Retract a record through `stack`.
+fn retract(f: &Fixture, stack: &Stack, id: &str, v: [f32; 2]) -> Result<()> {
+    f.db.run_on_stack(
+        &format!(
+            "?[id, at, v] <- [['{id}', 'RETRACT', [{}, {}]]] :put vrec {{id, at => v}}",
+            v[0], v[1]
+        ),
+        Default::default(),
+        stack,
+        None,
+        ScriptMutability::Mutable,
+    )?;
+    Ok(())
+}
+
+/// The `k` nearest *live* records, through a stack.
+fn live_neighbours(f: &Fixture, stack: &Stack) -> Result<BTreeSet<String>> {
+    let rows = f.db.run_on_stack(
+        "?[id] := ~vrec:idx{id | query: q, k: 10, ef: 50, validity: 'NOW'}, q = vec([1.0, 1.0])",
+        Default::default(),
+        stack,
+        None,
+        ScriptMutability::Immutable,
+    )?;
+    Ok(rows.rows.iter().map(|r| super::as_str(&r[0])).collect())
+}
+
+/// Every version of a record is its own node in the graph, and a retraction writes a version
+/// rather than removing one. So a branch that retracts a record still has the record's older
+/// versions in reach, and only a search that asks about liveness stops returning it.
+#[test]
+fn a_retraction_in_a_branch_hides_the_record_from_that_branch_only() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db
+        .run_script(SCHEMA, Default::default(), ScriptMutability::Mutable)?;
+    f.db
+        .run_script(INDEX, Default::default(), ScriptMutability::Mutable)?;
+    for (id, v) in [("a", [1.0, 1.0]), ("b", [1.2, 1.2]), ("c", [1.4, 1.4])] {
+        put(&f, &base(), id, v)?;
+    }
+
+    f.db.create_layer("work")?;
+    let fork = f.seq();
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+    retract(&f, &work, "b", [1.2, 1.2])?;
+
+    let all = ["a", "b", "c"]
+        .iter()
+        .map(|s| s.to_string())
+        .collect::<BTreeSet<_>>();
+    // The retraction is only a newer version, so the graph still reaches `b` from either side.
+    assert_eq!(neighbours(&f, &work)?, all);
+    assert_eq!(neighbours(&f, &base())?, all);
+
+    assert_eq!(
+        live_neighbours(&f, &work)?,
+        ["a", "c"].iter().map(|s| s.to_string()).collect(),
+        "the branch still sees the record it retracted"
+    );
+    assert_eq!(
+        live_neighbours(&f, &base())?,
+        all,
+        "a branch retraction reached the base"
+    );
+    Ok(())
+}
+
+/// A bound cuts the records off at a sequence but not the index, whose keys carry no trailing
+/// validity for a window to select on. The graph therefore names records the stack cannot
+/// read. Those nodes drop out of the walk; the search is not an error and does not lose the
+/// records that are still there.
+#[test]
+fn a_bounded_stack_skips_the_nodes_it_cannot_resolve() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db
+        .run_script(SCHEMA, Default::default(), ScriptMutability::Mutable)?;
+    f.db
+        .run_script(INDEX, Default::default(), ScriptMutability::Mutable)?;
+    for i in 0..12 {
+        put(&f, &base(), &format!("b{i:02}"), [i as f32, 0.0])?;
+    }
+
+    f.db.create_layer("work")?;
+    let fork = f.seq();
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+    put(&f, &work, "w0", [0.5, 1.0])?;
+
+    // The base moves on. Its new rows join the graph, which the bound does not hide.
+    for i in 12..24 {
+        put(&f, &base(), &format!("b{i:02}"), [i as f32, 0.0])?;
+    }
+
+    let found = neighbours(&f, &work)?;
+    let visible: BTreeSet<String> = f
+        .db
+        .run_on_stack(
+            "?[id] := *vrec{id @ 'NOW'}",
+            Default::default(),
+            &work,
+            None,
+            ScriptMutability::Immutable,
+        )?
+        .rows
+        .iter()
+        .map(|r| super::as_str(&r[0]))
+        .collect();
+
+    assert!(
+        found.is_subset(&visible),
+        "returned a record the stack cannot read: {:?}",
+        &found - &visible
+    );
+    for id in ["b00", "b01", "w0"] {
+        assert!(found.contains(id), "lost {id}; got {found:?}");
+    }
+    Ok(())
+}

--- a/cozo-core/src/storage/layered/tests/indexes.rs
+++ b/cozo-core/src/storage/layered/tests/indexes.rs
@@ -1,0 +1,104 @@
+/*
+ * Index relations through a branch cycle.
+ *
+ * Reads compose through a stack: an index stores its structure as ordinary rows, so a layer's
+ * rewritten neighbour lists shadow the base's and traversal sees a coherent graph. Flatten does
+ * not compose, and copying those rows would splice two independently evolved graphs into
+ * something structurally invalid whose only symptom is silent recall loss. So flatten skips
+ * them and the consumer drops and rebuilds.
+ */
+
+use std::collections::BTreeSet;
+
+use miette::Result;
+
+use super::{base, Fixture};
+use crate::runtime::db::ScriptMutability;
+use crate::storage::layered::{LayerRef, Stack};
+
+const SCHEMA: &str = ":create vrec {id: String, at: Validity => v: <F32; 2>}";
+const INDEX: &str = "::hnsw create vrec:idx {
+    dim: 2, m: 50, dtype: F32, fields: [v], distance: L2, ef_construction: 20
+}";
+
+fn put(f: &Fixture, stack: &Stack, id: &str, v: [f32; 2]) -> Result<()> {
+    f.db.run_on_stack(
+        &format!(
+            "?[id, at, v] <- [['{id}', 'ASSERT', [{}, {}]]] :put vrec {{id, at => v}}",
+            v[0], v[1]
+        ),
+        Default::default(),
+        stack,
+        None,
+        ScriptMutability::Mutable,
+    )?;
+    Ok(())
+}
+
+/// The `k` nearest neighbours of a probe, through a stack.
+fn neighbours(f: &Fixture, stack: &Stack) -> Result<BTreeSet<String>> {
+    let rows = f.db.run_on_stack(
+        "?[id] := ~vrec:idx{id | query: q, k: 10, ef: 50}, q = vec([1.0, 1.0])",
+        Default::default(),
+        stack,
+        None,
+        ScriptMutability::Immutable,
+    )?;
+    Ok(rows.rows.iter().map(|r| super::as_str(&r[0])).collect())
+}
+
+/// Vectors written in a branch, queried through the stack, then merged down with the
+/// index dropped and rebuilt. Recall after the rebuild matches what the stack query returned.
+#[test]
+fn an_index_survives_a_branch_cycle_by_being_rebuilt() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db
+        .run_script(SCHEMA, Default::default(), ScriptMutability::Mutable)?;
+    f.db
+        .run_script(INDEX, Default::default(), ScriptMutability::Mutable)?;
+
+    for (id, v) in [("base1", [1.0, 1.0]), ("base2", [2.0, 2.0])] {
+        put(&f, &base(), id, v)?;
+    }
+
+    f.db.create_layer("work")?;
+    let fork = f.seq();
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+    for (id, v) in [("work1", [1.1, 1.1]), ("work2", [3.0, 3.0])] {
+        put(&f, &work, id, v)?;
+    }
+
+    // Traversal through the stack sees both layers' vectors as one graph: the branch's
+    // inserts linked its new nodes into the base's neighbour lists, and the base's edges are
+    // still visible underneath them.
+    let through_stack = neighbours(&f, &work)?;
+    assert_eq!(
+        through_stack,
+        ["base1", "base2", "work1", "work2"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<BTreeSet<_>>(),
+        "traversal through the stack lost a layer"
+    );
+
+    // The base, meanwhile, knows nothing of the branch.
+    let before_merge = neighbours(&f, &base())?;
+    assert!(!before_merge.contains("work1"));
+
+    // Merge down. The index relation is not copied: only the records are.
+    let stats = f.db.flatten(&vec![LayerRef::new("work")], &base(), true)?;
+    assert_eq!(stats.rows_copied, 2, "only the records should be copied");
+
+    // Rebuild in the destination, and recall matches the pre-merge stack query.
+    f.db.run_script(
+        "::hnsw drop vrec:idx",
+        Default::default(),
+        ScriptMutability::Mutable,
+    )?;
+    f.db
+        .run_script(INDEX, Default::default(), ScriptMutability::Mutable)?;
+    f.db.drop_layer("work")?;
+
+    assert_eq!(neighbours(&f, &base())?, through_stack);
+    Ok(())
+}

--- a/cozo-core/src/storage/layered/tests/lifecycle.rs
+++ b/cozo-core/src/storage/layered/tests/lifecycle.rs
@@ -354,3 +354,44 @@ fn the_existing_entry_points_still_work() -> Result<()> {
     // in a single-layer stack; the multi-layer case is checked in the stackability suite.
     Ok(())
 }
+
+/// A value blob that will not decode is an error, not a panic.
+///
+/// The engine keeps every version of every record, so a single unreadable row must not make
+/// the rest of the history unreachable. The other backends decode fallibly for this reason;
+/// this pins the layered read path to the same contract.
+#[test]
+fn a_corrupt_value_is_an_error_not_a_panic() -> Result<()> {
+    use crate::runtime::relation::RelationId;
+    use crate::storage::{StoreTx, Storage};
+
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v")?;
+
+    // Find the raw key of a stored record, skipping the system relation that holds the catalog.
+    let lower = RelationId::SYSTEM.next().raw_encode().to_vec();
+    let upper = vec![0xffu8; 8];
+    let key = {
+        let tx = f.db.db.transact(false)?;
+        let mut it = tx.range_scan(&lower, &upper);
+        it.next().expect("the record just written should be there")?.0
+    };
+
+    // Overwrite its value with bytes that are not a value blob. `batch_put` is the restore
+    // path, so it writes raw pairs without going through the encoder.
+    f.db.db
+        .batch_put(Box::new(std::iter::once(Ok((key, vec![0xABu8; 5])))))?;
+
+    let err = f
+        .live(&base(), None)
+        .expect_err("a corrupt value should surface as an error");
+    // Specifically the corrupt-blob diagnostic, not merely "some error": the point is that the
+    // engine reports the unreadable row rather than dying on it.
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("value blob") || msg.contains("CorruptValueBlob") || msg.contains("corrupt"),
+        "expected a corrupt-value diagnostic, got: {msg}"
+    );
+    Ok(())
+}
+

--- a/cozo-core/src/storage/layered/tests/lifecycle.rs
+++ b/cozo-core/src/storage/layered/tests/lifecycle.rs
@@ -1,0 +1,356 @@
+/*
+ * Layer lifecycle and catalog.
+ */
+
+use miette::Result;
+use tempfile::TempDir;
+
+use super::{base, frontier, Fixture};
+use crate::runtime::db::ScriptMutability;
+use crate::storage::layered::{new_cozo_layered, LayerId, LayerRef, Stack};
+
+/// Create, list, write, drop.
+#[test]
+fn a_layer_round_trips() -> Result<()> {
+    let f = Fixture::new()?;
+    assert_eq!(f.db.list_layers()?, vec![LayerId("default".into())]);
+
+    f.db.create_layer("work")?;
+    assert_eq!(
+        f.db.list_layers()?,
+        vec![LayerId("default".into()), LayerId("work".into())]
+    );
+
+    let fork = f.seq();
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+    f.assert_rec(&work, "k", "v1")?;
+
+    f.db.drop_layer("work")?;
+    assert_eq!(f.db.list_layers()?, vec![LayerId("default".into())]);
+    Ok(())
+}
+
+/// A recreated layer is empty. Nothing the dropped one held comes back.
+#[test]
+fn a_dropped_layer_does_not_resurrect() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db.create_layer("work")?;
+    let fork = f.seq();
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+    f.assert_rec(&work, "scratch", "v1")?;
+    assert_eq!(f.live(&work, None)?, frontier(&[("scratch", "v1")]));
+
+    f.db.drop_layer("work")?;
+    f.db.create_layer("work")?;
+    assert_eq!(f.live(&work, None)?, frontier(&[]));
+    Ok(())
+}
+
+/// Layers and their contents survive a reopen, and stacks rebuild from consumer-held
+/// metadata: the fork point is just a number the consumer wrote down.
+#[test]
+fn layers_persist_across_a_reopen() -> Result<()> {
+    let dir = TempDir::new().unwrap();
+    let fork = {
+        let db = new_cozo_layered(dir.path())?;
+        db.run_script(
+            ":create rec {id: String, at: Validity => val: String}",
+            Default::default(),
+            ScriptMutability::Mutable,
+        )?;
+        db.run_on_stack(
+            "?[id, at, val] <- [['root', 'ASSERT', 'v1']] :put rec {id, at => val}",
+            Default::default(),
+            &base(),
+            None,
+            ScriptMutability::Mutable,
+        )?;
+        db.create_layer("work")?;
+        let fork = db.current_seq()?;
+        db.run_on_stack(
+            "?[id, at, val] <- [['scratch', 'ASSERT', 'v2']] :put rec {id, at => val}",
+            Default::default(),
+            &vec![LayerRef::new("work"), LayerRef::bounded("default", fork)],
+            None,
+            ScriptMutability::Mutable,
+        )?;
+        fork
+    };
+
+    let db = new_cozo_layered(dir.path())?;
+    assert_eq!(
+        db.list_layers()?,
+        vec![LayerId("default".into()), LayerId("work".into())]
+    );
+    let rows = db.run_on_stack(
+        "?[id, val] := *rec{id, val @ 'NOW'}",
+        Default::default(),
+        &vec![LayerRef::new("work"), LayerRef::bounded("default", fork)],
+        None,
+        ScriptMutability::Immutable,
+    )?;
+    assert_eq!(rows.rows.len(), 2);
+    Ok(())
+}
+
+/// A stack naming a layer that is gone fails at construction, not mid-query.
+#[test]
+fn a_missing_layer_fails_at_stack_construction() -> Result<()> {
+    let f = Fixture::new()?;
+    let err = f
+        .live(&vec![LayerRef::new("never-created")], None)
+        .unwrap_err();
+    assert!(format!("{err}").contains("no such layer"), "{err}");
+
+    f.db.create_layer("work")?;
+    f.db.drop_layer("work")?;
+    let err = f.live(&vec![LayerRef::new("work")], None).unwrap_err();
+    assert!(format!("{err}").contains("no such layer"), "{err}");
+    Ok(())
+}
+
+/// The default layer carries the catalog and the existing entry points, so it cannot be
+/// dropped.
+#[test]
+fn the_default_layer_is_protected() -> Result<()> {
+    let f = Fixture::new()?;
+    let err = f.db.drop_layer("default").unwrap_err();
+    assert!(format!("{err}").contains("cannot be dropped"), "{err}");
+    Ok(())
+}
+
+/// A stack that names the same layer twice has no coherent shadowing order, and is refused.
+#[test]
+fn a_layer_cannot_appear_twice_in_one_stack() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db.create_layer("work")?;
+    let err = f
+        .live(&vec![LayerRef::new("work"), LayerRef::new("work")], None)
+        .unwrap_err();
+    assert!(format!("{err}").contains("twice"), "{err}");
+    Ok(())
+}
+
+/// The catalog is global: a relation created through one stack is visible through every
+/// other, while its *contents* stay in the layer that wrote them.
+#[test]
+fn the_catalog_is_global_and_contents_are_local() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db.create_layer("work")?;
+    let fork = f.seq();
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+
+    f.db.run_on_stack(
+        ":create scratch {id: String, at: Validity => val: String}",
+        Default::default(),
+        &work,
+        None,
+        ScriptMutability::Mutable,
+    )?;
+    f.db.run_on_stack(
+        "?[id, at, val] <- [['a', 'ASSERT', 'v']] :put scratch {id, at => val}",
+        Default::default(),
+        &work,
+        None,
+        ScriptMutability::Mutable,
+    )?;
+
+    // Definition visible from the base stack...
+    let from_base = f.db.run_on_stack(
+        "?[id, val] := *scratch{id, val @ 'NOW'}",
+        Default::default(),
+        &base(),
+        None,
+        ScriptMutability::Immutable,
+    )?;
+    // ...contents are not.
+    assert!(from_base.rows.is_empty());
+
+    let from_work = f.db.run_on_stack(
+        "?[id, val] := *scratch{id, val @ 'NOW'}",
+        Default::default(),
+        &work,
+        None,
+        ScriptMutability::Immutable,
+    )?;
+    assert_eq!(from_work.rows.len(), 1);
+    Ok(())
+}
+
+/// Stackability is settled when the relation is created (a validity column or not), and
+/// enforced whenever the relation is reached through a multi-layer stack, before any row is
+/// read. The same relation through a single-layer stack works normally.
+#[test]
+fn a_non_stackable_relation_is_refused_by_a_multi_layer_stack() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db.run_script(
+        ":create plain {k: Int => v: Int}",
+        Default::default(),
+        ScriptMutability::Mutable,
+    )?;
+    f.db.run_script(
+        "?[k, v] <- [[1, 10]] :put plain {k => v}",
+        Default::default(),
+        ScriptMutability::Mutable,
+    )?;
+
+    f.db.create_layer("work")?;
+    let fork = f.seq();
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+
+    // Reading it through the stack fails, and says why.
+    let err = f
+        .db
+        .run_on_stack(
+            "?[k, v] := *plain{k, v}",
+            Default::default(),
+            &work,
+            None,
+            ScriptMutability::Immutable,
+        )
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("no validity column"),
+        "unexpected error: {err:?}"
+    );
+
+    // Writing to it through the stack fails the same way.
+    let err = f
+        .db
+        .run_on_stack(
+            "?[k, v] <- [[2, 20]] :put plain {k => v}",
+            Default::default(),
+            &work,
+            None,
+            ScriptMutability::Mutable,
+        )
+        .unwrap_err();
+    assert!(format!("{err:?}").contains("no validity column"), "{err:?}");
+
+    // Through a single-layer stack it is an ordinary relation.
+    let rows = f.db.run_on_stack(
+        "?[k, v] := *plain{k, v}",
+        Default::default(),
+        &base(),
+        None,
+        ScriptMutability::Immutable,
+    )?;
+    assert_eq!(rows.rows.len(), 1);
+    Ok(())
+}
+
+/// Destructive schema changes need a single-layer stack: through a multi-layer one they
+/// would strike layers the caller is not writing to, since the catalog is global but the rows
+/// are not.
+#[test]
+fn destructive_ddl_needs_a_single_layer_stack() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    f.db.create_layer("work")?;
+    let fork = f.seq();
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+
+    let err = f
+        .db
+        .run_on_stack(
+            "::remove rec",
+            Default::default(),
+            &work,
+            None,
+            ScriptMutability::Mutable,
+        )
+        .unwrap_err();
+    assert!(
+        format!("{err:?}").contains("single-layer stack"),
+        "unexpected error: {err:?}"
+    );
+    // The relation is intact.
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "v1")]));
+
+    // Additive DDL through the same stack is fine: definitions are global and benign (L7).
+    f.db.run_on_stack(
+        ":create added {id: String, at: Validity => val: String}",
+        Default::default(),
+        &work,
+        None,
+        ScriptMutability::Mutable,
+    )?;
+
+    // And through a single-layer stack, removal works.
+    f.db.run_on_stack(
+        "::remove added",
+        Default::default(),
+        &base(),
+        None,
+        ScriptMutability::Mutable,
+    )?;
+    Ok(())
+}
+
+/// Restoring a backup into a layered store is refused when the restored rows carry sequences
+/// the target store's own counter has not reached.
+///
+/// The stamps in a backup come from the sequence space of the store that produced them, and a
+/// fresh store's counter starts near zero. Writing to a store in that state would stamp new
+/// rows *below* restored ones, inverting history and breaking every fork point taken
+/// afterwards. There is no way to fast-forward RocksDB's counter, so this fails loudly instead.
+#[cfg(feature = "storage-sqlite")]
+#[test]
+fn restoring_a_backup_with_higher_sequences_is_refused() -> Result<()> {
+    let source_dir = TempDir::new().unwrap();
+    let backup = TempDir::new().unwrap();
+    let backup_file = backup.path().join("backup.db");
+
+    let source = new_cozo_layered(source_dir.path())?;
+    source.run_script(
+        ":create rec {id: String, at: Validity => val: String}",
+        Default::default(),
+        ScriptMutability::Mutable,
+    )?;
+    for i in 0..50 {
+        source.run_on_stack(
+            &format!("?[id, at, val] <- [['k{i}', 'ASSERT', 'v']] :put rec {{id, at => val}}"),
+            Default::default(),
+            &base(),
+            None,
+            ScriptMutability::Mutable,
+        )?;
+    }
+    source.backup_db(&backup_file)?;
+
+    let target_dir = TempDir::new().unwrap();
+    let target = new_cozo_layered(target_dir.path())?;
+    let err = target.restore_backup(&backup_file).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("sequences up to"),
+        "unexpected error: {err:?}"
+    );
+    Ok(())
+}
+
+/// The existing entry points run against a single-layer stack on the default column family
+/// and behave as they always did.
+#[test]
+fn the_existing_entry_points_still_work() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db.run_script(
+        ":create plain {k: Int => v: Int}",
+        Default::default(),
+        ScriptMutability::Mutable,
+    )?;
+    f.db.run_script(
+        "?[k, v] <- [[1, 10], [2, 20]] :put plain {k => v}",
+        Default::default(),
+        ScriptMutability::Mutable,
+    )?;
+    let rows = f.db.run_script(
+        "?[k, v] := *plain{k, v} :order k",
+        Default::default(),
+        ScriptMutability::Immutable,
+    )?;
+    assert_eq!(rows.rows.len(), 2);
+
+    // A relation with no validity column has no retraction mechanism, so it is only coherent
+    // in a single-layer stack; the multi-layer case is checked in the stackability suite.
+    Ok(())
+}

--- a/cozo-core/src/storage/layered/tests/mod.rs
+++ b/cozo-core/src/storage/layered/tests/mod.rs
@@ -31,6 +31,7 @@ mod immutability;
 mod indexes;
 mod lifecycle;
 mod oracle;
+mod projections;
 mod reads;
 mod restack;
 mod retraction;

--- a/cozo-core/src/storage/layered/tests/mod.rs
+++ b/cozo-core/src/storage/layered/tests/mod.rs
@@ -1,0 +1,192 @@
+/*
+ * Layered storage test harness.
+ *
+ * Two conventions matter throughout:
+ *
+ * *Never hardcode sequence numbers.* They are sparse, because the counter advances on every
+ * write to the instance and not only ours, so every expectation is derived from a stamp the
+ * test read back
+ * out of the store or captured from `current_seq()`.
+ *
+ * *Say which equivalence is meant.* `live()` compares frontiers: what a stack resolves to now.
+ * `versions()` compares histories: every row, with its stamp. Restamping breaks history
+ * equivalence by design, so tests that restamp compare frontiers only.
+ */
+
+use std::collections::BTreeMap;
+
+use miette::Result;
+use tempfile::TempDir;
+
+use crate::data::value::DataValue;
+use crate::runtime::db::ScriptMutability;
+use crate::storage::layered::{new_cozo_layered, LayerRef, LayeredStorage, Seq, Stack};
+use crate::Db;
+
+mod concurrency;
+mod crash;
+mod flatten;
+mod functional;
+mod immutability;
+mod indexes;
+mod lifecycle;
+mod oracle;
+mod reads;
+mod restack;
+mod retraction;
+mod sequences;
+mod three_way;
+mod windows;
+
+/// One row as the store holds it: key, stamp, whether it asserts, and its value.
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub(crate) struct Version {
+    pub id: String,
+    pub seq: Seq,
+    pub assertive: bool,
+    pub val: String,
+}
+
+pub(crate) struct Fixture {
+    _dir: TempDir,
+    pub db: Db<LayeredStorage>,
+}
+
+/// The default layer, unwindowed: the base of every fixture.
+pub(crate) fn base() -> Stack {
+    vec![LayerRef::new("default")]
+}
+
+impl Fixture {
+    /// A store holding one stackable relation, `rec`: UUID-shaped string keys, opaque values.
+    pub(crate) fn new() -> Result<Fixture> {
+        let dir = TempDir::new().unwrap();
+        let db = new_cozo_layered(dir.path())?;
+        db.run_script(
+            ":create rec {id: String, at: Validity => val: String}",
+            Default::default(),
+            ScriptMutability::Mutable,
+        )?;
+        Ok(Fixture { _dir: dir, db })
+    }
+
+    pub(crate) fn seq(&self) -> Seq {
+        self.db.current_seq().unwrap()
+    }
+
+    fn run(
+        &self,
+        script: &str,
+        params: BTreeMap<String, DataValue>,
+        stack: &Stack,
+        at: Option<Seq>,
+        mutability: ScriptMutability,
+    ) -> Result<crate::NamedRows> {
+        self.db.run_on_stack(script, params, stack, at, mutability)
+    }
+
+    /// Create a record through `stack`. Returns the sequence it was stamped with.
+    pub(crate) fn assert_rec(&self, stack: &Stack, id: &str, val: &str) -> Result<Seq> {
+        let mut params = BTreeMap::new();
+        params.insert("id".to_string(), DataValue::from(id));
+        params.insert("val".to_string(), DataValue::from(val));
+        self.run(
+            "?[id, at, val] <- [[$id, 'ASSERT', $val]] :put rec {id, at => val}",
+            params,
+            stack,
+            None,
+            ScriptMutability::Mutable,
+        )?;
+        // Read the stamp back rather than computing it: the test must not encode the stamping
+        // rule it is there to check.
+        let newest = self
+            .versions(stack)?
+            .into_iter()
+            .filter(|v| v.id == id)
+            .map(|v| v.seq)
+            .max()
+            .expect("the row just written is not there");
+        Ok(newest)
+    }
+
+    /// Retract a record through `stack`. Returns the sequence of the retraction.
+    pub(crate) fn retract_rec(&self, stack: &Stack, id: &str) -> Result<Seq> {
+        let mut params = BTreeMap::new();
+        params.insert("id".to_string(), DataValue::from(id));
+        self.run(
+            "?[id, at, val] <- [[$id, 'RETRACT', '']] :put rec {id, at => val}",
+            params,
+            stack,
+            None,
+            ScriptMutability::Mutable,
+        )?;
+        let newest = self
+            .versions(stack)?
+            .into_iter()
+            .filter(|v| v.id == id)
+            .map(|v| v.seq)
+            .max()
+            .expect("the retraction just written is not there");
+        Ok(newest)
+    }
+
+    /// The frontier through `stack`: what resolves live, optionally as of `at`.
+    pub(crate) fn live(&self, stack: &Stack, at: Option<Seq>) -> Result<BTreeMap<String, String>> {
+        let rows = self.run(
+            "?[id, val] := *rec{id, val @ 'NOW'}",
+            Default::default(),
+            stack,
+            at,
+            ScriptMutability::Immutable,
+        )?;
+        Ok(rows
+            .rows
+            .into_iter()
+            .map(|row| (as_str(&row[0]), as_str(&row[1])))
+            .collect())
+    }
+
+    /// Every version visible through `stack`, retractions included: the history, not the frontier.
+    pub(crate) fn versions(&self, stack: &Stack) -> Result<Vec<Version>> {
+        let rows = self.run(
+            "?[id, at, val] := *rec{id, at, val}",
+            Default::default(),
+            stack,
+            None,
+            ScriptMutability::Immutable,
+        )?;
+        let mut ret: Vec<Version> = rows
+            .rows
+            .into_iter()
+            .map(|row| {
+                let (seq, assertive) = match &row[1] {
+                    DataValue::Validity(v) => (v.timestamp.0 .0, v.is_assert.0),
+                    other => panic!("expected a validity, got {:?}", other),
+                };
+                Version {
+                    id: as_str(&row[0]),
+                    seq,
+                    assertive,
+                    val: as_str(&row[2]),
+                }
+            })
+            .collect();
+        ret.sort();
+        Ok(ret)
+    }
+}
+
+pub(crate) fn as_str(v: &DataValue) -> String {
+    match v {
+        DataValue::Str(s) => s.to_string(),
+        other => panic!("expected a string, got {:?}", other),
+    }
+}
+
+/// `{"k" => "v", ...}`, for comparing against [`Fixture::live`].
+pub(crate) fn frontier(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+}

--- a/cozo-core/src/storage/layered/tests/oracle.rs
+++ b/cozo-core/src/storage/layered/tests/oracle.rs
@@ -1,0 +1,510 @@
+/*
+ * A differential oracle, and the algebraic properties it makes testable.
+ *
+ * The model below is a deliberately naive restatement of the stack-resolution and flatten rules
+ * over ordered maps: no iterators, no encoding, no seeks, no windows expressed as byte ranges.
+ * That is the point. It shares the *rules* with the engine but none of the machinery, so what
+ * it catches is machinery: a seek that lands one row early, a window applied to the wrong
+ * layer, a merge that drops the last key of a range.
+ *
+ * It cannot catch a misreading of the rules that both implementations share. The explicit
+ * cases in the sibling modules are what stand behind that.
+ */
+
+use std::collections::BTreeMap;
+
+use miette::Result;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+use super::{base, Fixture};
+use crate::storage::layered::{LayerRef, Seq, Stack};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Row {
+    seq: Seq,
+    assertive: bool,
+    val: String,
+}
+
+/// A window, as the model sees it: an exclusive floor and an inclusive ceiling.
+#[derive(Copy, Clone, Debug, Default)]
+struct Win {
+    since: Option<Seq>,
+    bound: Option<Seq>,
+}
+
+impl Win {
+    fn admits(&self, seq: Seq, at: Option<Seq>) -> bool {
+        if let Some(since) = self.since {
+            if seq <= since {
+                return false;
+            }
+        }
+        // Two independent ceilings, composed by `min`: the layer's and the query's.
+        let ceiling = match (self.bound, at) {
+            (Some(b), Some(a)) => Some(b.min(a)),
+            (Some(b), None) => Some(b),
+            (None, Some(a)) => Some(a),
+            (None, None) => None,
+        };
+        match ceiling {
+            Some(c) => seq <= c,
+            None => true,
+        }
+    }
+}
+
+type View = Vec<(String, Win)>;
+
+#[derive(Default)]
+struct Model {
+    /// layer -> key -> versions, in no particular order.
+    layers: BTreeMap<String, BTreeMap<String, Vec<Row>>>,
+}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+struct ModelStats {
+    copied: u64,
+    deduped: u64,
+    dropped: u64,
+}
+
+impl Model {
+    fn layer(&mut self, name: &str) -> &mut BTreeMap<String, Vec<Row>> {
+        self.layers.entry(name.to_string()).or_default()
+    }
+
+    fn write(&mut self, layer: &str, id: &str, row: Row) {
+        self.layer(layer).entry(id.to_string()).or_default().push(row);
+    }
+
+    /// The winning version of every key through a view: newest by sequence, and on a tie the
+    /// one from the higher layer.
+    fn resolve(&self, view: &View, at: Option<Seq>) -> BTreeMap<String, Row> {
+        let mut best: BTreeMap<String, (usize, Row)> = BTreeMap::new();
+        for (idx, (name, win)) in view.iter().enumerate() {
+            let Some(layer) = self.layers.get(name) else {
+                continue;
+            };
+            for (id, versions) in layer {
+                for row in versions {
+                    if !win.admits(row.seq, at) {
+                        continue;
+                    }
+                    let better = match best.get(id) {
+                        None => true,
+                        Some((best_idx, best_row)) => {
+                            row.seq > best_row.seq || (row.seq == best_row.seq && idx < *best_idx)
+                        }
+                    };
+                    if better {
+                        best.insert(id.clone(), (idx, row.clone()));
+                    }
+                }
+            }
+        }
+        best.into_iter().map(|(id, (_, row))| (id, row)).collect()
+    }
+
+    fn live(&self, view: &View, at: Option<Seq>) -> BTreeMap<String, String> {
+        self.resolve(view, at)
+            .into_iter()
+            .filter(|(_, row)| row.assertive)
+            .map(|(id, row)| (id, row.val))
+            .collect()
+    }
+
+    /// Whether a key is live through a view, and the value it was last asserted with.
+    fn key_state(&self, view: &View, id: &str) -> (bool, Option<String>) {
+        let mut versions: Vec<(usize, &Row)> = vec![];
+        for (idx, (name, win)) in view.iter().enumerate() {
+            let Some(rows) = self.layers.get(name).and_then(|l| l.get(id)) else {
+                continue;
+            };
+            for row in rows {
+                if win.admits(row.seq, None) {
+                    versions.push((idx, row));
+                }
+            }
+        }
+        // Newest first; on a tie the higher layer.
+        versions.sort_by(|a, b| b.1.seq.cmp(&a.1.seq).then(a.0.cmp(&b.0)));
+        let live = versions.first().map(|(_, r)| r.assertive).unwrap_or(false);
+        let asserted = versions
+            .iter()
+            .find(|(_, r)| r.assertive)
+            .map(|(_, r)| r.val.clone());
+        (live, asserted)
+    }
+
+    /// The net effect of `src` materialized into `dst`'s top layer, at sequence `seq`.
+    /// `Err` means the flatten must fail on a value collision.
+    fn flatten(
+        &mut self,
+        src: &View,
+        dst: &View,
+        restamp: bool,
+        seq: Seq,
+    ) -> std::result::Result<ModelStats, String> {
+        let net = self.resolve(src, None);
+        let mut stats = ModelStats::default();
+        let mut writes = vec![];
+        for (id, row) in net {
+            let (live, asserted) = self.key_state(dst, &id);
+            if row.assertive {
+                match asserted {
+                    Some(ref existing) if *existing != row.val => {
+                        return Err(format!("collision on {id}"))
+                    }
+                    Some(_) if live => {
+                        stats.deduped += 1;
+                        continue;
+                    }
+                    _ => writes.push((id, row)),
+                }
+            } else if live {
+                writes.push((id, row));
+            } else {
+                stats.dropped += 1;
+            }
+        }
+        let top = dst[0].0.clone();
+        for (id, row) in writes {
+            stats.copied += 1;
+            self.write(
+                &top,
+                &id,
+                Row {
+                    seq: if restamp { seq } else { row.seq },
+                    ..row
+                },
+            );
+        }
+        Ok(stats)
+    }
+}
+
+/// The store and the model, driven in lockstep.
+struct Pair {
+    f: Fixture,
+    model: Model,
+    /// Every key's one immutable value: records are created and deleted, never updated.
+    values: BTreeMap<String, String>,
+    /// Fork points, so a branch's stack can be rebuilt at any time.
+    forks: BTreeMap<String, Seq>,
+    log: Vec<String>,
+}
+
+fn view_of(stack: &Stack) -> View {
+    stack
+        .iter()
+        .map(|l| {
+            (
+                l.id.0.clone(),
+                Win {
+                    since: l.since,
+                    bound: l.bound,
+                },
+            )
+        })
+        .collect()
+}
+
+impl Pair {
+    fn new() -> Result<Pair> {
+        Ok(Pair {
+            f: Fixture::new()?,
+            model: Model::default(),
+            values: BTreeMap::new(),
+            forks: BTreeMap::new(),
+            log: vec![],
+        })
+    }
+
+    fn branch(&mut self, name: &str) -> Result<Stack> {
+        self.f.db.create_layer(name)?;
+        let fork = self.f.seq();
+        self.forks.insert(name.to_string(), fork);
+        self.log.push(format!("branch {name} @ {fork}"));
+        Ok(self.stack_of(name))
+    }
+
+    fn stack_of(&self, name: &str) -> Stack {
+        if name == "default" {
+            return base();
+        }
+        vec![
+            LayerRef::new(name),
+            LayerRef::bounded("default", self.forks[name]),
+        ]
+    }
+
+    fn assert_rec(&mut self, layer: &str, id: &str) -> Result<()> {
+        let stack = self.stack_of(layer);
+        let val = self
+            .values
+            .entry(id.to_string())
+            .or_insert_with(|| format!("val-of-{id}"))
+            .clone();
+        self.log.push(format!("assert {id} in {layer}"));
+        let seq = self.f.assert_rec(&stack, id, &val)?;
+        self.model.write(
+            layer,
+            id,
+            Row {
+                seq,
+                assertive: true,
+                val,
+            },
+        );
+        Ok(())
+    }
+
+    fn retract_rec(&mut self, layer: &str, id: &str) -> Result<()> {
+        let stack = self.stack_of(layer);
+        self.log.push(format!("retract {id} in {layer}"));
+        let seq = self.f.retract_rec(&stack, id)?;
+        self.model.write(
+            layer,
+            id,
+            Row {
+                seq,
+                assertive: false,
+                val: String::new(),
+            },
+        );
+        Ok(())
+    }
+
+    fn merge_down(&mut self, layer: &str) -> Result<()> {
+        let src = vec![LayerRef::new(layer)];
+        self.log.push(format!("merge {layer} down"));
+        let stats = self.f.db.flatten(&src, &base(), true)?;
+        let seq = stats
+            .seq_range
+            .expect("a restamping flatten reports its sequence")
+            .0;
+        let modelled = self
+            .model
+            .flatten(&view_of(&src), &view_of(&base()), true, seq)
+            .map_err(|e| miette::miette!("the model expected this flatten to fail: {e}"))?;
+        assert_eq!(
+            (stats.rows_copied, stats.rows_deduped, stats.tombstones_dropped),
+            (modelled.copied, modelled.deduped, modelled.dropped),
+            "flatten stats diverged\n{}",
+            self.log.join("\n")
+        );
+        Ok(())
+    }
+
+    /// Compare every stack the scenario can name, at the frontier and at a historical bound.
+    fn check(&self, at: Option<Seq>) -> Result<()> {
+        let mut stacks = vec![base()];
+        for name in self.forks.keys() {
+            stacks.push(self.stack_of(name));
+        }
+        for stack in stacks {
+            let expected = self.model.live(&view_of(&stack), at);
+            let actual = self.f.live(&stack, at)?;
+            assert_eq!(
+                actual,
+                expected,
+                "the store and the model disagree on stack {stack:?} at {at:?}\n{}",
+                self.log.join("\n")
+            );
+        }
+        Ok(())
+    }
+}
+
+/// The randomized driver: arbitrary legal operation sequences against the store and the
+/// model at once, with every read compared. The explicit cases cover the situations worth
+/// naming; this covers the ones nobody thought to name.
+#[test]
+fn randomized_operations_match_the_model() -> Result<()> {
+    for seed in 0..24u64 {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut p = Pair::new()?;
+        p.branch("a")?;
+        p.branch("b")?;
+        let layers = ["default", "a", "b"];
+        let ids: Vec<String> = (0..6).map(|i| format!("k{i}")).collect();
+        let mut checkpoints: Vec<Seq> = vec![];
+
+        for step in 0..40 {
+            let layer = layers[rng.gen_range(0..layers.len())];
+            let id = &ids[rng.gen_range(0..ids.len())];
+            match rng.gen_range(0..10) {
+                0..=4 => p.assert_rec(layer, id)?,
+                5..=7 => p.retract_rec(layer, id)?,
+                8 => {
+                    // Merging a branch down is legal at any point; the branch keeps its own
+                    // fork, so it goes on reading its own view afterwards.
+                    let branch = if rng.gen() { "a" } else { "b" };
+                    p.merge_down(branch)?;
+                }
+                _ => checkpoints.push(p.f.seq()),
+            }
+            if step % 4 == 0 {
+                p.check(None)?;
+            }
+        }
+
+        p.check(None)?;
+        for at in checkpoints {
+            p.check(Some(at))?;
+        }
+    }
+    Ok(())
+}
+
+/// Merging the same layer twice is merging it once.
+#[test]
+fn merging_is_idempotent() -> Result<()> {
+    for seed in 0..8u64 {
+        let mut rng = StdRng::seed_from_u64(seed);
+        let mut p = Pair::new()?;
+        p.branch("a")?;
+        for _ in 0..12 {
+            let id = format!("k{}", rng.gen_range(0..5));
+            let layer = if rng.gen() { "default" } else { "a" };
+            if rng.gen_range(0..3) == 0 {
+                p.retract_rec(layer, &id)?;
+            } else {
+                p.assert_rec(layer, &id)?;
+            }
+        }
+        p.merge_down("a")?;
+        let once = p.f.live(&base(), None)?;
+        p.merge_down("a")?;
+        assert_eq!(p.f.live(&base(), None)?, once);
+        p.check(None)?;
+    }
+    Ok(())
+}
+
+/// Merging two branches commutes whenever no key is retracted in one and asserted in the
+/// other. With keys that are collision-free by construction, that is the ordinary case.
+#[test]
+fn disjoint_merges_commute() -> Result<()> {
+    fn build(order: [&str; 2]) -> Result<BTreeMap<String, String>> {
+        let f = Fixture::new()?;
+        f.assert_rec(&base(), "shared", "v0")?;
+        f.db.create_layer("a")?;
+        f.db.create_layer("b")?;
+        let fork = f.seq();
+        let a: Stack = vec![LayerRef::new("a"), LayerRef::bounded("default", fork)];
+        let b: Stack = vec![LayerRef::new("b"), LayerRef::bounded("default", fork)];
+
+        f.assert_rec(&a, "only-a", "va")?;
+        f.retract_rec(&a, "shared")?;
+        f.assert_rec(&b, "only-b", "vb")?;
+
+        for name in order {
+            f.db.flatten(&vec![LayerRef::new(name)], &base(), true)?;
+        }
+        f.live(&base(), None)
+    }
+
+    assert_eq!(build(["a", "b"])?, build(["b", "a"])?);
+    Ok(())
+}
+
+/// The documented non-property.
+///
+/// One branch retracts a key the base holds; the other re-asserts it. Merging A then B leaves
+/// the key live; B then A leaves it dead, because B's assertion dedupes against a row that is
+/// still live and then A's tombstone lands on it. Merge order is semantics, exactly as it is
+/// in git. This test exists so that nobody "fixes" one ordering into the other.
+#[test]
+fn delete_and_reintroduce_merges_do_not_commute() -> Result<()> {
+    fn build(order: [&str; 2]) -> Result<BTreeMap<String, String>> {
+        let f = Fixture::new()?;
+        f.assert_rec(&base(), "k", "v1")?;
+        f.db.create_layer("deleter")?;
+        f.db.create_layer("keeper")?;
+        let fork = f.seq();
+        let deleter: Stack = vec![LayerRef::new("deleter"), LayerRef::bounded("default", fork)];
+        let keeper: Stack = vec![LayerRef::new("keeper"), LayerRef::bounded("default", fork)];
+
+        f.retract_rec(&deleter, "k")?;
+        f.assert_rec(&keeper, "k", "v1")?;
+
+        for name in order {
+            f.db.flatten(&vec![LayerRef::new(name)], &base(), true)?;
+        }
+        f.live(&base(), None)
+    }
+
+    // Deleter first: the keeper's assertion lands on a dead key and revives it.
+    assert_eq!(build(["deleter", "keeper"])?, super::frontier(&[("k", "v1")]));
+    // Keeper first: its assertion dedupes against the still-live row, so nothing is written,
+    // and the deleter's tombstone then bites.
+    assert_eq!(build(["keeper", "deleter"])?, super::frontier(&[]));
+    Ok(())
+}
+
+/// Fork, work, merge down, drop is the same as doing the work directly on a quiescent base.
+#[test]
+fn a_fork_merge_round_trip_matches_direct_work() -> Result<()> {
+    let direct = {
+        let f = Fixture::new()?;
+        f.assert_rec(&base(), "seeded", "v0")?;
+        f.assert_rec(&base(), "added", "v1")?;
+        f.assert_rec(&base(), "added2", "v2")?;
+        f.retract_rec(&base(), "seeded")?;
+        f.live(&base(), None)?
+    };
+    let forked = {
+        let f = Fixture::new()?;
+        f.assert_rec(&base(), "seeded", "v0")?;
+        f.db.create_layer("work")?;
+        let fork = f.seq();
+        let stack: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+        f.assert_rec(&stack, "added", "v1")?;
+        f.assert_rec(&stack, "added2", "v2")?;
+        f.retract_rec(&stack, "seeded")?;
+        f.db.flatten(&vec![LayerRef::new("work")], &base(), true)?;
+        f.db.drop_layer("work")?;
+        f.live(&base(), None)?
+    };
+    assert_eq!(direct, forked);
+    Ok(())
+}
+
+/// Picking a window and then reverting it leaves the frontier where it started. Tombstone
+/// counts differ (the history remembers both moves), but the frontier must not.
+#[test]
+fn a_pick_and_its_revert_cancel() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "existing", "v0")?;
+    let start = f.seq();
+    let before = f.live(&base(), None)?;
+
+    f.db.create_layer("source")?;
+    let source: Stack = vec![LayerRef::new("source"), LayerRef::bounded("default", start)];
+    f.assert_rec(&source, "picked", "v1")?;
+    f.retract_rec(&source, "existing")?;
+
+    // Pick the whole branch into the base...
+    f.db.flatten(&vec![LayerRef::new("source")], &base(), true)?;
+    assert_eq!(f.live(&base(), None)?, super::frontier(&[("picked", "v1")]));
+
+    // ...then revert it: retract what it asserted, re-assert what it retracted.
+    for change in f.versions(&vec![LayerRef::new("source")])? {
+        if change.assertive {
+            f.retract_rec(&base(), &change.id)?;
+        } else {
+            let pre_image = f
+                .versions(&vec![LayerRef::bounded("default", start)])?
+                .into_iter()
+                .find(|v| v.id == change.id && v.assertive)
+                .expect("a retraction must have had something to retract");
+            f.assert_rec(&base(), &change.id, &pre_image.val)?;
+        }
+    }
+
+    assert_eq!(f.live(&base(), None)?, before);
+    Ok(())
+}

--- a/cozo-core/src/storage/layered/tests/projections.rs
+++ b/cozo-core/src/storage/layered/tests/projections.rs
@@ -1,0 +1,301 @@
+/*
+ * Cached graph projections through a stack.
+ *
+ * A projection is an in-memory adjacency built from a relation and reused across algorithm
+ * calls. Its guarantee is that it never serves data differing from what the consuming
+ * transaction's own scan would return, and the protocol behind that reasons entirely about
+ * *mutation*: a relation's content version changes when someone writes it.
+ *
+ * A stack breaks that assumption without writing anything. Two transactions over the same
+ * relation, no write between them, see different content because they compose different
+ * layers. The cache therefore keys on the view as well, and these tests pin both halves: that
+ * a stack is never served another stack's graph, and that keying on the view did not simply
+ * turn caching off.
+ */
+
+use miette::Result;
+
+use super::{base, Fixture};
+use crate::runtime::db::ScriptMutability::{Immutable, Mutable};
+use crate::storage::layered::{LayerRef, Stack};
+
+/// An edge relation that a multi-layer stack is allowed to read: its last key column is a
+/// validity, so it can express a cross-layer retraction.
+const EDGES: &str = ":create knows {a: Int, b: Int, at: Validity}";
+
+fn link(f: &Fixture, stack: &Stack, a: i64, b: i64) -> Result<()> {
+    f.db.run_on_stack(
+        &format!("?[a, b, at] <- [[{a}, {b}, 'ASSERT']] :put knows {{a, b, at}}"),
+        Default::default(),
+        stack,
+        None,
+        Mutable,
+    )?;
+    Ok(())
+}
+
+/// Nodes reachable through the named projection, which is what an algorithm consuming it sees.
+fn nodes_via_projection(f: &Fixture, stack: &Stack) -> Result<usize> {
+    Ok(f.db
+        .run_on_stack(
+            "?[n, c] <~ ConnectedComponents(graph: 'g')",
+            Default::default(),
+            stack,
+            None,
+            Immutable,
+        )?
+        .rows
+        .len())
+}
+
+/// Two branches of one relation, and a projection over it.
+fn two_branches(f: &Fixture) -> Result<(Stack, Stack, i64)> {
+    f.db.run_script(EDGES, Default::default(), Mutable)?;
+    link(f, &base(), 1, 2)?;
+    let fork = f.seq();
+    f.db.create_layer("work")?;
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+    link(f, &work, 3, 4)?;
+    f.db.run_on_stack(
+        "::graph create g {edges: knows}",
+        Default::default(),
+        &base(),
+        None,
+        Mutable,
+    )?;
+    Ok((base(), work, fork))
+}
+
+/// The base's graph is one edge over two nodes; the branch's is that plus its own, over four.
+/// Each stack must get its own, whichever asks first.
+#[test]
+fn a_stack_is_never_served_another_stacks_graph() -> Result<()> {
+    let f = Fixture::new()?;
+    let (base_stack, work, _) = two_branches(&f)?;
+
+    // Base first, so the branch is the one that would have taken a stale hit.
+    assert_eq!(nodes_via_projection(&f, &base_stack)?, 2);
+    assert_eq!(
+        nodes_via_projection(&f, &work)?,
+        4,
+        "the branch was served the base's graph"
+    );
+
+    // And in the other order, on a fresh store: whoever builds first must not poison the other.
+    let g = Fixture::new()?;
+    let (base_stack, work, _) = two_branches(&g)?;
+    assert_eq!(nodes_via_projection(&g, &work)?, 4);
+    assert_eq!(
+        nodes_via_projection(&g, &base_stack)?,
+        2,
+        "the base was served the branch's graph"
+    );
+    Ok(())
+}
+
+/// Keying on the view must not amount to switching caching off: a second query on the same
+/// stack still reuses what the first one built.
+#[test]
+fn a_stack_reuses_its_own_cached_projection() -> Result<()> {
+    let f = Fixture::new()?;
+    let (base_stack, work, _) = two_branches(&f)?;
+
+    nodes_via_projection(&f, &base_stack)?;
+    nodes_via_projection(&f, &work)?;
+    let after_first_pass = f.db.graph_projections.build_count();
+
+    nodes_via_projection(&f, &base_stack)?;
+    nodes_via_projection(&f, &work)?;
+    assert_eq!(
+        f.db.graph_projections.build_count(),
+        after_first_pass,
+        "a repeated query on an unchanged stack rebuilt instead of hitting the cache"
+    );
+    Ok(())
+}
+
+/// A layer name is reusable, so a dropped and recreated layer is a different layer holding
+/// different content. Nothing is written to the relation across the recreate, so the mutation
+/// half of the protocol cannot tell the two apart and would serve the dead layer's graph. The
+/// generation carried in the view identity is the only thing that distinguishes them.
+#[test]
+fn a_recreated_layer_does_not_inherit_the_old_ones_graph() -> Result<()> {
+    let f = Fixture::new()?;
+    let (_, work, fork) = two_branches(&f)?;
+    assert_eq!(nodes_via_projection(&f, &work)?, 4, "the branch's own graph");
+
+    // Replace the layer. Deliberately write nothing afterwards: a write would bump the
+    // relation's content version and invalidate the entry through the mutation axis, which
+    // would hide whether the view identity did its job.
+    f.db.drop_layer("work")?;
+    f.db.create_layer("work")?;
+    // The same name and the same window as before, so the generation is the only thing that
+    // differs between the dead layer's view identity and the new one's.
+    let reborn: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+
+    assert_eq!(
+        nodes_via_projection(&f, &reborn)?,
+        2,
+        "an empty new layer over the base should see only the base's edge; it was served the \
+         graph of the layer it replaced"
+    );
+    Ok(())
+}
+
+/// Distinct stacks must have distinct identities even when a layer name looks like the
+/// rendering of another stack.
+///
+/// The identity is structured, so this cannot fail by construction. It is here because an
+/// earlier version encoded the stack into one string, and a layer named after that encoding's
+/// separators reproduced another stack's identity exactly, after a reopen. The test pins the
+/// representation against regressing to anything with an encoding to forge.
+#[test]
+fn a_layer_name_cannot_forge_another_stacks_identity() -> Result<()> {
+    use crate::storage::layered::new_cozo_layered;
+    use crate::storage::{Storage, StorageView, StoreTx};
+
+    let dir = tempfile::TempDir::new().unwrap();
+    {
+        let db = new_cozo_layered(dir.path())?;
+        db.create_layer("a#0;b")?;
+        db.create_layer("a")?;
+        db.create_layer("b")?;
+    }
+    let db = new_cozo_layered(dir.path())?;
+    let view_of = |stack: &Stack| -> Result<StorageView> {
+        let spec = db.db.resolve(stack)?;
+        let bound = db.db.with_stack(spec);
+        let tx = bound.transact(false)?;
+        Ok(tx.storage_view())
+    };
+
+    let forged: Stack = vec![LayerRef::new("a#0;b")];
+    let genuine: Stack = vec![LayerRef::new("a"), LayerRef::new("b")];
+    assert_ne!(
+        view_of(&forged)?,
+        view_of(&genuine)?,
+        "a layer name reproduced another stack's view identity"
+    );
+    Ok(())
+}
+
+/// Two stacks over the same layers at the same generations, differing only in what their
+/// windows admit, are different views and must not share a cached graph.
+#[test]
+fn stacks_differing_only_by_window_are_different_views() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db.run_script(EDGES, Default::default(), Mutable)?;
+    link(&f, &base(), 1, 2)?;
+    let early = f.seq();
+    link(&f, &base(), 3, 4)?;
+    f.db.run_on_stack(
+        "::graph create g {edges: knows}",
+        Default::default(),
+        &base(),
+        None,
+        Mutable,
+    )?;
+
+    // Same layer, same generation; only the ceiling differs.
+    let clipped: Stack = vec![LayerRef::bounded("default", early)];
+    let whole: Stack = vec![LayerRef::new("default")];
+    assert_eq!(nodes_via_projection(&f, &whole)?, 4);
+    assert_eq!(
+        nodes_via_projection(&f, &clipped)?,
+        2,
+        "a bounded stack was served the unbounded stack's graph"
+    );
+    Ok(())
+}
+
+/// A lone unwindowed default layer is the whole store, which is the view every non-layered
+/// engine presents. Reporting it as such costs nothing to build and lets the ordinary path
+/// share cache entries with plain `run_script`, which reads exactly the same rows.
+#[test]
+fn the_plain_default_stack_is_the_global_view() -> Result<()> {
+    use crate::storage::{Storage, StorageView, StoreTx};
+
+    let f = Fixture::new()?;
+    f.db.run_script(EDGES, Default::default(), Mutable)?;
+    link(&f, &base(), 1, 2)?;
+    let fork = f.seq();
+    f.db.create_layer("work")?;
+
+    let view_of = |stack: &Stack| -> Result<StorageView> {
+        let spec = f.db.db.resolve(stack)?;
+        let bound = f.db.db.with_stack(spec);
+        let tx = bound.transact(false)?;
+        Ok(tx.storage_view())
+    };
+
+    assert_eq!(view_of(&base())?, StorageView::undivided());
+    // Anything else is a composed view, distinct from GLOBAL and from each other.
+    let bounded = view_of(&vec![LayerRef::bounded("default", fork)])?;
+    let stacked = view_of(&vec![
+        LayerRef::new("work"),
+        LayerRef::bounded("default", fork),
+    ])?;
+    assert_ne!(bounded, StorageView::undivided());
+    assert_ne!(stacked, StorageView::undivided());
+    assert_ne!(bounded, stacked);
+    Ok(())
+}
+
+/// The behavioural half of the above: a projection built through plain `run_script` is reused
+/// by an explicit read of the same default stack, rather than rebuilt under a second identity.
+#[test]
+fn plain_and_explicit_reads_of_the_default_share_a_projection() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db.run_script(EDGES, Default::default(), Mutable)?;
+    link(&f, &base(), 1, 2)?;
+    f.db.run_script(
+        "::graph create g {edges: knows}",
+        Default::default(),
+        Mutable,
+    )?;
+
+    f.db.run_script(
+        "?[n, c] <~ ConnectedComponents(graph: 'g')",
+        Default::default(),
+        Immutable,
+    )?;
+    let after_plain = f.db.graph_projections.build_count();
+
+    nodes_via_projection(&f, &base())?;
+    assert_eq!(
+        f.db.graph_projections.build_count(),
+        after_plain,
+        "an explicit read of the default stack rebuilt what plain run_script had already built"
+    );
+    Ok(())
+}
+
+/// Every layer gets its own incarnation, including the ones already on disk when the store
+/// opens. A shared value would make two layers indistinguishable to anything keyed on the
+/// view, which is the whole point of carrying one.
+#[test]
+fn layers_present_at_open_get_distinct_incarnations() -> Result<()> {
+    use crate::storage::layered::new_cozo_layered;
+    use crate::storage::{Storage, StorageView, StoreTx};
+
+    let dir = tempfile::TempDir::new().unwrap();
+    {
+        let db = new_cozo_layered(dir.path())?;
+        db.create_layer("one")?;
+        db.create_layer("two")?;
+    }
+    let db = new_cozo_layered(dir.path())?;
+    let view_of = |stack: &Stack| -> Result<StorageView> {
+        let spec = db.db.resolve(stack)?;
+        let bound = db.db.with_stack(spec);
+        let tx = bound.transact(false)?;
+        Ok(tx.storage_view())
+    };
+
+    assert_ne!(
+        view_of(&vec![LayerRef::new("one")])?,
+        view_of(&vec![LayerRef::new("two")])?,
+        "two layers that existed before the store opened share an incarnation"
+    );
+    Ok(())
+}

--- a/cozo-core/src/storage/layered/tests/reads.rs
+++ b/cozo-core/src/storage/layered/tests/reads.rs
@@ -1,0 +1,234 @@
+/*
+ * Point reads, shadowing, and the merge iterator.
+ */
+
+use miette::Result;
+
+use super::{base, frontier, Fixture};
+use crate::runtime::db::ScriptMutability;
+use crate::storage::layered::{LayerRef, Stack};
+
+/// Three layers, `top` over `mid` over `default`, all unwindowed.
+///
+/// Windows are exercised in their own suite; leaving them open here keeps these tests about
+/// shadowing and merge order alone, and lets a write to any layer happen at any point.
+fn three_layers(f: &Fixture) -> Result<(Stack, Stack, Stack)> {
+    f.db.create_layer("mid")?;
+    f.db.create_layer("top")?;
+    let base_stack = base();
+    let mid: Stack = vec![LayerRef::new("mid"), LayerRef::new("default")];
+    let top: Stack = vec![
+        LayerRef::new("top"),
+        LayerRef::new("mid"),
+        LayerRef::new("default"),
+    ];
+    Ok((base_stack, mid, top))
+}
+
+/// A key held in any single position of the stack resolves, with the right value.
+#[test]
+fn a_key_resolves_from_any_position() -> Result<()> {
+    let f = Fixture::new()?;
+    let (base_stack, mid, top) = three_layers(&f)?;
+    f.assert_rec(&base_stack, "bottom", "v1")?;
+    f.assert_rec(&mid, "middle", "v2")?;
+    f.assert_rec(&top, "upper", "v3")?;
+
+    assert_eq!(
+        f.live(&top, None)?,
+        frontier(&[("bottom", "v1"), ("middle", "v2"), ("upper", "v3")])
+    );
+    Ok(())
+}
+
+/// A key absent from every layer is absent, and no neighbouring key leaks in.
+#[test]
+fn an_absent_key_stays_absent() -> Result<()> {
+    let f = Fixture::new()?;
+    let (base_stack, mid, top) = three_layers(&f)?;
+    f.assert_rec(&base_stack, "aa", "v1")?;
+    f.assert_rec(&mid, "ac", "v2")?;
+
+    let rows = f.db.run_on_stack(
+        "?[val] := *rec{id: 'ab', val @ 'NOW'}",
+        Default::default(),
+        &top,
+        None,
+        ScriptMutability::Immutable,
+    )?;
+    assert!(rows.rows.is_empty(), "a neighbouring key leaked in");
+    Ok(())
+}
+
+/// Keys interleaved across three layers emit in key order, and a key several layers
+/// hold emits exactly once.
+///
+/// Value immutability means two layers can never legitimately disagree about a
+/// key's *value*, so "the topmost layer wins" is observable as deduplication here and as
+/// precedence in the retraction case below, never as one value beating another.
+#[test]
+fn a_scan_merges_in_key_order_and_emits_each_key_once() -> Result<()> {
+    let f = Fixture::new()?;
+    let (base_stack, mid, top) = three_layers(&f)?;
+    f.assert_rec(&base_stack, "a", "va")?;
+    f.assert_rec(&base_stack, "d", "vd")?;
+    f.assert_rec(&mid, "b", "vb")?;
+    f.assert_rec(&mid, "d", "vd")?;
+    f.assert_rec(&top, "c", "vc")?;
+    f.assert_rec(&top, "d", "vd")?;
+
+    let rows = f.db.run_on_stack(
+        "?[id, val] := *rec{id, val @ 'NOW'} :order id",
+        Default::default(),
+        &top,
+        None,
+        ScriptMutability::Immutable,
+    )?;
+    let seen: Vec<(String, String)> = rows
+        .rows
+        .iter()
+        .map(|r| (super::as_str(&r[0]), super::as_str(&r[1])))
+        .collect();
+    assert_eq!(
+        seen,
+        vec![
+            ("a".to_string(), "va".to_string()),
+            ("b".to_string(), "vb".to_string()),
+            ("c".to_string(), "vc".to_string()),
+            ("d".to_string(), "vd".to_string()),
+        ]
+    );
+    Ok(())
+}
+
+/// The precedence half of R2: a retraction in a higher layer wins over the lower layer's row,
+/// whichever layer wrote it.
+#[test]
+fn a_higher_layer_takes_precedence() -> Result<()> {
+    let f = Fixture::new()?;
+    let (base_stack, mid, top) = three_layers(&f)?;
+    f.assert_rec(&base_stack, "a", "va")?;
+    f.assert_rec(&base_stack, "b", "vb")?;
+    f.retract_rec(&mid, "a")?;
+    f.retract_rec(&top, "b")?;
+
+    assert_eq!(f.live(&top, None)?, frontier(&[]));
+    assert_eq!(f.live(&mid, None)?, frontier(&[("b", "vb")]));
+    assert_eq!(
+        f.live(&base_stack, None)?,
+        frontier(&[("a", "va"), ("b", "vb")])
+    );
+    Ok(())
+}
+
+/// Empty layers mid-stack, and a stack that is empty throughout, scan cleanly.
+#[test]
+fn empty_layers_scan_cleanly() -> Result<()> {
+    let f = Fixture::new()?;
+    let (base_stack, _mid, top) = three_layers(&f)?;
+    assert_eq!(f.live(&top, None)?, frontier(&[]));
+
+    f.assert_rec(&base_stack, "only", "v1")?;
+    assert_eq!(f.live(&top, None)?, frontier(&[("only", "v1")]));
+    Ok(())
+}
+
+/// A scan of one relation emits no rows of another, from any layer.
+#[test]
+fn relations_do_not_leak_across_layers() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db.run_script(
+        ":create other {id: String, at: Validity => val: String}",
+        Default::default(),
+        ScriptMutability::Mutable,
+    )?;
+    let (base_stack, _mid, top) = three_layers(&f)?;
+    f.assert_rec(&base_stack, "in-rec", "v1")?;
+    f.db.run_on_stack(
+        "?[id, at, val] <- [['in-other', 'ASSERT', 'v2']] :put other {id, at => val}",
+        Default::default(),
+        &top,
+        None,
+        ScriptMutability::Mutable,
+    )?;
+
+    assert_eq!(f.live(&top, None)?, frontier(&[("in-rec", "v1")]));
+    let others = f.db.run_on_stack(
+        "?[id, val] := *other{id, val @ 'NOW'}",
+        Default::default(),
+        &top,
+        None,
+        ScriptMutability::Immutable,
+    )?;
+    assert_eq!(others.rows.len(), 1);
+    Ok(())
+}
+
+/// Bounded scans, the shape of upstream's stored-relation `prefix_join` regression
+/// (commit `ff9a4fce`), behave across layers as they do on one.
+#[test]
+fn bounded_scans_compose_across_layers() -> Result<()> {
+    let f = Fixture::new()?;
+    let (base_stack, mid, top) = three_layers(&f)?;
+    for id in ["a1", "a2", "b1", "b2", "c1"] {
+        f.assert_rec(&base_stack, id, "base")?;
+    }
+    // Re-asserted higher up: the merge must still emit them once each.
+    f.assert_rec(&mid, "b2", "base")?;
+    f.assert_rec(&top, "c1", "base")?;
+
+    let rows = f.db.run_on_stack(
+        "?[id, val] := *rec{id, val @ 'NOW'}, id >= 'a2', id < 'c1' :order id",
+        Default::default(),
+        &top,
+        None,
+        ScriptMutability::Immutable,
+    )?;
+    let seen: Vec<(String, String)> = rows
+        .rows
+        .iter()
+        .map(|r| (super::as_str(&r[0]), super::as_str(&r[1])))
+        .collect();
+    assert_eq!(
+        seen,
+        vec![
+            ("a2".to_string(), "base".to_string()),
+            ("b1".to_string(), "base".to_string()),
+            ("b2".to_string(), "base".to_string()),
+        ]
+    );
+    Ok(())
+}
+
+/// Read results do not depend on the order in which layers were created.
+#[test]
+fn results_are_independent_of_layer_creation_order() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "shared", "base")?;
+    let fork = f.seq();
+
+    // Create the upper layer first, then the one that sits below it.
+    f.db.create_layer("later")?;
+    f.db.create_layer("earlier")?;
+    let stack: Stack = vec![
+        LayerRef::new("later"),
+        LayerRef::new("earlier"),
+        LayerRef::bounded("default", fork),
+    ];
+    f.assert_rec(
+        &vec![LayerRef::new("earlier"), LayerRef::bounded("default", fork)],
+        "from-earlier",
+        "v1",
+    )?;
+    f.assert_rec(&stack, "from-later", "v2")?;
+
+    assert_eq!(
+        f.live(&stack, None)?,
+        frontier(&[
+            ("shared", "base"),
+            ("from-earlier", "v1"),
+            ("from-later", "v2")
+        ])
+    );
+    Ok(())
+}

--- a/cozo-core/src/storage/layered/tests/reads.rs
+++ b/cozo-core/src/storage/layered/tests/reads.rs
@@ -232,3 +232,43 @@ fn results_are_independent_of_layer_creation_order() -> Result<()> {
     );
     Ok(())
 }
+
+/// A batched read agrees with the one-at-a-time read, for every position in the stack.
+///
+/// The batched path resolves a layer at a time rather than a key at a time, so it has its own
+/// chance to get the shadowing order wrong, to mishandle a key no layer holds, or to ignore a
+/// layer's window. It is checked against `get`, which is what the default implementation does.
+#[test]
+fn a_batched_read_agrees_with_reading_one_at_a_time() -> Result<()> {
+    use crate::storage::{StoreTx, Storage};
+
+    let f = Fixture::new()?;
+    let (base_stack, mid, top) = three_layers(&f)?;
+    f.assert_rec(&base_stack, "in-base", "vb")?;
+    f.assert_rec(&mid, "in-mid", "vm")?;
+    f.assert_rec(&top, "in-top", "vt")?;
+    // Held by two layers at once, so the batched path has to prefer the topmost.
+    f.assert_rec(&base_stack, "shared", "same")?;
+    f.assert_rec(&top, "shared", "same")?;
+
+    // Collect every stored key, plus one that does not exist.
+    let spec = f.db.db.resolve(&top)?;
+    let view = f.db.db.with_stack(spec);
+    let tx = view.transact(false)?;
+    let mut keys: Vec<Vec<u8>> = tx
+        .range_scan(&[0u8; 8], &[0xffu8; 8])
+        .map(|kv| kv.map(|(k, _)| k))
+        .collect::<Result<Vec<_>>>()?;
+    assert!(keys.len() >= 5, "expected the written rows, got {}", keys.len());
+    let mut absent = keys[0].clone();
+    *absent.last_mut().unwrap() = absent.last().unwrap().wrapping_add(1);
+    keys.push(absent);
+
+    let batched = tx.multi_get(&keys, false)?;
+    let singly: Vec<Option<Vec<u8>>> = keys
+        .iter()
+        .map(|k| tx.get(k, false))
+        .collect::<Result<Vec<_>>>()?;
+    assert_eq!(batched, singly, "batched and single reads disagreed");
+    Ok(())
+}

--- a/cozo-core/src/storage/layered/tests/restack.rs
+++ b/cozo-core/src/storage/layered/tests/restack.rs
@@ -1,0 +1,145 @@
+/*
+ * Re-parenting a layer onto a base it was not authored over: the "restack" family.
+ *
+ * A stack is composed per query, so re-parenting needs no operation: it is just a different
+ * `Vec<LayerRef>`. These tests cover what that composition means when the stack is not a
+ * lineage. Elsewhere every lower layer is bounded at the fork its upper layer was taken from,
+ * so a lower layer can never hold a newer stamp than the layer above it, and "topmost wins"
+ * and "newest stamp wins" agree on every input. The stacks here break that bounding, which is
+ * what makes the two rules distinguishable.
+ */
+
+use miette::Result;
+
+use super::{base, frontier, Fixture};
+use crate::storage::layered::{LayerRef, Stack};
+
+/// Two branches taken from the same fork, neither aware of the other, composed into one stack.
+/// This is the rebase-onto-a-different-branch shape: `work-a` is read over a base that is not
+/// its lineage. Both contributions resolve, and history is merged rather than collapsed.
+#[test]
+fn a_sibling_can_be_restacked_underneath() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "root", "v0")?;
+    let fork = f.seq();
+
+    f.db.create_layer("work-a")?;
+    f.db.create_layer("work-b")?;
+    let a: Stack = vec![LayerRef::new("work-a"), LayerRef::bounded("default", fork)];
+    let b: Stack = vec![LayerRef::new("work-b"), LayerRef::bounded("default", fork)];
+
+    f.assert_rec(&a, "on-a", "v1")?;
+    f.assert_rec(&b, "on-b", "v2")?;
+    // The same record, asserted independently on both siblings. Legal: identical value.
+    f.assert_rec(&a, "shared", "same")?;
+    f.assert_rec(&b, "shared", "same")?;
+    let bound = f.seq();
+
+    // Neither branch sees the other while they stand apart.
+    assert_eq!(
+        f.live(&a, None)?,
+        frontier(&[("root", "v0"), ("on-a", "v1"), ("shared", "same")])
+    );
+
+    // Restack: `work-a` over its sibling, which it never forked from.
+    let restacked: Stack = vec![
+        LayerRef::new("work-a"),
+        LayerRef::bounded("work-b", bound),
+        LayerRef::bounded("default", fork),
+    ];
+    assert_eq!(
+        f.live(&restacked, None)?,
+        frontier(&[
+            ("root", "v0"),
+            ("on-a", "v1"),
+            ("on-b", "v2"),
+            ("shared", "same")
+        ])
+    );
+
+    // Restacking merges the frontier; it does not collapse history. Both siblings' assertions
+    // of `shared` are still there, at their own stamps.
+    let shared: Vec<_> = f
+        .versions(&restacked)?
+        .into_iter()
+        .filter(|v| v.id == "shared")
+        .collect();
+    assert_eq!(shared.len(), 2, "both authorings survive: {shared:?}");
+    assert!(shared[0].seq < shared[1].seq);
+
+    // Writes through the restacked composition land in its top layer, which is still `work-a`.
+    f.assert_rec(&restacked, "after-restack", "v3")?;
+    assert!(f.live(&a, None)?.contains_key("after-restack"));
+    assert!(!f.live(&b, None)?.contains_key("after-restack"));
+    Ok(())
+}
+
+/// A layer read over a base clipped *below* the fork it was authored over. Windows are
+/// per-layer, so lowering the base's ceiling withdraws the base's later rows and leaves the
+/// layer's own content untouched, even though every row in it postdates the new ceiling.
+#[test]
+fn restacking_below_the_fork_keeps_the_layer_intact() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "early", "v0")?;
+    let earlier = f.seq();
+    f.assert_rec(&base(), "late", "v1")?;
+    let fork = f.seq();
+
+    f.db.create_layer("work")?;
+    let work: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+    let authored = f.assert_rec(&work, "on-work", "v2")?;
+    assert!(
+        authored > fork,
+        "the branch's own row postdates the base ceiling it is about to be given"
+    );
+
+    // Re-parent onto an older base. `late` was never in this branch's lineage under the new
+    // ceiling, so it goes; `on-work` stays, because the ceiling belongs to `default` alone.
+    let rebased: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", earlier)];
+    assert_eq!(
+        f.live(&rebased, None)?,
+        frontier(&[("early", "v0"), ("on-work", "v2")])
+    );
+
+    // A query-level `at` is the one ceiling that does apply to every layer at once.
+    assert_eq!(
+        f.live(&rebased, Some(earlier))?,
+        frontier(&[("early", "v0")])
+    );
+    Ok(())
+}
+
+/// The discriminating case. `upper` sits above `lower`, but `lower` is written *afterwards*,
+/// so it holds the newer stamp. Precedence follows the stamp, not the stack position: the
+/// merge presents each key's versions newest-first across the whole stack and the ordinary
+/// single-store validity rule decides from there.
+///
+/// Under value immutability this is observable only through retraction, which is why the rest
+/// of the suite, where lower layers are always bounded at a fork and so always older, never
+/// has to choose between the two readings.
+#[test]
+fn precedence_follows_the_stamp_not_the_stack_position() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db.create_layer("lower")?;
+    f.db.create_layer("upper")?;
+    let lower: Stack = vec![LayerRef::new("lower"), LayerRef::new("default")];
+    let upper: Stack = vec![
+        LayerRef::new("upper"),
+        LayerRef::new("lower"),
+        LayerRef::new("default"),
+    ];
+
+    // Newer retraction underneath an older assertion.
+    let asserted = f.assert_rec(&upper, "under", "v1")?;
+    let retracted = f.retract_rec(&lower, "under")?;
+    assert!(retracted > asserted, "the lower layer holds the newer stamp");
+
+    // Older retraction underneath a newer assertion: the mirror, and the case the rest of the
+    // suite exercises.
+    f.retract_rec(&lower, "over")?;
+    let revived = f.assert_rec(&upper, "over", "v2")?;
+    assert!(revived > retracted);
+
+    assert_eq!(f.live(&upper, None)?, frontier(&[("over", "v2")]));
+    Ok(())
+}

--- a/cozo-core/src/storage/layered/tests/retraction.rs
+++ b/cozo-core/src/storage/layered/tests/retraction.rs
@@ -1,0 +1,143 @@
+/*
+ * Cross-layer retraction: the subtlest correctness case in the design.
+ */
+
+use miette::Result;
+
+use super::{base, frontier, Fixture};
+use crate::storage::layered::{LayerRef, Stack};
+
+fn branch(f: &Fixture, name: &str) -> Result<(Stack, i64)> {
+    f.db.create_layer(name)?;
+    let fork = f.seq();
+    Ok((
+        vec![LayerRef::new(name), LayerRef::bounded("default", fork)],
+        fork,
+    ))
+}
+
+/// A retraction written in the top layer hides the lower layer's row through this
+/// stack and only through this stack. The lower layer keeps its row: a stack that omits the
+/// retracting layer still sees it.
+#[test]
+fn a_retraction_is_scoped_to_the_stack_that_wrote_it() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    let (work, fork) = branch(&f, "work")?;
+    f.retract_rec(&work, "k")?;
+
+    assert_eq!(f.live(&work, None)?, frontier(&[]));
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "v1")]));
+
+    // The row itself is untouched underneath: read the same base layer through a second stack.
+    let other: Stack = vec![LayerRef::bounded("default", fork)];
+    assert_eq!(f.live(&other, None)?, frontier(&[("k", "v1")]));
+    Ok(())
+}
+
+/// Retract then re-assert the identical value in the same layer: live again.
+#[test]
+fn a_retraction_can_be_undone_in_place() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    f.retract_rec(&base(), "k")?;
+    assert_eq!(f.live(&base(), None)?, frontier(&[]));
+
+    f.assert_rec(&base(), "k", "v1")?;
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "v1")]));
+    Ok(())
+}
+
+/// Time travel across a retraction: a sequence captured before it still shows the row
+/// live, through the very stack that now hides it.
+#[test]
+fn history_survives_a_retraction() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    let before = f.seq();
+    let (work, _) = branch(&f, "work")?;
+    f.retract_rec(&work, "k")?;
+
+    assert_eq!(f.live(&work, None)?, frontier(&[]));
+    assert_eq!(f.live(&work, Some(before))?, frontier(&[("k", "v1")]));
+    Ok(())
+}
+
+/// Retracting a key no layer holds is legal and harmless: a cherry-picked delete whose
+/// record the target never saw. It costs a row that the next flatten's liveness check drops.
+#[test]
+fn retracting_the_never_existent_is_harmless() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "present", "v1")?;
+    let (work, _) = branch(&f, "work")?;
+
+    f.retract_rec(&work, "never-existed")?;
+
+    assert_eq!(f.live(&work, None)?, frontier(&[("present", "v1")]));
+    assert_eq!(f.live(&base(), None)?, frontier(&[("present", "v1")]));
+    Ok(())
+}
+
+/// A retraction stamped above a layer's ceiling is not visible, so the row it would have
+/// hidden emits.
+#[test]
+fn a_retraction_above_the_ceiling_does_not_bite() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "k", "v1")?;
+    let fork = f.seq();
+    f.retract_rec(&base(), "k")?;
+
+    assert_eq!(f.live(&base(), None)?, frontier(&[]));
+    assert_eq!(
+        f.live(&vec![LayerRef::bounded("default", fork)], None)?,
+        frontier(&[("k", "v1")])
+    );
+    Ok(())
+}
+
+/// A hard delete cannot reach a lower layer, so the engine refuses it deterministically,
+/// from the relation, not from where the row happens to sit.
+///
+/// Both attempts below fail identically: one names a row that lives in a lower layer, the
+/// other a row this stack wrote itself. Deciding per-key would make the error depend on
+/// storage layout, which is exactly the "surprise mid-query" the check exists to avoid.
+#[test]
+fn a_hard_delete_through_a_stack_is_refused() -> Result<()> {
+    let f = Fixture::new()?;
+    let below = f.assert_rec(&base(), "k", "v1")?;
+    let (work, _) = branch(&f, "work")?;
+    let above = f.assert_rec(&work, "own", "v2")?;
+
+    for (id, stamp) in [("k", below), ("own", above)] {
+        let err = rm(&f, &work, id, stamp).unwrap_err();
+        assert!(
+            format!("{err:?}").contains("is a retraction"),
+            "unexpected error for {id}: {err:?}"
+        );
+    }
+
+    assert_eq!(f.live(&base(), None)?, frontier(&[("k", "v1")]));
+    // The same delete against a single-layer stack is ordinary and works.
+    rm(&f, &base(), "k", below)?;
+    assert_eq!(f.live(&base(), None)?, frontier(&[]));
+    Ok(())
+}
+
+fn rm(f: &Fixture, stack: &Stack, id: &str, stamp: i64) -> Result<crate::NamedRows> {
+    let mut params = std::collections::BTreeMap::new();
+    params.insert("id".to_string(), crate::DataValue::from(id));
+    params.insert(
+        "at".to_string(),
+        crate::DataValue::Validity(crate::Validity {
+            timestamp: crate::ValidityTs(std::cmp::Reverse(stamp)),
+            is_assert: std::cmp::Reverse(true),
+        }),
+    );
+    f.db.run_on_stack(
+        "?[id, at] <- [[$id, $at]] :rm rec {id, at}",
+        params,
+        stack,
+        None,
+        crate::runtime::db::ScriptMutability::Mutable,
+    )
+}

--- a/cozo-core/src/storage/layered/tests/sequences.rs
+++ b/cozo-core/src/storage/layered/tests/sequences.rs
@@ -1,0 +1,240 @@
+/*
+ * Sequence and commit stamping.
+ */
+
+use std::collections::BTreeMap;
+
+use miette::Result;
+use tempfile::TempDir;
+
+use super::{base, Fixture};
+use crate::data::value::DataValue;
+use crate::runtime::db::ScriptMutability;
+use crate::storage::layered::new_cozo_layered;
+
+/// Sequential commits carry strictly increasing stamps.
+#[test]
+fn stamps_increase_with_commit_order() -> Result<()> {
+    let f = Fixture::new()?;
+    let mut stamps = vec![];
+    for i in 0..5 {
+        stamps.push(f.assert_rec(&base(), &format!("k{i}"), "v")?);
+    }
+    for pair in stamps.windows(2) {
+        assert!(
+            pair[0] < pair[1],
+            "stamps did not increase: {:?}",
+            stamps
+        );
+    }
+    Ok(())
+}
+
+/// Every row of one transaction carries the identical stamp: a transaction is a single
+/// point in commit order.
+#[test]
+fn one_transaction_is_one_stamp() -> Result<()> {
+    let f = Fixture::new()?;
+    f.db.run_on_stack(
+        "?[id, at, val] <- [['a', 'ASSERT', 'v'], ['b', 'ASSERT', 'v'], ['c', 'ASSERT', 'v']]
+         :put rec {id, at => val}",
+        Default::default(),
+        &base(),
+        None,
+        ScriptMutability::Mutable,
+    )?;
+    let stamps: Vec<_> = f.versions(&base())?.into_iter().map(|v| v.seq).collect();
+    assert_eq!(stamps.len(), 3);
+    assert!(
+        stamps.windows(2).all(|w| w[0] == w[1]),
+        "rows of one transaction were stamped apart: {:?}",
+        stamps
+    );
+    Ok(())
+}
+
+/// A transaction is indivisible under time travel: a read at its stamp sees all of its
+/// rows, and a read at any earlier captured sequence sees none of them.
+#[test]
+fn a_transaction_is_atomic_under_time_travel() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "old", "v0")?;
+    let before = f.seq();
+
+    f.db.run_on_stack(
+        "?[id, at, val] <- [['a', 'ASSERT', 'v'], ['b', 'ASSERT', 'v']]
+         :put rec {id, at => val}",
+        Default::default(),
+        &base(),
+        None,
+        ScriptMutability::Mutable,
+    )?;
+    let stamp = f.versions(&base())?.iter().map(|v| v.seq).max().unwrap();
+
+    assert_eq!(f.live(&base(), Some(before))?.len(), 1);
+    assert_eq!(f.live(&base(), Some(stamp))?.len(), 3);
+    Ok(())
+}
+
+/// A fork point never subsequently acquires rows.
+///
+/// Pinned so that stamping cannot drift back to write time: were the sequence read when the
+/// row was buffered rather than when it was committed, a fork captured in between would grow a
+/// row underneath it.
+#[test]
+fn a_fork_point_is_stable() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "before-fork", "v1")?;
+    let fork = f.seq();
+
+    for i in 0..5 {
+        f.assert_rec(&base(), &format!("after{i}"), "v")?;
+    }
+
+    for v in f.versions(&base())? {
+        if v.id != "before-fork" {
+            assert!(
+                v.seq > fork,
+                "a row committed after the fork was stamped at or below it: {:?} vs {}",
+                v,
+                fork
+            );
+        }
+    }
+    assert_eq!(f.live(&base(), Some(fork))?.len(), 1);
+    Ok(())
+}
+
+/// Sparseness tolerance: unrelated writes move the counter, and nothing may depend on
+/// consecutiveness. This is the meta-test for the no-hardcoded-sequences convention.
+#[test]
+fn expectations_survive_unrelated_writes() -> Result<()> {
+    let f = Fixture::new()?;
+    let first = f.assert_rec(&base(), "k", "v1")?;
+
+    // An unrelated relation churns the sequence counter between the writes under test.
+    f.db.run_script(
+        ":create noise {k: Int => v: Int}",
+        Default::default(),
+        ScriptMutability::Mutable,
+    )?;
+    for i in 0..20 {
+        let mut params = BTreeMap::new();
+        params.insert("k".to_string(), DataValue::from(i));
+        f.db.run_script(
+            "?[k, v] <- [[$k, $k]] :put noise {k => v}",
+            params,
+            ScriptMutability::Mutable,
+        )?;
+    }
+
+    let second = f.assert_rec(&base(), "k2", "v2")?;
+    assert!(second > first);
+    assert_eq!(f.live(&base(), Some(first))?.len(), 1);
+    assert_eq!(f.live(&base(), Some(second))?.len(), 2);
+    Ok(())
+}
+
+/// Restart continuity: persisted stamps are unchanged by a reopen, and new stamps land
+/// strictly above every persisted one.
+#[test]
+fn stamps_survive_a_restart() -> Result<()> {
+    let dir = TempDir::new().unwrap();
+    let persisted = {
+        let db = new_cozo_layered(dir.path())?;
+        db.run_script(
+            ":create rec {id: String, at: Validity => val: String}",
+            Default::default(),
+            ScriptMutability::Mutable,
+        )?;
+        db.run_on_stack(
+            "?[id, at, val] <- [['a', 'ASSERT', 'v']] :put rec {id, at => val}",
+            Default::default(),
+            &base(),
+            None,
+            ScriptMutability::Mutable,
+        )?;
+        read_stamps(&db)?
+    };
+    assert_eq!(persisted.len(), 1);
+
+    let db = new_cozo_layered(dir.path())?;
+    assert_eq!(read_stamps(&db)?, persisted);
+    assert!(db.current_seq()? >= persisted[0]);
+
+    db.run_on_stack(
+        "?[id, at, val] <- [['b', 'ASSERT', 'v']] :put rec {id, at => val}",
+        Default::default(),
+        &base(),
+        None,
+        ScriptMutability::Mutable,
+    )?;
+    let after = read_stamps(&db)?;
+    assert!(
+        after.iter().all(|s| *s >= persisted[0]),
+        "a post-restart stamp landed below a persisted one"
+    );
+    assert!(after.iter().any(|s| *s > persisted[0]));
+    Ok(())
+}
+
+/// Explicit validity is rejected. A user-supplied sequence above the current one would
+/// shadow future writes and break layer isolation; one below it would appear to predate a fork
+/// it postdates. Failing beats accepting it, and beats silently ignoring it.
+#[test]
+fn explicit_validity_is_rejected() -> Result<()> {
+    let f = Fixture::new()?;
+
+    for literal in ["[12345, true]", "'2023-01-01T00:00:00Z'", "'~2023-01-01T00:00:00Z'"] {
+        let script = format!(
+            "?[id, at, val] <- [['k', {literal}, 'v']] :put rec {{id, at => val}}"
+        );
+        let err = f
+            .db
+            .run_on_stack(
+                &script,
+                Default::default(),
+                &base(),
+                None,
+                ScriptMutability::Mutable,
+            )
+            .unwrap_err();
+        assert!(
+            format!("{err:?}").contains("explicit validity"),
+            "{literal} was accepted or failed for the wrong reason: {err:?}"
+        );
+    }
+
+    // The accepted inputs still work, through the ordinary entry point as well as `run_on_stack`.
+    f.assert_rec(&base(), "k", "v")?;
+    f.db.run_script(
+        "?[id, at, val] <- [['k2', 'ASSERT', 'v']] :put rec {id, at => val}",
+        Default::default(),
+        ScriptMutability::Mutable,
+    )?;
+    assert_eq!(f.live(&base(), None)?.len(), 2);
+    // Rows written through the ordinary entry point are stamped in sequence, not wall clock.
+    let ceiling = f.seq();
+    assert!(f.versions(&base())?.iter().all(|v| v.seq <= ceiling));
+    Ok(())
+}
+
+fn read_stamps(db: &crate::Db<crate::storage::layered::LayeredStorage>) -> Result<Vec<i64>> {
+    let rows = db.run_on_stack(
+        "?[id, at] := *rec{id, at}",
+        Default::default(),
+        &base(),
+        None,
+        ScriptMutability::Immutable,
+    )?;
+    let mut ret: Vec<i64> = rows
+        .rows
+        .iter()
+        .map(|row| match &row[1] {
+            DataValue::Validity(v) => v.timestamp.0 .0,
+            other => panic!("expected a validity, got {:?}", other),
+        })
+        .collect();
+    ret.sort();
+    Ok(ret)
+}

--- a/cozo-core/src/storage/layered/tests/three_way.rs
+++ b/cozo-core/src/storage/layered/tests/three_way.rs
@@ -1,0 +1,250 @@
+/*
+ * A three way merge, assembled from what this engine provides.
+ *
+ * Two branches that forked from a common base and never saw each other cannot be merged by
+ * `flatten` alone: it is a two way operation, and without the base it cannot tell a branch
+ * undoing its own deletion from two branches disagreeing about whether a record should exist.
+ * The base is what makes those distinguishable, and supplying it is the caller's job.
+ *
+ * This test is that caller, in miniature. It scans each branch against the fork point, joins
+ * the two streams, and adjudicates. What it demonstrates is that the engine hands up enough to
+ * do so: which side touched which key, whether the touch added or removed, and what value it
+ * claimed. Neither scan reports a conflict on its own, which is the point -- every conflict
+ * here is a property of the pair, visible only once both are in hand.
+ */
+
+use std::collections::BTreeMap;
+
+use miette::Result;
+
+use super::{base, frontier, Fixture};
+use crate::storage::layered::flatten::{FlattenCursor, FlattenItem};
+use crate::storage::layered::{LayerRef, Stack};
+
+/// What one branch did to one key, relative to the fork point.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum Side {
+    /// The branch asserts this value where the base had nothing, or had it retracted.
+    Added(String),
+    /// The branch retracts a record the base holds live.
+    Removed,
+    /// The branch wrote the key but the base already agrees: an intent to keep it, with no
+    /// net change. This is what makes a delete on the other side a conflict rather than a
+    /// clean apply.
+    Kept,
+}
+
+/// The verdict for one key once both branches have been consulted.
+#[derive(Debug, Eq, PartialEq)]
+enum Verdict {
+    Add(String),
+    Remove,
+    Conflict(&'static str),
+}
+
+/// Everything one branch changed relative to `at_fork`, read a page at a time.
+fn changes_against_base(f: &Fixture, branch: &str, at_fork: &Stack) -> Result<Vec<(String, Side)>> {
+    let view: Stack = vec![LayerRef::new(branch)];
+    let mut out = vec![];
+    let mut cursor: Option<FlattenCursor> = None;
+    loop {
+        let page = f.db.flatten_page(&view, at_fork, cursor.as_ref(), 2)?;
+        for item in page.items {
+            match item {
+                FlattenItem::Copy {
+                    key,
+                    value,
+                    asserts,
+                    ..
+                } => {
+                    let id = super::as_str(&key[0]);
+                    out.push((
+                        id,
+                        if asserts {
+                            Side::Added(super::as_str(&value[0]))
+                        } else {
+                            Side::Removed
+                        },
+                    ));
+                }
+                FlattenItem::Dedupe { key, .. } => {
+                    out.push((super::as_str(&key[0]), Side::Kept));
+                }
+                // A retraction of something the base never held: the branch intended nothing
+                // the base does not already reflect, so it carries no weight in the merge.
+                FlattenItem::TombstoneDropped { .. } => {}
+                FlattenItem::Conflict(c) => {
+                    panic!("a single branch against its own fork point should not conflict: {c:?}")
+                }
+            }
+        }
+        match page.next {
+            Some(next) => cursor = Some(next),
+            None => break,
+        }
+    }
+    Ok(out)
+}
+
+/// Join two branches' changes and decide each key. Both inputs arrive in key order, so this
+/// walks them together rather than holding either whole.
+fn adjudicate(a: &[(String, Side)], b: &[(String, Side)]) -> BTreeMap<String, Verdict> {
+    let mut out = BTreeMap::new();
+    let (mut i, mut j) = (0, 0);
+    while i < a.len() || j < b.len() {
+        let (id, left, right) = match (a.get(i), b.get(j)) {
+            (Some((ka, va)), Some((kb, vb))) if ka == kb => {
+                i += 1;
+                j += 1;
+                (ka.clone(), Some(va), Some(vb))
+            }
+            (Some((ka, va)), Some((kb, _))) if ka < kb => {
+                i += 1;
+                (ka.clone(), Some(va), None)
+            }
+            (Some(_), Some((kb, vb))) => {
+                j += 1;
+                (kb.clone(), None, Some(vb))
+            }
+            (Some((ka, va)), None) => {
+                i += 1;
+                (ka.clone(), Some(va), None)
+            }
+            (None, Some((kb, vb))) => {
+                j += 1;
+                (kb.clone(), None, Some(vb))
+            }
+            (None, None) => unreachable!(),
+        };
+        let verdict = match (left, right) {
+            // Only one side touched it, so that side decides.
+            (Some(Side::Added(v)), None) | (None, Some(Side::Added(v))) => {
+                Some(Verdict::Add(v.clone()))
+            }
+            (Some(Side::Removed), None) | (None, Some(Side::Removed)) => Some(Verdict::Remove),
+            (Some(Side::Kept), None) | (None, Some(Side::Kept)) => None,
+            // Both sides did the same thing.
+            (Some(Side::Added(x)), Some(Side::Added(y))) if x == y => {
+                Some(Verdict::Add(x.clone()))
+            }
+            (Some(Side::Removed), Some(Side::Removed)) => Some(Verdict::Remove),
+            (Some(Side::Kept), Some(Side::Kept)) => None,
+            // One kept or added it, the other took it away.
+            (Some(Side::Removed), Some(_)) | (Some(_), Some(Side::Removed)) => {
+                Some(Verdict::Conflict("removed on one side, kept on the other"))
+            }
+            // Both added, with different values.
+            (Some(Side::Added(_)), Some(Side::Added(_))) => {
+                Some(Verdict::Conflict("two values claimed for one key"))
+            }
+            // Both branches are measured against the same base, so one of them cannot see the
+            // key as already present while the other sees it as new.
+            (Some(Side::Added(_)), Some(Side::Kept)) | (Some(Side::Kept), Some(Side::Added(_))) => {
+                unreachable!("one base cannot both hold and lack a key")
+            }
+            (None, None) => unreachable!(),
+        };
+        if let Some(verdict) = verdict {
+            out.insert(id, verdict);
+        }
+    }
+    out
+}
+
+/// The whole shape, end to end: two siblings, a common base, and a verdict for every key that
+/// either of them touched.
+#[test]
+fn two_siblings_merge_through_their_common_base() -> Result<()> {
+    let f = Fixture::new()?;
+
+    // The common base, before either branch exists.
+    f.assert_rec(&base(), "untouched", "v")?;
+    f.assert_rec(&base(), "dropped-by-a", "v")?;
+    f.assert_rec(&base(), "dropped-by-both", "v")?;
+    f.assert_rec(&base(), "contested", "v")?;
+    let fork = f.seq();
+    let at_fork: Stack = vec![LayerRef::bounded("default", fork)];
+
+    f.db.create_layer("a")?;
+    f.db.create_layer("b")?;
+    let a: Stack = vec![LayerRef::new("a"), LayerRef::bounded("default", fork)];
+    let b: Stack = vec![LayerRef::new("b"), LayerRef::bounded("default", fork)];
+
+    // Branch a.
+    f.retract_rec(&a, "dropped-by-a")?;
+    f.retract_rec(&a, "dropped-by-both")?;
+    f.retract_rec(&a, "contested")?;
+    f.assert_rec(&a, "only-on-a", "va")?;
+    f.assert_rec(&a, "agreed", "same")?;
+    f.assert_rec(&a, "disputed", "from-a")?;
+    // Created and retracted inside the branch: the base never saw it, so it nets to nothing.
+    f.assert_rec(&a, "ephemeral", "x")?;
+    f.retract_rec(&a, "ephemeral")?;
+
+    // Branch b, which cannot see any of that.
+    f.retract_rec(&b, "dropped-by-both")?;
+    // Re-affirms the record a deleted. Identical value, so no net change against the base.
+    f.assert_rec(&b, "contested", "v")?;
+    f.assert_rec(&b, "only-on-b", "vb")?;
+    f.assert_rec(&b, "agreed", "same")?;
+    f.assert_rec(&b, "disputed", "from-b")?;
+
+    // Each branch against the fork point. Neither reports a conflict on its own.
+    let from_a = changes_against_base(&f, "a", &at_fork)?;
+    let from_b = changes_against_base(&f, "b", &at_fork)?;
+
+    assert_eq!(
+        from_a,
+        vec![
+            ("agreed".to_string(), Side::Added("same".to_string())),
+            ("contested".to_string(), Side::Removed),
+            ("disputed".to_string(), Side::Added("from-a".to_string())),
+            ("dropped-by-a".to_string(), Side::Removed),
+            ("dropped-by-both".to_string(), Side::Removed),
+            ("only-on-a".to_string(), Side::Added("va".to_string())),
+        ],
+        "branch a's changes, with `ephemeral` netting to nothing"
+    );
+    assert_eq!(
+        from_b,
+        vec![
+            ("agreed".to_string(), Side::Added("same".to_string())),
+            ("contested".to_string(), Side::Kept),
+            ("disputed".to_string(), Side::Added("from-b".to_string())),
+            ("dropped-by-both".to_string(), Side::Removed),
+            ("only-on-b".to_string(), Side::Added("vb".to_string())),
+        ],
+        "branch b's changes, with `contested` a keep rather than a change"
+    );
+
+    let merged = adjudicate(&from_a, &from_b);
+    let expect: BTreeMap<String, Verdict> = [
+        ("agreed", Verdict::Add("same".to_string())),
+        (
+            "contested",
+            Verdict::Conflict("removed on one side, kept on the other"),
+        ),
+        (
+            "disputed",
+            Verdict::Conflict("two values claimed for one key"),
+        ),
+        ("dropped-by-a", Verdict::Remove),
+        ("dropped-by-both", Verdict::Remove),
+        ("only-on-a", Verdict::Add("va".to_string())),
+        ("only-on-b", Verdict::Add("vb".to_string())),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_string(), v))
+    .collect();
+    assert_eq!(merged, expect);
+
+    // `untouched` and `ephemeral` appear nowhere: neither branch changed anything about them.
+    assert!(!merged.contains_key("untouched"));
+    assert!(!merged.contains_key("ephemeral"));
+
+    // The delete-and-keep disagreement is invisible to either branch on its own. That is why
+    // it has to be settled here and not inside a flatten.
+    assert!(f.db.flatten_plan(&vec![LayerRef::new("a")], &at_fork)?.is_clean());
+    assert!(f.db.flatten_plan(&vec![LayerRef::new("b")], &at_fork)?.is_clean());
+    Ok(())
+}

--- a/cozo-core/src/storage/layered/tests/three_way.rs
+++ b/cozo-core/src/storage/layered/tests/three_way.rs
@@ -17,7 +17,7 @@ use std::collections::BTreeMap;
 
 use miette::Result;
 
-use super::{base, frontier, Fixture};
+use super::{base, Fixture};
 use crate::storage::layered::flatten::{FlattenCursor, FlattenItem};
 use crate::storage::layered::{LayerRef, Stack};
 

--- a/cozo-core/src/storage/layered/tests/windows.rs
+++ b/cozo-core/src/storage/layered/tests/windows.rs
@@ -1,0 +1,135 @@
+/*
+ * Window semantics.
+ */
+
+use miette::Result;
+
+use super::{base, frontier, Fixture};
+use crate::storage::layered::{LayerRef, Stack};
+
+/// The window is `(since, bound]`: a row stamped exactly at the ceiling is visible, one
+/// stamped exactly at the floor is not. The fork-point row belongs to the parent.
+#[test]
+fn the_window_is_half_open() -> Result<()> {
+    let f = Fixture::new()?;
+    let a = f.assert_rec(&base(), "a", "v1")?;
+    let b = f.assert_rec(&base(), "b", "v2")?;
+
+    // Ceiling inclusive: bounding at `a`'s own stamp keeps `a`.
+    assert_eq!(
+        f.live(&vec![LayerRef::bounded("default", a)], None)?,
+        frontier(&[("a", "v1")])
+    );
+    // Floor exclusive: flooring at `a`'s own stamp drops `a`.
+    assert_eq!(
+        f.live(
+            &vec![LayerRef::windowed("default", Some(a), Some(b))],
+            None
+        )?,
+        frontier(&[("b", "v2")])
+    );
+    Ok(())
+}
+
+/// `since == bound` is a legal, empty window: the natural changeset of a fork with no work.
+#[test]
+fn an_empty_window_is_legal() -> Result<()> {
+    let f = Fixture::new()?;
+    let a = f.assert_rec(&base(), "a", "v1")?;
+    let empty: Stack = vec![LayerRef::windowed("default", Some(a), Some(a))];
+    assert_eq!(f.live(&empty, None)?, frontier(&[]));
+    Ok(())
+}
+
+/// An inverted window is always a consumer bug, and stack construction is where errors are
+/// cheap and deterministic.
+#[test]
+fn an_inverted_window_is_rejected_at_stack_construction() -> Result<()> {
+    let f = Fixture::new()?;
+    let a = f.assert_rec(&base(), "a", "v1")?;
+    let inverted: Stack = vec![LayerRef::windowed("default", Some(a + 10), Some(a))];
+    let err = f.live(&inverted, None).unwrap_err();
+    assert!(
+        format!("{err}").contains("inverted window"),
+        "unexpected error: {err}"
+    );
+    Ok(())
+}
+
+/// A query's `at` is a ceiling only. It never lowers a floor, so a historical read of a
+/// changeset view yields nothing rather than the pre-window state.
+#[test]
+fn a_query_bound_never_lowers_a_floor() -> Result<()> {
+    let f = Fixture::new()?;
+    let a = f.assert_rec(&base(), "a", "v1")?;
+    f.assert_rec(&base(), "b", "v2")?;
+
+    let changeset: Stack = vec![LayerRef::windowed("default", Some(a), None)];
+    assert_eq!(f.live(&changeset, Some(a))?, frontier(&[]));
+    Ok(())
+}
+
+/// A floor hides the frontier: a floored layer contributes what changed inside the window,
+/// not the state the window inherited.
+#[test]
+fn a_floor_hides_the_frontier() -> Result<()> {
+    let f = Fixture::new()?;
+    let established = f.assert_rec(&base(), "established", "v1")?;
+    f.assert_rec(&base(), "fresh", "v2")?;
+
+    let changeset: Stack = vec![LayerRef::windowed("default", Some(established), None)];
+    // Not `established` at its old value: no `established` at all.
+    assert_eq!(f.live(&changeset, None)?, frontier(&[("fresh", "v2")]));
+    Ok(())
+}
+
+/// A query bound preceding the top layer's first row degenerates to a historical read of
+/// the layers below it. This falls out of `min` rather than needing a branch in the code, but
+/// it is the case a consumer will hit first, so it is pinned.
+#[test]
+fn a_query_below_the_top_layer_reads_through_it() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "root", "v1")?;
+    let fork = f.seq();
+
+    f.db.create_layer("work")?;
+    let branch: Stack = vec![LayerRef::new("work"), LayerRef::bounded("default", fork)];
+    f.assert_rec(&branch, "scratch", "v2")?;
+
+    assert_eq!(f.live(&branch, Some(fork))?, frontier(&[("root", "v1")]));
+    Ok(())
+}
+
+/// Flooring one layer of a three-layer stack affects that layer's contribution and nothing
+/// else.
+#[test]
+fn a_mid_stack_window_is_local_to_its_layer() -> Result<()> {
+    let f = Fixture::new()?;
+    f.assert_rec(&base(), "bottom", "v1")?;
+    let fork1 = f.seq();
+
+    f.db.create_layer("mid")?;
+    let mid: Stack = vec![LayerRef::new("mid"), LayerRef::bounded("default", fork1)];
+    let early = f.assert_rec(&mid, "mid-early", "v2")?;
+    f.assert_rec(&mid, "mid-late", "v3")?;
+    let fork2 = f.seq();
+
+    f.db.create_layer("top")?;
+    let full: Stack = vec![
+        LayerRef::new("top"),
+        LayerRef::bounded("mid", fork2),
+        LayerRef::bounded("default", fork1),
+    ];
+    f.assert_rec(&full, "top", "v4")?;
+
+    let floored: Stack = vec![
+        LayerRef::new("top"),
+        LayerRef::windowed("mid", Some(early), Some(fork2)),
+        LayerRef::bounded("default", fork1),
+    ];
+    assert_eq!(
+        f.live(&floored, None)?,
+        frontier(&[("bottom", "v1"), ("mid-late", "v3"), ("top", "v4")])
+    );
+    Ok(())
+}

--- a/cozo-core/src/storage/layered/tx.rs
+++ b/cozo-core/src/storage/layered/tx.rs
@@ -1,0 +1,532 @@
+/*
+ * Layered storage: the stack-aware transaction.
+ */
+
+use std::cell::OnceCell;
+use std::sync::Arc;
+
+use miette::{bail, miette, IntoDiagnostic, Result, WrapErr};
+use rocksdb::BoundColumnFamily;
+
+use std::borrow::Cow;
+
+use crate::data::memcmp::{
+    contains_validity_ts, restamp_all_validity, tail_validity, KeyBounds,
+};
+use crate::storage::layered::catalog::{catalog_relations, relation_of, Catalog};
+use crate::data::tuple::Tuple;
+use crate::data::value::ValidityTs;
+use crate::storage::layered::iter::{
+    LayeredTxn, StackMerge, StackRawIter, StackSkipIter, StackTupleIter, Window,
+};
+use crate::storage::layered::{LayeredInner, StackSpec, Seq, PENDING_SEQ};
+use crate::storage::StoreTx;
+
+/// A resolved stack, together with the scratch space its per-key lookups reuse.
+///
+/// The buffers are an implementation detail of [`BoundStack::key_state`]: they are filled and
+/// consumed inside a single call, so nothing outside this type sees them.
+pub(crate) struct BoundStack<'a> {
+    pub(crate) layers: Vec<BoundLayer<'a>>,
+    bounds: KeyBounds,
+}
+
+impl<'a> BoundStack<'a> {
+    pub(crate) fn new(layers: Vec<BoundLayer<'a>>) -> Self {
+        Self {
+            layers,
+            bounds: KeyBounds::default(),
+        }
+    }
+
+    /// The exclusive end of the range covering every version of `key`'s identity, held in
+    /// this stack's own buffer.
+    ///
+    /// The value is only valid until the next call that fills the buffer, which is why it is
+    /// returned as a borrow rather than handed out.
+    pub(crate) fn range_end(&mut self, key: &[u8]) -> &[u8] {
+        self.bounds.fill(key);
+        self.bounds.upper()
+    }
+
+    /// What this stack says about one key's identity right now.
+    ///
+    /// Reads the identity's versions newest first and stops at the first assertion, which is
+    /// all either answer needs: the newest version decides liveness, and under value
+    /// immutability every assertion under a key carries the same value. Nothing beyond that
+    /// point is read, so a key with a long history costs no more than one with two versions.
+    pub(crate) fn key_state(&mut self, txn: &LayeredTxn<'_>, key: &[u8]) -> Result<KeyState> {
+        self.bounds.fill(key);
+        let iters = self
+            .layers
+            .iter()
+            .map(|l| (txn.raw_iterator_cf(&l.cf), l.window))
+            .collect();
+        let mut merge = StackMerge::new(iters, Some(Cow::Borrowed(self.bounds.upper())));
+        merge.seek(self.bounds.lower())?;
+
+        let mut state = KeyState {
+            live: false,
+            asserted: None,
+            asserted_layer: None,
+        };
+        let mut idx = 0usize;
+        while let Some(row) = merge.next_borrowed() {
+            let (at_layer, k, v) = row?;
+            let at = idx;
+            idx += 1;
+            let Some(vld) = tail_validity(k) else { continue };
+            if at == 0 {
+                state.live = vld.is_assert.0;
+            }
+            if vld.is_assert.0 {
+                // The one value worth keeping; every tombstone before it is only read.
+                state.asserted = Some(v.to_vec());
+                state.asserted_layer = Some(at_layer);
+                break;
+            }
+        }
+        Ok(state)
+    }
+}
+
+/// A layer, resolved against the open database for the life of one transaction.
+pub(crate) struct BoundLayer<'a> {
+    pub(crate) name: String,
+    pub(crate) cf: Arc<BoundColumnFamily<'a>>,
+    pub(crate) window: Window,
+}
+
+/// A transaction over a stack of layers.
+///
+/// Reads compose the stack; writes land in the top layer only, which is what makes concurrent
+/// stacks safe. Catalog keys are the exception: they are global and are
+/// read and written against the default column family whatever stack is in play.
+pub struct LayeredTx<'a> {
+    pub(crate) inner: &'a LayeredInner,
+    pub(crate) tx: Option<LayeredTxn<'a>>,
+    pub(crate) stack: BoundStack<'a>,
+    pub(crate) catalog: Arc<BoundColumnFamily<'a>>,
+    /// Keys written with the pending stamp, awaiting a sequence number at commit.
+    pub(crate) pending: Vec<Vec<u8>>,
+    /// The catalog, read lazily: only a multi-layer stack needs it, and then only once.
+    pub(crate) relations: OnceCell<Catalog>,
+}
+
+// Same caveat as the other RocksDB backends: the underlying transaction is not `Sync`, and the
+// engine relies on Cozo never sharing one transaction across threads concurrently.
+unsafe impl<'a> Sync for LayeredTx<'a> {}
+
+/// Catalog keys live under the system relation, which is global across layers.
+#[inline]
+pub(crate) fn is_catalog_key(key: &[u8]) -> bool {
+    key.len() >= 8 && key[..8] == [0u8; 8]
+}
+
+impl<'a> LayeredTx<'a> {
+    fn txn(&self) -> Result<&LayeredTxn<'a>> {
+        self.tx
+            .as_ref()
+            .ok_or_else(|| miette!("transaction already committed"))
+    }
+
+    fn top(&self) -> &BoundLayer<'a> {
+        &self.stack.layers[0]
+    }
+
+    /// Where a write goes: the catalog is global, everything else goes to the top layer.
+    fn write_target(&self, key: &[u8]) -> Arc<BoundColumnFamily<'a>> {
+        if is_catalog_key(key) {
+            self.catalog.clone()
+        } else {
+            self.top().cf.clone()
+        }
+    }
+
+    /// The layers a scan of `lower` must compose. Catalog scans see the default layer alone.
+    fn read_layers(&self, lower: &[u8]) -> Vec<(Arc<BoundColumnFamily<'a>>, Window)> {
+        if is_catalog_key(lower) {
+            vec![(self.catalog.clone(), Window::OPEN)]
+        } else {
+            self.stack.layers
+                .iter()
+                .map(|l| (l.cf.clone(), l.window))
+                .collect()
+        }
+    }
+
+    fn merge(&'a self, lower: &[u8], upper: Option<Vec<u8>>) -> Result<StackMerge<'a>> {
+        let txn = self.txn()?;
+        let iters = self
+            .read_layers(lower)
+            .into_iter()
+            .map(|(cf, win)| (txn.raw_iterator_cf(&cf), win))
+            .collect();
+        Ok(StackMerge::new(iters, upper.map(std::borrow::Cow::Owned)))
+    }
+
+    fn raw_iter(&'a self, lower: &[u8], upper: Option<Vec<u8>>) -> Result<StackRawIter<'a>> {
+        Ok(StackRawIter {
+            merge: self.merge(lower, upper)?,
+            started: false,
+            lower: lower.to_vec(),
+        })
+    }
+
+    /// What the catalog says about every relation, read once per transaction and only when a
+    /// multi-layer stack actually needs it.
+    fn relations(&self) -> Result<&Catalog> {
+        if let Some(known) = self.relations.get() {
+            return Ok(known);
+        }
+        let scanned = catalog_relations(self.txn()?, &self.catalog)?;
+        Ok(self.relations.get_or_init(|| scanned))
+    }
+
+    /// The gate a multi-layer stack puts in front of every key it touches.
+    ///
+    /// Stackability is decided at relation creation and read back from the catalog here, so
+    /// the answer depends on the relation alone, not on which layer a particular row happens
+    /// to sit in, and not on whether the operation would have found anything. It fails before
+    /// any row is read, which is the whole point of checking it here rather than at delete time.
+    fn gate(&self, key: &[u8], destructive: bool) -> Result<()> {
+        if self.stack.layers.len() < 2 {
+            return Ok(());
+        }
+        if is_catalog_key(key) {
+            if destructive {
+                // Destructive DDL through a multi-layer stack would strike layers the caller is
+                // not writing to: the catalog is global, but the rows are not.
+                bail!(
+                    "destructive schema changes need a single-layer stack; this one is [{}]",
+                    self.stack_description()
+                );
+            }
+            return Ok(());
+        }
+        let Some(rel_id) = relation_of(key) else {
+            return Ok(());
+        };
+        let Some(info) = self.relations()?.get(rel_id) else {
+            // A relation the catalog has not caught up with: a definition written earlier in
+            // this same transaction. It cannot be older than this stack, so let it through.
+            return Ok(());
+        };
+        // Index relations are exempt. They hold no user records (nothing anyone retracts),
+        // and the engine maintains them inside whichever layer is being written. Reads compose
+        // through the stack by exact key, and a stack topology change invalidates them anyway:
+        // the remedy is drop-and-rebuild, not a retraction.
+        if !info.stackable && !info.is_index {
+            bail!(
+                "relation '{}' has no validity column, so it cannot express a cross-layer \
+                 retraction and may only be reached through a single-layer stack; this one is [{}]",
+                info.name,
+                self.stack_description()
+            );
+        }
+        if destructive && !info.is_index {
+            // A hard delete can only remove a row from the layer it is written to, so through a
+            // stack it is never the operation the caller wants. Index rows are the exception:
+            // they are maintained by the engine within the layer that wrote them.
+            bail!(
+                "relation '{}' cannot be deleted from through stack [{}]: a delete that must \
+                 cross layers is a retraction",
+                info.name,
+                self.stack_description()
+            );
+        }
+        Ok(())
+    }
+
+    /// The layer stack, as spelled for error messages.
+    pub(crate) fn stack_description(&self) -> String {
+        self.stack.layers
+            .iter()
+            .map(|l| match (l.window.since, l.window.bound) {
+                (None, None) => l.name.clone(),
+                (None, Some(b)) => format!("{}@{}", l.name, b),
+                (Some(s), None) => format!("{}({}..]", l.name, s),
+                (Some(s), Some(b)) => format!("{}({}..{}]", l.name, s, b),
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+/// What a stack currently says about one key's identity: everything a write-path or flatten
+/// decision needs.
+pub(crate) struct KeyState {
+    /// Whether the newest visible version asserts.
+    pub(crate) live: bool,
+    /// The value of the newest visible assertion, if the key was ever asserted. Under value
+    /// immutability every assertion under a key carries this same value.
+    pub(crate) asserted: Option<Vec<u8>>,
+    /// Which layer of the stack holds `asserted`, as an index into its layers.
+    pub(crate) asserted_layer: Option<usize>,
+}
+
+impl<'s> StoreTx<'s> for LayeredTx<'s> {
+    fn get(&self, key: &[u8], _for_update: bool) -> Result<Option<Vec<u8>>> {
+        self.gate(key, false)?;
+        let txn = self.txn()?;
+        if is_catalog_key(key) {
+            return txn
+                .get_cf(&self.catalog, key)
+                .into_diagnostic()
+                .wrap_err("failed to read catalog");
+        }
+        for layer in self.stack.layers.iter() {
+            // A key invisible through this layer's window contributes nothing here, but a
+            // lower layer with a different window may still hold it.
+            if !layer.window.admits(key) {
+                continue;
+            }
+            let found = txn
+                .get_cf(&layer.cf, key)
+                .into_diagnostic()
+                .wrap_err_with(|| format!("failed to read layer {}", layer.name))?;
+            if found.is_some() {
+                return Ok(found);
+            }
+        }
+        Ok(None)
+    }
+
+    fn put(&mut self, key: &[u8], val: &[u8]) -> Result<()> {
+        self.gate(key, false)?;
+        let target = self.write_target(key);
+        let vld = tail_validity(key);
+        let stamped = matches!(vld, Some(v) if v.timestamp.0 .0 == PENDING_SEQ);
+        // A derived row, such as an index entry, carries the stamped key of the row it describes
+        // rather than referring to it, so the pending stamp can be anywhere in either half.
+        let carries_pending =
+            stamped || contains_validity_ts(key, PENDING_SEQ) || contains_validity_ts(val, PENDING_SEQ);
+
+        // The sequence is assigned by storage, not by the query. A user-supplied value above
+        // the current sequence would shadow future writes and break layer isolation, and one
+        // below it would appear to predate a fork it postdates. Failing is better than
+        // accepting it or silently ignoring it.
+        if vld.is_some() && !stamped {
+            bail!(
+                "explicit validity is not accepted: the sequence is assigned by storage at \
+                 commit. Use 'ASSERT' or 'RETRACT'."
+            );
+        }
+
+        // A key's value is immutable; its visibility is not. Re-asserting the
+        // identical value is how a retracted record is re-introduced; asserting a different
+        // one (over a live row or a tombstoned one) is backdoor mutability, and merge
+        // soundness rests on it never happening.
+        if stamped && vld.map_or(false, |v| v.is_assert.0) {
+            // Borrow the transaction and the stack disjointly: the lookup needs the stack
+            // mutably, and the transaction is a sibling field.
+            let Self { tx, stack, .. } = self;
+            let txn = tx
+                .as_ref()
+                .ok_or_else(|| miette!("transaction already committed"))?;
+            let state = stack.key_state(txn, key)?;
+            if let Some(previous) = state.asserted {
+                if previous != val {
+                    bail!(
+                        "a different value is already asserted under this key through stack \
+                         [{}]: a record may be created and retracted, never updated",
+                        self.stack_description()
+                    );
+                }
+            }
+        }
+
+        let txn = self.txn()?;
+        txn.put_cf(&target, key, val)
+            .into_diagnostic()
+            .wrap_err("failed to write row")?;
+        if carries_pending {
+            self.pending.push(key.to_vec());
+        }
+        Ok(())
+    }
+
+    fn supports_par_put(&self) -> bool {
+        // Deliberately not supported. Parallel puts would have several threads writing to one
+        // RocksDB transaction at once, and a transaction's write batch is not thread-safe; the
+        // pending-stamp buffer and the write-path invariant check would
+        // both need locking on top of that. Cozo falls back to sequential puts, which costs
+        // bulk-import throughput and nothing else.
+        false
+    }
+
+    fn del(&mut self, key: &[u8]) -> Result<()> {
+        self.gate(key, true)?;
+        let target = self.write_target(key);
+        let txn = self.txn()?;
+        txn.delete_cf(&target, key)
+            .into_diagnostic()
+            .wrap_err("failed to delete row")
+    }
+
+    fn del_range_from_persisted(&mut self, lower: &[u8], upper: &[u8]) -> Result<()> {
+        self.gate(lower, true)?;
+        // Deletes only ever touch the layer being written to, so this is a top-layer scan.
+        let target = self.write_target(lower);
+        let txn = self.txn()?;
+        let mut it = txn.raw_iterator_cf(&target);
+        it.seek(lower);
+        let mut doomed = vec![];
+        while let Some(key) = it.key() {
+            if key >= upper {
+                break;
+            }
+            doomed.push(key.to_vec());
+            it.next();
+        }
+        it.status()
+            .into_diagnostic()
+            .wrap_err("failed to scan for range delete")?;
+        for key in doomed {
+            txn.delete_cf(&target, &key)
+                .into_diagnostic()
+                .wrap_err("failed during range delete")?;
+        }
+        Ok(())
+    }
+
+    fn exists(&self, key: &[u8], for_update: bool) -> Result<bool> {
+        Ok(self.get(key, for_update)?.is_some())
+    }
+
+    fn commit(&mut self) -> Result<()> {
+        let txn = self
+            .tx
+            .take()
+            .ok_or_else(|| miette!("transaction already committed"))?;
+
+        // The stamp is commit order, so it has to be read where commits are serialized, and the
+        // batch has to land before the next commit proceeds.
+        let _ordered = self
+            .inner
+            .commit_lock
+            .lock()
+            .map_err(|_| miette!("commit lock poisoned"))?;
+
+        if !self.pending.is_empty() {
+            let seq = self.inner.next_stamp();
+            let cf = self.top().cf.clone();
+            for key in std::mem::take(&mut self.pending) {
+                // A row written and then deleted within this transaction has nothing to stamp.
+                let Some(mut val) = txn.get_cf(&cf, &key).into_diagnostic()? else {
+                    continue;
+                };
+                let mut stamped = key.clone();
+                restamp_all_validity(&mut stamped, PENDING_SEQ, seq);
+                restamp_all_validity(&mut val, PENDING_SEQ, seq);
+                txn.delete_cf(&cf, &key).into_diagnostic()?;
+                txn.put_cf(&cf, &stamped, &val).into_diagnostic()?;
+            }
+        }
+
+        txn.commit().into_diagnostic().wrap_err("commit failed")
+    }
+
+    fn range_scan_tuple<'a>(
+        &'a self,
+        lower: &[u8],
+        upper: &[u8],
+    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a>
+    where
+        's: 'a,
+    {
+        match self.gate(lower, false).and_then(|()| self.raw_iter(lower, Some(upper.to_vec()))) {
+            Ok(inner) => Box::new(StackTupleIter { inner }),
+            Err(err) => Box::new(std::iter::once(Err(err))),
+        }
+    }
+
+    fn range_skip_scan_tuple<'a>(
+        &'a self,
+        lower: &[u8],
+        upper: &[u8],
+        valid_at: ValidityTs,
+    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a> {
+        match self.gate(lower, false).and_then(|()| self.merge(lower, Some(upper.to_vec()))) {
+            Ok(merge) => Box::new(StackSkipIter {
+                merge,
+                valid_at,
+                next_bound: lower.to_vec(),
+            }),
+            Err(err) => Box::new(std::iter::once(Err(err))),
+        }
+    }
+
+    fn range_scan<'a>(
+        &'a self,
+        lower: &[u8],
+        upper: &[u8],
+    ) -> Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>)>> + 'a>
+    where
+        's: 'a,
+    {
+        match self.gate(lower, false).and_then(|()| self.raw_iter(lower, Some(upper.to_vec()))) {
+            Ok(it) => Box::new(it),
+            Err(err) => Box::new(std::iter::once(Err(err))),
+        }
+    }
+
+    fn range_count<'a>(&'a self, lower: &[u8], upper: &[u8]) -> Result<usize>
+    where
+        's: 'a,
+    {
+        self.gate(lower, false)?;
+        let mut count = 0;
+        for row in self.raw_iter(lower, Some(upper.to_vec()))? {
+            row?;
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    fn total_scan<'a>(&'a self) -> Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>)>> + 'a>
+    where
+        's: 'a,
+    {
+        // A total scan is over user data, which lives in the stack; the catalog rides along in
+        // the default layer, exactly as it does for a single-store engine.
+        match self.raw_iter(&[], None) {
+            Ok(it) => Box::new(it),
+            Err(err) => Box::new(std::iter::once(Err(err))),
+        }
+    }
+}
+
+/// The sequence a stamped row would carry if it were committed right now. Only meaningful
+/// under the commit lock.
+impl LayeredInner {
+    pub(crate) fn next_stamp(&self) -> Seq {
+        // `latest_sequence_number` is the last sequence RocksDB assigned, which is exactly the
+        // fork point a consumer would have captured. Stamping one above it is what
+        // makes a fork point stable: rows committed after a fork are strictly above it.
+        self.db.latest_sequence_number() as Seq + 1
+    }
+}
+
+/// Resolve a stack spec against the open database, for the life of one transaction.
+pub(crate) fn bind_layers<'a>(
+    inner: &'a LayeredInner,
+    spec: &StackSpec,
+) -> Result<Vec<BoundLayer<'a>>> {
+    spec.layers
+        .iter()
+        .map(|layer| {
+            let cf = inner.db.cf_handle(&layer.name).ok_or_else(|| {
+                miette!(
+                    "layer '{}' is not open; it was dropped or never created",
+                    layer.name
+                )
+            })?;
+            Ok(BoundLayer {
+                name: layer.name.clone(),
+                cf,
+                window: layer.window,
+            })
+        })
+        .collect()
+}

--- a/cozo-core/src/storage/layered/tx.rs
+++ b/cozo-core/src/storage/layered/tx.rs
@@ -20,7 +20,7 @@ use crate::storage::layered::iter::{
     LayeredTxn, StackMerge, StackRawIter, StackSkipIter, StackTupleIter, Window,
 };
 use crate::storage::layered::{LayeredInner, StackSpec, Seq, PENDING_SEQ};
-use crate::storage::StoreTx;
+use crate::storage::{StorageView, StoreTx};
 
 /// A resolved stack, together with the scratch space its per-key lookups reuse.
 ///
@@ -28,13 +28,17 @@ use crate::storage::StoreTx;
 /// consumed inside a single call, so nothing outside this type sees them.
 pub(crate) struct BoundStack<'a> {
     pub(crate) layers: Vec<BoundLayer<'a>>,
+    /// The identity of the stack these layers came from, carried so a transaction can report
+    /// which view it reads without re-deriving it.
+    pub(crate) view: StorageView,
     bounds: KeyBounds,
 }
 
 impl<'a> BoundStack<'a> {
-    pub(crate) fn new(layers: Vec<BoundLayer<'a>>) -> Self {
+    pub(crate) fn new(layers: Vec<BoundLayer<'a>>, view: StorageView) -> Self {
         Self {
             layers,
+            view,
             bounds: KeyBounds::default(),
         }
     }
@@ -93,6 +97,8 @@ impl<'a> BoundStack<'a> {
 /// A layer, resolved against the open database for the life of one transaction.
 pub(crate) struct BoundLayer<'a> {
     pub(crate) name: String,
+    /// The incarnation the name resolved to; part of this stack's view identity.
+    pub(crate) incarnation: u64,
     pub(crate) cf: Arc<BoundColumnFamily<'a>>,
     pub(crate) window: Window,
 }
@@ -290,6 +296,73 @@ impl<'s> StoreTx<'s> for LayeredTx<'s> {
             }
         }
         Ok(None)
+    }
+
+    /// Resolve many keys at once: one batched read per layer rather than one point lookup per
+    /// key per layer.
+    ///
+    /// Layers are visited top first and a slot is filled only once, so the result is the same
+    /// as calling [`StoreTx::get`] on each key, which is what the default implementation does.
+    /// Which view this transaction reads, decided when the stack was resolved.
+    ///
+    /// Interning happens in `resolve`, which already holds the layer registry, so this is a
+    /// field read: the identity costs nothing to hand out and nothing to compare.
+    fn storage_view(&self) -> StorageView {
+        self.stack.view.clone()
+    }
+
+    fn multi_get(&self, keys: &[Vec<u8>], _for_update: bool) -> Result<Vec<Option<Vec<u8>>>> {
+        for key in keys {
+            self.gate(key, false)?;
+        }
+        let txn = self.txn()?;
+        let mut out: Vec<Option<Vec<u8>>> = vec![None; keys.len()];
+
+        // The catalog is global, so its keys are resolved against the default layer whatever
+        // stack is in play.
+        let catalog_at: Vec<usize> = (0..keys.len())
+            .filter(|&i| is_catalog_key(&keys[i]))
+            .collect();
+        if !catalog_at.is_empty() {
+            let found = txn.multi_get_cf(
+                catalog_at
+                    .iter()
+                    .map(|&i| (&self.catalog, keys[i].as_slice())),
+            );
+            for (&at, res) in catalog_at.iter().zip(found) {
+                out[at] = res.into_diagnostic().wrap_err("failed to read catalog")?;
+            }
+        }
+
+        let mut pending: Vec<usize> = (0..keys.len())
+            .filter(|&i| !is_catalog_key(&keys[i]) )
+            .collect();
+        for layer in self.stack.layers.iter() {
+            if pending.is_empty() {
+                break;
+            }
+            // A key this layer's window excludes contributes nothing here, but a lower layer
+            // with a different window may still hold it.
+            let asking: Vec<usize> = pending
+                .iter()
+                .copied()
+                .filter(|&i| layer.window.admits(&keys[i]))
+                .collect();
+            if asking.is_empty() {
+                continue;
+            }
+            let found = txn.multi_get_cf(asking.iter().map(|&i| (&layer.cf, keys[i].as_slice())));
+            for (&at, res) in asking.iter().zip(found) {
+                if let Some(val) = res
+                    .into_diagnostic()
+                    .wrap_err_with(|| format!("failed to read layer {}", layer.name))?
+                {
+                    out[at] = Some(val);
+                }
+            }
+            pending.retain(|&i| out[i].is_none());
+        }
+        Ok(out)
     }
 
     fn put(&mut self, key: &[u8], val: &[u8]) -> Result<()> {
@@ -524,6 +597,7 @@ pub(crate) fn bind_layers<'a>(
             })?;
             Ok(BoundLayer {
                 name: layer.name.clone(),
+                incarnation: layer.incarnation,
                 cf,
                 window: layer.window,
             })

--- a/cozo-core/src/storage/layered/tx.rs
+++ b/cozo-core/src/storage/layered/tx.rs
@@ -15,12 +15,11 @@ use crate::data::memcmp::{
 };
 use crate::storage::layered::catalog::{catalog_relations, relation_of, Catalog};
 use crate::data::tuple::Tuple;
-use crate::data::value::ValidityTs;
 use crate::storage::layered::iter::{
-    LayeredTxn, StackMerge, StackRawIter, StackSkipIter, StackTupleIter, Window,
+    LayeredTxn, StackCursor, StackMerge, StackRawIter, StackTupleIter, Window,
 };
 use crate::storage::layered::{LayeredInner, StackSpec, Seq, PENDING_SEQ};
-use crate::storage::{StorageView, StoreTx};
+use crate::storage::{StorageView, StoreCursor, StoreTx};
 
 /// A resolved stack, together with the scratch space its per-key lookups reuse.
 ///
@@ -514,20 +513,14 @@ impl<'s> StoreTx<'s> for LayeredTx<'s> {
         }
     }
 
-    fn range_skip_scan_tuple<'a>(
-        &'a self,
-        lower: &[u8],
-        upper: &[u8],
-        valid_at: ValidityTs,
-    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a> {
-        match self.gate(lower, false).and_then(|()| self.merge(lower, Some(upper.to_vec()))) {
-            Ok(merge) => Box::new(StackSkipIter {
-                merge,
-                valid_at,
-                next_bound: lower.to_vec(),
-            }),
-            Err(err) => Box::new(std::iter::once(Err(err))),
-        }
+    fn cursor<'a>(&'a self, lower: &[u8], upper: &[u8]) -> Result<Box<dyn StoreCursor + 'a>>
+    where
+        's: 'a,
+    {
+        self.gate(lower, false)?;
+        Ok(Box::new(StackCursor::new(
+            self.merge(lower, Some(upper.to_vec()))?,
+        )))
     }
 
     fn range_scan<'a>(

--- a/cozo-core/src/storage/mem.rs
+++ b/cozo-core/src/storage/mem.rs
@@ -19,10 +19,9 @@ use std::sync::Arc;
 use itertools::Itertools;
 use miette::{bail, Result};
 
-use crate::data::tuple::{check_key_for_validity, Tuple};
-use crate::data::value::ValidityTs;
-use crate::runtime::relation::{try_decode_tuple_from_kv, try_extend_tuple_from_v};
-use crate::storage::{Storage, StoreTx};
+use crate::data::tuple::Tuple;
+use crate::runtime::relation::try_decode_tuple_from_kv;
+use crate::storage::{Storage, StoreCursor, StoreTx};
 use crate::utils::swap_option_result;
 
 /// Create a database backed by memory.
@@ -198,28 +197,21 @@ impl<'s> StoreTx<'s> for MemTx<'s> {
         }
     }
 
-    fn range_skip_scan_tuple<'a>(
-        &'a self,
-        lower: &[u8],
-        upper: &[u8],
-        valid_at: ValidityTs,
-    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a> {
-        match self {
-            MemTx::Reader(stored) => Box::new(SkipIterator {
-                inner: stored,
-                upper: upper.to_vec(),
-                valid_at,
-                next_bound: lower.to_vec(),
-                size_hint: None,
-            }),
-            MemTx::Writer(stored, delta) => Box::new(SkipDualIterator {
-                stored,
-                delta,
-                upper: upper.to_vec(),
-                valid_at,
-                next_bound: lower.to_vec(),
-            }),
-        }
+    fn cursor<'a>(&'a self, _lower: &[u8], upper: &[u8]) -> Result<Box<dyn StoreCursor + 'a>>
+    where
+        's: 'a,
+    {
+        let (stored, delta) = match self {
+            MemTx::Reader(stored) => (&**stored, None),
+            MemTx::Writer(stored, delta) => (&**stored, Some(delta)),
+        };
+        Ok(Box::new(MemCursor {
+            stored,
+            delta,
+            upper: upper.to_vec(),
+            at: Vec::new(),
+            current: None,
+        }))
     }
 
     fn range_scan<'a>(
@@ -435,100 +427,85 @@ impl Iterator for CacheIter<'_> {
 }
 
 /// Keep an eye on https://github.com/rust-lang/rust/issues/49638
-pub(crate) struct SkipIterator<'a> {
-    pub(crate) inner: &'a BTreeMap<Vec<u8>, Vec<u8>>,
-    pub(crate) upper: Vec<u8>,
-    pub(crate) valid_at: ValidityTs,
-    pub(crate) next_bound: Vec<u8>,
-    pub(crate) size_hint: Option<usize>,
+
+/// A positioned scan over the stored map, with a write transaction's pending changes laid over
+/// it. A key the transaction has deleted is stepped over, exactly as a committed delete would
+/// be, so the two read alike.
+pub(crate) struct MemCursor<'a> {
+    stored: &'a BTreeMap<Vec<u8>, Vec<u8>>,
+    delta: Option<&'a BTreeMap<Vec<u8>, Option<Vec<u8>>>>,
+    upper: Vec<u8>,
+    /// The seek position, held here so stepping over a deleted key reuses one buffer.
+    at: Vec<u8>,
+    current: Option<(&'a [u8], &'a [u8])>,
 }
 
-impl<'a> Iterator for SkipIterator<'a> {
-    type Item = Result<Tuple>;
+impl<'a> MemCursor<'a> {
+    /// A cursor over a plain map, with no pending changes laid over it.
+    pub(crate) fn over(stored: &'a BTreeMap<Vec<u8>, Vec<u8>>, upper: &[u8]) -> MemCursor<'a> {
+        MemCursor {
+            stored,
+            delta: None,
+            upper: upper.to_vec(),
+            at: Vec::new(),
+            current: None,
+        }
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
+    fn first_at_or_after<'k, V>(
+        map: &'a BTreeMap<Vec<u8>, V>,
+        from: &'k [u8],
+        upper: &'k [u8],
+    ) -> Option<(&'a [u8], &'a V)> {
+        map.range::<[u8], _>((Bound::Included(from), Bound::Excluded(upper)))
+            .next()
+            .map(|(k, v)| (k.as_slice(), v))
+    }
+}
+
+impl StoreCursor for MemCursor<'_> {
+    fn seek(&mut self, from: &[u8]) -> Result<bool> {
+        self.at.clear();
+        self.at.extend_from_slice(from);
         loop {
-            let nxt = self
-                .inner
-                .range::<Vec<u8>, (Bound<&Vec<u8>>, Bound<&Vec<u8>>)>((
-                    Bound::Included(&self.next_bound),
-                    Bound::Excluded(&self.upper),
-                ))
-                .next();
-            match nxt {
-                None => return None,
-                Some((candidate_key, candidate_val)) => {
-                    let (ret, nxt_bound) =
-                        check_key_for_validity(candidate_key, self.valid_at, self.size_hint);
-                    self.next_bound = nxt_bound;
-                    if let Some(mut nk) = ret {
-                        return Some(try_extend_tuple_from_v(&mut nk, candidate_val).map(|()| nk));
-                    }
+            let stored = Self::first_at_or_after(self.stored, &self.at, &self.upper)
+                .map(|(key, val)| (key, val.as_slice()));
+            let pending = match self.delta {
+                None => None,
+                Some(delta) => Self::first_at_or_after(delta, &self.at, &self.upper),
+            };
+            // Whichever key comes first wins, and a pending change wins a tie because it is
+            // the newer state of that key.
+            let (key, change) = match pending {
+                Some((key, change)) if stored.map_or(true, |(at, _)| key <= at) => (key, change),
+                _ => {
+                    self.current = stored;
+                    return Ok(stored.is_some());
+                }
+            };
+            match change {
+                Some(val) => {
+                    self.current = Some((key, val.as_slice()));
+                    return Ok(true);
+                }
+                // A key this transaction deleted: resume just past it.
+                None => {
+                    self.at.clear();
+                    self.at.extend_from_slice(key);
+                    self.at.push(0);
                 }
             }
         }
     }
-}
 
-struct SkipDualIterator<'a> {
-    stored: &'a BTreeMap<Vec<u8>, Vec<u8>>,
-    delta: &'a BTreeMap<Vec<u8>, Option<Vec<u8>>>,
-    upper: Vec<u8>,
-    valid_at: ValidityTs,
-    next_bound: Vec<u8>,
-}
+    fn key(&self) -> &[u8] {
+        self.current.expect("cursor key after a successful seek").0
+    }
 
-impl<'a> Iterator for SkipDualIterator<'a> {
-    type Item = Result<Tuple>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            let stored_nxt = self
-                .stored
-                .range::<Vec<u8>, (Bound<&Vec<u8>>, Bound<&Vec<u8>>)>((
-                    Bound::Included(&self.next_bound),
-                    Bound::Excluded(&self.upper),
-                ))
-                .next();
-            let delta_nxt = self
-                .delta
-                .range::<Vec<u8>, (Bound<&Vec<u8>>, Bound<&Vec<u8>>)>((
-                    Bound::Included(&self.next_bound),
-                    Bound::Excluded(&self.upper),
-                ))
-                .next();
-            let (candidate_key, candidate_val) = match (stored_nxt, delta_nxt) {
-                (None, None) => return None,
-                (None, Some((delta_key, maybe_delta_val))) => match maybe_delta_val {
-                    None => {
-                        let (_, nxt_seek) = check_key_for_validity(delta_key, self.valid_at, None);
-                        self.next_bound = nxt_seek;
-                        continue;
-                    }
-                    Some(delta_val) => (delta_key, delta_val),
-                },
-                (Some((stored_key, stored_val)), None) => (stored_key, stored_val),
-                (Some((stored_key, stored_val)), Some((delta_key, maybe_delta_val))) => {
-                    if stored_key < delta_key {
-                        (stored_key, stored_val)
-                    } else {
-                        match maybe_delta_val {
-                            None => {
-                                let (_, nxt_seek) =
-                                    check_key_for_validity(delta_key, self.valid_at, None);
-                                self.next_bound = nxt_seek;
-                                continue;
-                            }
-                            Some(delta_val) => (delta_key, delta_val),
-                        }
-                    }
-                }
-            };
-            let (ret, nxt_bound) = check_key_for_validity(candidate_key, self.valid_at, None);
-            self.next_bound = nxt_bound;
-            if let Some(mut nk) = ret {
-                return Some(try_extend_tuple_from_v(&mut nk, candidate_val).map(|()| nk));
-            }
-        }
+    fn value(&mut self) -> Result<&[u8]> {
+        Ok(self
+            .current
+            .expect("cursor value after a successful seek")
+            .1)
     }
 }

--- a/cozo-core/src/storage/mod.rs
+++ b/cozo-core/src/storage/mod.rs
@@ -12,6 +12,27 @@ use crate::data::tuple::Tuple;
 use crate::data::value::ValidityTs;
 use crate::try_decode_tuple_from_kv;
 
+// `storage-rocksdb` links a RocksDB built from the vendored submodule through `cozorocks`.
+// `storage-new-rocksdb` and `storage-layered` link a second one through `librocksdb-sys`. Both
+// are static, both export the same C++ symbols, and they are built from different RocksDB
+// releases, so a binary holding both resolves calls across mismatched layouts and dies with a
+// segmentation fault rather than a test failure.
+//
+// Cargo features are additive and cannot express the exclusion, so it is rejected here. This
+// makes `--all-features` fail to build, which is the point: it used to segfault.
+#[cfg(all(feature = "storage-rocksdb", feature = "storage-new-rocksdb"))]
+compile_error!(
+    "features `storage-rocksdb` and `storage-new-rocksdb` cannot be enabled together: each \
+     links its own static build of RocksDB, and the two export the same symbols"
+);
+#[cfg(all(feature = "storage-rocksdb", feature = "storage-layered"))]
+compile_error!(
+    "features `storage-rocksdb` and `storage-layered` cannot be enabled together: each links \
+     its own static build of RocksDB, and the two export the same symbols"
+);
+
+#[cfg(feature = "storage-layered")]
+pub mod layered;
 pub(crate) mod mem;
 #[cfg(feature = "storage-new-rocksdb")]
 pub mod newrocks;
@@ -33,6 +54,16 @@ pub trait Storage<'s>: Send + Sync + Clone {
 
     /// Returns a string that identifies the storage kind
     fn storage_kind(&self) -> &'static str;
+
+    /// What `'NOW'` means to this engine when a script is run.
+    ///
+    /// The default is wall-clock time, which is what a single-store engine has to use. An
+    /// engine that assigns validity itself (the layered engine stamps commit order) returns
+    /// its own marker instead, so that scripts run through the ordinary entry points are
+    /// stamped the same way as those run through the engine's own.
+    fn now_validity(&self) -> ValidityTs {
+        crate::data::functions::current_validity()
+    }
 
     /// Create a transaction object. Write ops will only be called when `write == true`.
     fn transact(&'s self, write: bool) -> Result<Self::Tx>;

--- a/cozo-core/src/storage/mod.rs
+++ b/cozo-core/src/storage/mod.rs
@@ -13,7 +13,8 @@ use std::sync::Arc;
 
 use miette::{bail, Result};
 
-use crate::data::tuple::Tuple;
+use crate::data::tuple::{check_key_for_validity, Tuple};
+use crate::runtime::relation::try_extend_tuple_from_v;
 use crate::data::value::ValidityTs;
 use crate::try_decode_tuple_from_kv;
 
@@ -211,6 +212,134 @@ pub trait Storage<'s>: Send + Sync + Clone {
 
 /// Trait for the associated transaction type of a storage engine.
 /// A transaction needs to guarantee MVCC semantics for all operations.
+/// The validity skip scan: seek, test the key, read the value only if the test asks for it,
+/// and resume wherever the test says.
+struct SkipScan<'a> {
+    cursor: Box<dyn StoreCursor + 'a>,
+    matcher: Box<dyn SkipMatch + 'a>,
+    valid_at: ValidityTs,
+    next_bound: Vec<u8>,
+    done: bool,
+}
+
+impl SkipScan<'_> {
+    /// Resume just past `key`, the smallest bound that cannot land on it again.
+    fn after(key: &[u8]) -> Vec<u8> {
+        let mut bound = Vec::with_capacity(key.len() + 1);
+        bound.extend_from_slice(key);
+        bound.push(0);
+        bound
+    }
+
+    fn next_inner(&mut self) -> Result<Option<Tuple>> {
+        while self.cursor.seek(&self.next_bound)? {
+            // The validity rule reads the key alone, and the bound it returns clears every
+            // remaining row of this key prefix.
+            let (admitted, past_group) =
+                check_key_for_validity(self.cursor.key(), self.valid_at, None);
+            self.next_bound = past_group;
+            let Some(mut row) = admitted else { continue };
+            // A row the key test kept is offered its value, which only the matcher can
+            // decide to decode. The borrow ends with the call, leaving the key reachable below.
+            let step = match self.matcher.match_key(&row)? {
+                Step::Yield => self.matcher.match_value(&mut row, self.cursor.value()?)?,
+                declined => declined,
+            };
+            match step {
+                Step::Yield => return Ok(Some(row)),
+                Step::SkipGroup => continue,
+                Step::NextKey => {
+                    self.next_bound = Self::after(self.cursor.key());
+                    continue;
+                }
+            }
+        }
+        Ok(None)
+    }
+}
+
+impl Iterator for SkipScan<'_> {
+    type Item = Result<Tuple>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
+        match self.next_inner() {
+            Ok(None) => {
+                self.done = true;
+                None
+            }
+            Ok(Some(tuple)) => Some(Ok(tuple)),
+            Err(err) => {
+                self.done = true;
+                Some(Err(err))
+            }
+        }
+    }
+}
+
+/// A scan positioned on one row at a time, able to jump to an arbitrary key.
+///
+/// The value is fetched separately from the key because reading it is not free everywhere: the
+/// SQLite backend copies the blob out of the row, and a scan that decides from the key alone
+/// should not pay for it.
+pub trait StoreCursor {
+    /// Move to the first entry at or after `from`. `false` once nothing is left below the
+    /// upper bound the cursor was built with.
+    fn seek(&mut self, from: &[u8]) -> Result<bool>;
+
+    /// The key at the current position. Only valid after `seek` returned `true`.
+    fn key(&self) -> &[u8];
+
+    /// The value at the current position. Only valid after `seek` returned `true`.
+    fn value(&mut self) -> Result<&[u8]>;
+}
+
+/// Whether a scan returns a row, and where it resumes afterwards.
+pub enum Step {
+    /// Return the row.
+    Yield,
+    /// Discard it and resume past every row sharing its key prefix.
+    SkipGroup,
+    /// Discard it and resume at the key immediately after it.
+    NextKey,
+}
+
+/// Which rows a validity scan returns, and where it resumes after each one it declines.
+///
+/// The two halves run in order, and the second only when the first asks for it, so a scan that
+/// decides from key columns never pays to materialize a value it would discard. Each decision
+/// names where the scan resumes, so declining on a value is not silently assumed to resume
+/// wherever declining on a key would have.
+pub trait SkipMatch {
+    /// Decide from the key columns of a row the validity rule admitted. A row declined here
+    /// never has its value read.
+    fn match_key(&mut self, key: &Tuple) -> Result<Step>;
+
+    /// Decide again for a row `match_key` kept, given its value bytes.
+    ///
+    /// Decoding them into `row` is what costs, not receiving them, so this is where a scan
+    /// that only wants key columns declines to pay: override it to ignore `value`. The default
+    /// appends them, which is what a scan returning whole tuples wants.
+    fn match_value(&mut self, row: &mut Tuple, value: &[u8]) -> Result<Step> {
+        try_extend_tuple_from_v(row, value)?;
+        Ok(Step::Yield)
+    }
+}
+
+/// The rule every stored relation's time-travel scan follows: of the rows sharing a key prefix,
+/// the newest assertion no later than `valid_at`, and nothing else.
+///
+/// Left alone it reproduces `range_skip_scan_tuple`; wrap it to add conditions of your own.
+pub struct LiveAt;
+
+impl SkipMatch for LiveAt {
+    fn match_key(&mut self, _key: &Tuple) -> Result<Step> {
+        Ok(Step::Yield)
+    }
+}
+
 pub trait StoreTx<'s>: Sync {
     /// Get a key. If `for_update` is `true` (only possible in a write transaction),
     /// then the database needs to guarantee that `commit()` can only succeed if
@@ -302,6 +431,15 @@ pub trait StoreTx<'s>: Sync {
         }))
     }
 
+    /// A positioned scan over `[lower, upper)` that can jump.
+    ///
+    /// A skip rule rejects a key and then resumes from a position it computes, which a forward
+    /// iterator cannot express. This is the only part of such a scan that depends on the
+    /// backend; the rules themselves are shared.
+    fn cursor<'a>(&'a self, lower: &[u8], upper: &[u8]) -> Result<Box<dyn StoreCursor + 'a>>
+    where
+        's: 'a;
+
     /// Scan on a range with a certain validity.
     ///
     /// `lower` is inclusive whereas `upper` is exclusive.
@@ -323,7 +461,39 @@ pub trait StoreTx<'s>: Sync {
         lower: &[u8],
         upper: &[u8],
         valid_at: ValidityTs,
-    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a>;
+    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a>
+    where
+        's: 'a,
+    {
+        self.range_skip_scan_matched(lower, upper, valid_at, Box::new(LiveAt))
+    }
+
+    /// The same scan, with a say in which rows come back and where it resumes after the ones
+    /// that do not. See [`SkipMatch`].
+    ///
+    /// This is where the validity rule actually lives, written once over [`cursor`](Self::cursor)
+    /// rather than per backend.
+    fn range_skip_scan_matched<'a>(
+        &'a self,
+        lower: &[u8],
+        upper: &[u8],
+        valid_at: ValidityTs,
+        matcher: Box<dyn SkipMatch + 'a>,
+    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a>
+    where
+        's: 'a,
+    {
+        match self.cursor(lower, upper) {
+            Ok(cursor) => Box::new(SkipScan {
+                cursor,
+                matcher,
+                valid_at,
+                next_bound: lower.to_vec(),
+                done: false,
+            }),
+            Err(err) => Box::new(std::iter::once(Err(err))),
+        }
+    }
 
     /// Two-level bitemporal scan (mnestic fork, bitemporality step 4b; see
     /// `data/bitemporal.rs`). The default implementation drives the generic

--- a/cozo-core/src/storage/mod.rs
+++ b/cozo-core/src/storage/mod.rs
@@ -6,6 +6,11 @@
  * You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
+use std::any::Any;
+use std::cmp::Ordering;
+use std::fmt::Debug;
+use std::sync::Arc;
+
 use miette::{bail, Result};
 
 use crate::data::tuple::Tuple;
@@ -46,6 +51,77 @@ pub(crate) mod temp;
 #[cfg(feature = "storage-tikv")]
 pub(crate) mod tikv;
 // pub(crate) mod re;
+
+/// An engine's identity for one of the views it presents.
+///
+/// Implemented by the engine, never inspected outside it. The only thing anything else may do
+/// with one is compare it to another, and the only promise an engine makes is that two of its
+/// transactions get equal identities exactly when they see equal content.
+///
+/// An implementor orders only against its own type and answers `None` otherwise; [`StorageView`]
+/// settles those by concrete type instead. So no implementor has to invent an order against
+/// types it has never heard of, and the common case costs one downcast rather than a type
+/// comparison followed by one.
+pub trait ViewIdentity: Any + Debug + Send + Sync {
+    /// Order this identity against another, or `None` if `other` is not the same type.
+    fn view_cmp(&self, other: &dyn ViewIdentity) -> Option<Ordering>;
+}
+
+/// Which view of the store a transaction reads.
+///
+/// Engine-level caches key their entries on relation identity plus a content version, which is
+/// sound only while every transaction sees the same content for a relation at a given version.
+/// An engine whose transactions can disagree without any write between them breaks that, so it
+/// distinguishes its views here and the caches key on this as well.
+///
+/// The identity type belongs to the engine: what divides a store is the engine's business, and
+/// differs entirely between one that shards, one that reads a replica with lag, and one that
+/// composes layers. An engine that presents its store whole reports [`StorageView::undivided`],
+/// which is what the default implementation does.
+#[derive(Clone, Debug, Default)]
+pub struct StorageView(Option<Arc<dyn ViewIdentity>>);
+
+impl StorageView {
+    /// The store presented whole: one view, nothing to tell apart.
+    pub fn undivided() -> Self {
+        StorageView(None)
+    }
+
+    /// An engine's identity for one of several views it presents.
+    pub fn of(identity: Arc<dyn ViewIdentity>) -> Self {
+        StorageView(Some(identity))
+    }
+}
+
+impl Ord for StorageView {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match (&self.0, &other.0) {
+            (None, None) => Ordering::Equal,
+            (None, Some(_)) => Ordering::Less,
+            (Some(_), None) => Ordering::Greater,
+            (Some(a), Some(b)) => a.view_cmp(b.as_ref()).unwrap_or_else(|| {
+                // Different engines' identities, which only meet if a process runs more than
+                // one engine. Ordering by concrete type keeps the total order total; nothing
+                // depends on which type sorts first.
+                Any::type_id(a.as_ref()).cmp(&Any::type_id(b.as_ref()))
+            }),
+        }
+    }
+}
+
+impl PartialOrd for StorageView {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for StorageView {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for StorageView {}
 
 /// Swappable storage trait for Cozo's storage engine
 pub trait Storage<'s>: Send + Sync + Clone {
@@ -144,6 +220,13 @@ pub trait StoreTx<'s>: Sync {
     /// Get multiple keys. If `for_update` is `true` (only possible in a write transaction),
     /// then the database needs to guarantee that `commit()` can only succeed if
     /// the keys have not been modified outside the transaction.
+    /// Which view of the store this transaction reads, for caches that would otherwise
+    /// conflate two transactions seeing different content. Defaults to
+    /// [`StorageView::undivided`]; only the layered backend composes more than one view.
+    fn storage_view(&self) -> StorageView {
+        StorageView::undivided()
+    }
+
     fn multi_get(&self, keys: &[Vec<u8>], for_update: bool) -> Result<Vec<Option<Vec<u8>>>> {
         keys.iter().map(|k| self.get(k, for_update)).collect()
     }
@@ -293,4 +376,90 @@ pub trait StoreTx<'s>: Sync {
     fn total_scan<'a>(&'a self) -> Box<dyn Iterator<Item = Result<(Vec<u8>, Vec<u8>)>> + 'a>
     where
         's: 'a;
+}
+
+#[cfg(test)]
+mod view_tests {
+    use std::cmp::Ordering;
+    use std::sync::Arc;
+
+    use super::{StorageView, ViewIdentity};
+
+    /// Two engines, so the cross-type path is reachable. Neither knows the other exists, which
+    /// is the point: each answers only for its own type.
+    #[derive(Debug)]
+    struct Alpha(u64);
+    #[derive(Debug)]
+    struct Beta(u64);
+
+    impl ViewIdentity for Alpha {
+        fn view_cmp(&self, other: &dyn ViewIdentity) -> Option<Ordering> {
+            (other as &dyn std::any::Any)
+                .downcast_ref::<Alpha>()
+                .map(|other| self.0.cmp(&other.0))
+        }
+    }
+    impl ViewIdentity for Beta {
+        fn view_cmp(&self, other: &dyn ViewIdentity) -> Option<Ordering> {
+            (other as &dyn std::any::Any)
+                .downcast_ref::<Beta>()
+                .map(|other| self.0.cmp(&other.0))
+        }
+    }
+
+    fn alpha(n: u64) -> StorageView {
+        StorageView::of(Arc::new(Alpha(n)))
+    }
+    fn beta(n: u64) -> StorageView {
+        StorageView::of(Arc::new(Beta(n)))
+    }
+
+    #[test]
+    fn an_engine_orders_its_own_views() {
+        assert_eq!(alpha(1), alpha(1));
+        assert_ne!(alpha(1), alpha(2));
+        assert!(alpha(1) < alpha(2));
+    }
+
+    #[test]
+    fn the_undivided_store_is_its_own_view() {
+        assert_eq!(StorageView::undivided(), StorageView::undivided());
+        assert_ne!(StorageView::undivided(), alpha(0));
+        assert!(StorageView::undivided() < alpha(0));
+    }
+
+    /// Identities from different engines never compare equal, and the order between them is
+    /// antisymmetric. A `BTreeMap` keyed on these would corrupt silently otherwise.
+    #[test]
+    fn identities_from_different_engines_are_ordered_not_conflated() {
+        assert_ne!(alpha(7), beta(7), "same number, different engines");
+        assert_eq!(
+            alpha(7).cmp(&beta(7)).reverse(),
+            beta(7).cmp(&alpha(7)),
+            "the order between two engines is not antisymmetric"
+        );
+        // Whichever way the types sort, it must be consistent across values.
+        let first = alpha(0).cmp(&beta(0));
+        for (a, b) in [(0, 99), (99, 0), (5, 5)] {
+            assert_eq!(
+                alpha(a).cmp(&beta(b)),
+                first,
+                "type ordering must not depend on the values"
+            );
+        }
+    }
+
+    /// The ordering is total, which is what a map keyed on it requires.
+    #[test]
+    fn mixed_identities_sort_into_a_stable_total_order() {
+        use std::collections::BTreeSet;
+        let mut set = BTreeSet::new();
+        for v in [alpha(2), beta(1), StorageView::undivided(), alpha(1), beta(2)] {
+            assert!(set.insert(v), "a distinct view collided with one already present");
+        }
+        assert_eq!(set.len(), 5);
+        // Re-inserting an equal identity must be recognised as already present.
+        assert!(!set.insert(alpha(1)));
+        assert!(!set.insert(StorageView::undivided()));
+    }
 }

--- a/cozo-core/src/storage/newrocks.rs
+++ b/cozo-core/src/storage/newrocks.rs
@@ -2,7 +2,7 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
-use miette::{miette, IntoDiagnostic, Result, WrapErr};
+use miette::{bail, miette, IntoDiagnostic, Result, WrapErr};
 
 use rocksdb::{
     OptimisticTransactionDB, OptimisticTransactionOptions, Options, WriteBatchWithTransaction,
@@ -13,7 +13,7 @@ use crate::data::tuple::{check_key_for_validity, Tuple};
 use crate::data::value::ValidityTs;
 use crate::runtime::db::{BadDbInit, DbManifest};
 use crate::runtime::relation::{try_decode_tuple_from_kv, try_extend_tuple_from_v};
-use crate::storage::{Storage, StoreTx};
+use crate::storage::{Storage, StoreCursor, StoreTx};
 use crate::Db;
 
 const KEY_PREFIX_LEN: usize = 9;
@@ -296,25 +296,17 @@ impl<'s> StoreTx<'s> for NewRocksDbTx<'s> {
         }
     }
 
-    fn range_skip_scan_tuple<'a>(
-        &'a self,
-        lower: &[u8],
-        upper: &[u8],
-        valid_at: ValidityTs,
-    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a> {
+    fn cursor<'a>(&'a self, _lower: &[u8], upper: &[u8]) -> Result<Box<dyn StoreCursor + 'a>>
+    where
+        's: 'a,
+    {
         match self.db_tx {
-            Some(ref db_tx) => Box::new(NewRocksDbSkipIterator {
-                inner: db_tx.iterator(rocksdb::IteratorMode::From(
-                    lower,
-                    rocksdb::Direction::Forward,
-                )),
+            Some(ref db_tx) => Ok(Box::new(NewRocksDbCursor {
+                inner: db_tx.iterator(rocksdb::IteratorMode::Start),
                 upper_bound: upper.to_vec(),
-                valid_at,
-                next_bound: lower.to_vec(),
-            }),
-            None => Box::new(std::iter::once(Err(miette!(
-                "Transaction already committed"
-            )))),
+                current: None,
+            })),
+            None => bail!("Transaction already committed"),
         }
     }
 
@@ -403,41 +395,43 @@ impl<'a> Iterator for NewRocksDbIterator<'a> {
     }
 }
 
-pub(crate) struct NewRocksDbSkipIterator<'a> {
+/// A positioned scan. Re-seeking is `set_mode`, and the iterator hands back both halves of an
+/// entry at once, so the value is already in hand by the time it is asked for.
+pub(crate) struct NewRocksDbCursor<'a> {
     inner: rocksdb::DBIteratorWithThreadMode<'a, rocksdb::Transaction<'a, OptimisticTransactionDB>>,
     upper_bound: Vec<u8>,
-    valid_at: ValidityTs,
-    next_bound: Vec<u8>,
+    current: Option<(Box<[u8]>, Box<[u8]>)>,
 }
 
-impl<'a> Iterator for NewRocksDbSkipIterator<'a> {
-    type Item = Result<Tuple>;
+impl StoreCursor for NewRocksDbCursor<'_> {
+    fn seek(&mut self, from: &[u8]) -> Result<bool> {
+        self.inner.set_mode(rocksdb::IteratorMode::From(
+            from,
+            rocksdb::Direction::Forward,
+        ));
+        self.current = match self.inner.next() {
+            None => None,
+            Some(Err(err)) => bail!("Iterator Error: {}", err),
+            Some(Ok((key, val))) if key.as_ref() < self.upper_bound.as_slice() => Some((key, val)),
+            Some(Ok(_)) => None,
+        };
+        Ok(self.current.is_some())
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
-        loop {
-            self.inner.set_mode(rocksdb::IteratorMode::From(
-                &self.next_bound,
-                rocksdb::Direction::Forward,
-            ));
-            match self.inner.next() {
-                None => return None,
-                Some(Ok((k_slice, v_slice))) => {
-                    if self.upper_bound.as_slice() <= k_slice.as_ref() {
-                        return None;
-                    }
+    fn key(&self) -> &[u8] {
+        &self
+            .current
+            .as_ref()
+            .expect("cursor key after a successful seek")
+            .0
+    }
 
-                    let (ret, nxt_bound) =
-                        check_key_for_validity(k_slice.as_ref(), self.valid_at, None);
-                    self.next_bound = nxt_bound;
-                    if let Some(mut tup) = ret {
-                        return Some(
-                            try_extend_tuple_from_v(&mut tup, v_slice.as_ref()).map(|()| tup),
-                        );
-                    }
-                }
-                Some(Err(e)) => return Some(Err(miette!("Iterator Error: {}", e))),
-            }
-        }
+    fn value(&mut self) -> Result<&[u8]> {
+        Ok(&self
+            .current
+            .as_ref()
+            .expect("cursor value after a successful seek")
+            .1)
     }
 }
 

--- a/cozo-core/src/storage/rocks.rs
+++ b/cozo-core/src/storage/rocks.rs
@@ -21,7 +21,7 @@ use crate::data::tuple::{check_key_for_validity, Tuple};
 use crate::data::value::ValidityTs;
 use crate::runtime::db::{BadDbInit, DbManifest};
 use crate::runtime::relation::{try_decode_tuple_from_kv, try_extend_tuple_from_v};
-use crate::storage::{Storage, StoreTx};
+use crate::storage::{Storage, StoreCursor, StoreTx};
 use crate::utils::swap_option_result;
 use crate::Db;
 
@@ -530,19 +530,14 @@ impl<'s> StoreTx<'s> for RocksDbTx {
         })
     }
 
-    fn range_skip_scan_tuple<'a>(
-        &'a self,
-        lower: &[u8],
-        upper: &[u8],
-        valid_at: ValidityTs,
-    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a> {
-        let inner = self.iter_builder().upper_bound(upper).start();
-        Box::new(RocksDbSkipIterator {
-            inner,
+    fn cursor<'a>(&'a self, _lower: &[u8], upper: &[u8]) -> Result<Box<dyn StoreCursor + 'a>>
+    where
+        's: 'a,
+    {
+        Ok(Box::new(RocksDbCursor {
+            inner: self.iter_builder().upper_bound(upper).start(),
             upper_bound: upper.to_vec(),
-            next_bound: lower.to_owned(),
-            valid_at,
-        })
+        }))
     }
 
     fn range_bitemporal_scan_tuple<'a>(
@@ -682,42 +677,34 @@ impl crate::data::bitemporal::SeekCursor for RocksSeekCursor {
     }
 }
 
-pub(crate) struct RocksDbSkipIterator {
+/// A positioned scan. The iterator's own upper bound stops it, and the explicit compare
+/// guards the case where the bound was not honoured.
+pub(crate) struct RocksDbCursor {
     inner: DbIter,
     upper_bound: Vec<u8>,
-    next_bound: Vec<u8>,
-    valid_at: ValidityTs,
 }
 
-impl RocksDbSkipIterator {
-    #[inline]
-    fn next_inner(&mut self) -> Result<Option<Tuple>> {
-        loop {
-            self.inner.seek(&self.next_bound);
-            match self.inner.pair()? {
-                None => return Ok(None),
-                Some((k_slice, v_slice)) => {
-                    if self.upper_bound.as_slice() <= k_slice {
-                        return Ok(None);
-                    }
-
-                    let (ret, nxt_bound) = check_key_for_validity(k_slice, self.valid_at, None);
-                    self.next_bound = nxt_bound;
-                    if let Some(mut tup) = ret {
-                        try_extend_tuple_from_v(&mut tup, v_slice)?;
-                        return Ok(Some(tup));
-                    }
-                }
-            }
+impl StoreCursor for RocksDbCursor {
+    fn seek(&mut self, from: &[u8]) -> Result<bool> {
+        self.inner.seek(from);
+        match self.inner.key()? {
+            None => Ok(false),
+            Some(key) => Ok(key < self.upper_bound.as_slice()),
         }
     }
-}
 
-impl Iterator for RocksDbSkipIterator {
-    type Item = Result<Tuple>;
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        swap_option_result(self.next_inner())
+    fn key(&self) -> &[u8] {
+        self.inner
+            .key()
+            .expect("cursor key after a successful seek")
+            .expect("cursor key after a successful seek")
+    }
+
+    fn value(&mut self) -> Result<&[u8]> {
+        Ok(self
+            .inner
+            .val()?
+            .expect("cursor value after a successful seek"))
     }
 }
 

--- a/cozo-core/src/storage/sled.rs
+++ b/cozo-core/src/storage/sled.rs
@@ -12,13 +12,13 @@ use std::iter::Fuse;
 use std::path::Path;
 
 use itertools::Itertools;
-use miette::{miette, IntoDiagnostic, Result};
+use miette::{bail, miette, IntoDiagnostic, Result};
 use sled::{Batch, Config, Db, IVec, Iter, Mode};
 
 use crate::data::tuple::Tuple;
 use crate::data::value::ValidityTs;
 use crate::runtime::relation::try_decode_tuple_from_kv;
-use crate::storage::{Storage, StoreTx};
+use crate::storage::{Storage, StoreCursor, StoreTx};
 use crate::utils::{swap_option_result, TempCollector};
 
 /// Creates a Sled database object. Experimental.
@@ -217,15 +217,11 @@ impl<'s> StoreTx<'s> for SledTx {
         }
     }
 
-    fn range_skip_scan_tuple<'a>(
-        &'a self,
-        _lower: &[u8],
-        _upper: &[u8],
-        _valid_at: ValidityTs,
-    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a> {
-        Box::new(iter::once(Err(miette!(
-            "Sled backend does not support time travelling."
-        ))))
+    fn cursor<'a>(&'a self, _lower: &[u8], _upper: &[u8]) -> Result<Box<dyn StoreCursor + 'a>>
+    where
+        's: 'a,
+    {
+        bail!("Sled backend does not support time travelling.")
     }
 
     fn range_scan<'a>(

--- a/cozo-core/src/storage/sqlite.rs
+++ b/cozo-core/src/storage/sqlite.rs
@@ -15,11 +15,10 @@ use either::{Either, Left, Right};
 use miette::{bail, miette, IntoDiagnostic, Result};
 use sqlite::{ConnectionThreadSafe, State, Statement};
 
-use crate::data::tuple::{check_key_for_validity, Tuple};
+use crate::data::tuple::Tuple;
 use crate::data::value::ValidityTs;
-use crate::runtime::relation::{try_decode_tuple_from_kv, try_extend_tuple_from_v};
-use crate::storage::{Storage, StoreTx};
-use crate::utils::swap_option_result;
+use crate::runtime::relation::try_decode_tuple_from_kv;
+use crate::storage::{Storage, StoreCursor, StoreTx};
 
 /// The Sqlite storage engine
 #[derive(Clone)]
@@ -34,11 +33,27 @@ pub struct SqliteStorage {
 ///
 /// You must provide a disk-based path: `:memory:` is not OK.
 /// If you want a pure memory storage, use [`new_cozo_mem`](crate::new_cozo_mem).
+/// How long a statement waits for a lock another connection holds before giving up.
+///
+/// Readers take no explicit transaction, so their locking is per-statement and a connection
+/// handed back to the pool can still be settling. Without a wait, a writer meeting that
+/// momentary overlap fails outright with "database is locked" instead of proceeding a
+/// millisecond later.
+const BUSY_TIMEOUT_MS: u32 = 3000;
+
+/// Open a connection to `path` and give it the shared busy timeout.
+fn open_connection(path: impl AsRef<Path>) -> Result<ConnectionThreadSafe> {
+    let conn = Connection::open_thread_safe(path).into_diagnostic()?;
+    conn.execute(format!("pragma busy_timeout = {BUSY_TIMEOUT_MS};"))
+        .into_diagnostic()?;
+    Ok(conn)
+}
+
 pub fn new_cozo_sqlite(path: impl AsRef<Path>) -> Result<crate::Db<SqliteStorage>> {
     if path.as_ref().to_str() == Some("") {
         bail!("empty path for sqlite storage")
     }
-    let conn = Connection::open_thread_safe(&path).into_diagnostic()?;
+    let conn = open_connection(&path)?;
     let query = r#"
         create table if not exists cozo
         (
@@ -65,7 +80,7 @@ impl<'s> Storage<'s> for SqliteStorage {
     fn transact(&'s self, write: bool) -> Result<Self::Tx> {
         let conn = {
             match self.pool.lock().unwrap_or_else(|e| e.into_inner()).pop() {
-                None => Connection::open_thread_safe(&self.name).into_diagnostic()?,
+                None => open_connection(&self.name)?,
                 Some(conn) => conn,
             }
         };
@@ -148,6 +163,13 @@ const COUNT_RANGE_QUERY: usize = 6;
 
 impl Drop for SqliteTx<'_> {
     fn drop(&mut self) {
+        // The cached statements borrow the connection through a transmuted lifetime, and any
+        // that stopped on a row is still holding a read lock. Finalize them first: the
+        // rollback below needs the connection quiet, and once it is in the pool another
+        // thread may take it while these would still have been alive.
+        for slot in self.stmts.iter() {
+            drop(slot.lock().unwrap_or_else(|e| e.into_inner()).take());
+        }
         if let Right(ShardedLockWriteGuard { .. }) = self.lock {
             if !self.committed {
                 let query = r#"rollback;"#;
@@ -286,20 +308,22 @@ impl<'s> StoreTx<'s> for SqliteTx<'s> {
         Box::new(TupleIter(statement))
     }
 
-    fn range_skip_scan_tuple<'a>(
-        &'a self,
-        lower: &[u8],
-        upper: &[u8],
-        valid_at: ValidityTs,
-    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a> {
-        let query = QUERIES[SKIP_RANGE_QUERY];
-        let statement = self.conn.as_ref().unwrap().prepare(query).unwrap();
-        Box::new(SkipIter {
-            stmt: statement,
-            valid_at,
-            next_bound: lower.to_vec(),
+    fn cursor<'a>(&'a self, _lower: &[u8], upper: &[u8]) -> Result<Box<dyn StoreCursor + 'a>>
+    where
+        's: 'a,
+    {
+        let stmt = self
+            .conn
+            .as_ref()
+            .unwrap()
+            .prepare(QUERIES[SKIP_RANGE_QUERY])
+            .into_diagnostic()?;
+        Ok(Box::new(SqliteCursor {
+            stmt,
             upper_bound: upper.to_vec(),
-        })
+            key: Vec::new(),
+            value: None,
+        }))
     }
 
     fn range_bitemporal_scan_tuple<'a>(
@@ -447,41 +471,40 @@ impl<'l> crate::data::bitemporal::SeekCursor for SqliteSeekCursor<'l> {
     }
 }
 
-struct SkipIter<'l> {
+/// A positioned scan. Each seek rebinds the range query; the value column is read only when
+/// asked for, because reading it copies the blob out of the row.
+struct SqliteCursor<'l> {
     stmt: Statement<'l>,
-    valid_at: ValidityTs,
-    next_bound: Vec<u8>,
     upper_bound: Vec<u8>,
+    key: Vec<u8>,
+    value: Option<Vec<u8>>,
 }
 
-impl<'l> SkipIter<'l> {
-    fn next_inner(&mut self) -> Result<Option<Tuple>> {
-        loop {
-            self.stmt.reset().into_diagnostic()?;
-            self.stmt.bind((1, &self.next_bound as &[u8])).unwrap();
-            self.stmt.bind((2, &self.upper_bound as &[u8])).unwrap();
-
-            match self.stmt.next().into_diagnostic()? {
-                State::Done => return Ok(None),
-                State::Row => {
-                    let k = self.stmt.read::<Vec<u8>, _>(0).unwrap();
-                    let (ret, nxt_bound) = check_key_for_validity(&k, self.valid_at, None);
-                    self.next_bound = nxt_bound;
-                    if let Some(mut tup) = ret {
-                        let v = self.stmt.read::<Vec<u8>, _>(1).unwrap();
-                        try_extend_tuple_from_v(&mut tup, &v)?;
-                        return Ok(Some(tup));
-                    }
-                }
+impl StoreCursor for SqliteCursor<'_> {
+    fn seek(&mut self, from: &[u8]) -> Result<bool> {
+        self.stmt.reset().into_diagnostic()?;
+        self.stmt.bind((1, from)).into_diagnostic()?;
+        self.stmt
+            .bind((2, &self.upper_bound as &[u8]))
+            .into_diagnostic()?;
+        match self.stmt.next().into_diagnostic()? {
+            State::Done => Ok(false),
+            State::Row => {
+                self.key = self.stmt.read::<Vec<u8>, _>(0).into_diagnostic()?;
+                self.value = None;
+                Ok(true)
             }
         }
     }
-}
 
-impl<'l> Iterator for SkipIter<'l> {
-    type Item = Result<Tuple>;
+    fn key(&self) -> &[u8] {
+        &self.key
+    }
 
-    fn next(&mut self) -> Option<Self::Item> {
-        swap_option_result(self.next_inner())
+    fn value(&mut self) -> Result<&[u8]> {
+        if self.value.is_none() {
+            self.value = Some(self.stmt.read::<Vec<u8>, _>(1).into_diagnostic()?);
+        }
+        Ok(self.value.as_deref().unwrap())
     }
 }

--- a/cozo-core/src/storage/temp.rs
+++ b/cozo-core/src/storage/temp.rs
@@ -12,10 +12,9 @@ use std::default::Default;
 use miette::Result;
 
 use crate::data::tuple::Tuple;
-use crate::data::value::ValidityTs;
 use crate::runtime::relation::try_decode_tuple_from_kv;
-use crate::storage::mem::SkipIterator;
-use crate::storage::{Storage, StoreTx};
+use crate::storage::mem::MemCursor;
+use crate::storage::{Storage, StoreCursor, StoreTx};
 
 #[derive(Default, Clone)]
 pub(crate) struct TempStorage;
@@ -95,19 +94,11 @@ impl<'s> StoreTx<'s> for TempTx {
         )
     }
 
-    fn range_skip_scan_tuple<'a>(
-        &'a self,
-        lower: &[u8],
-        upper: &[u8],
-        valid_at: ValidityTs,
-    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a> {
-        Box::new(SkipIterator {
-            inner: &self.store,
-            upper: upper.to_vec(),
-            valid_at,
-            next_bound: lower.to_vec(),
-            size_hint: None,
-        })
+    fn cursor<'a>(&'a self, _lower: &[u8], upper: &[u8]) -> Result<Box<dyn StoreCursor + 'a>>
+    where
+        's: 'a,
+    {
+        Ok(Box::new(MemCursor::over(&self.store, upper)))
     }
 
     fn range_scan<'a>(

--- a/cozo-core/src/storage/tikv.rs
+++ b/cozo-core/src/storage/tikv.rs
@@ -12,14 +12,14 @@ use std::sync::{Arc, Mutex};
 
 use itertools::Itertools;
 use lazy_static::lazy_static;
-use miette::{miette, IntoDiagnostic, Result};
+use miette::{bail, miette, IntoDiagnostic, Result};
 use tikv_client::{Transaction, TransactionClient};
 use tokio::runtime::Runtime;
 
 use crate::data::tuple::Tuple;
 use crate::data::value::ValidityTs;
 use crate::runtime::relation::try_decode_tuple_from_kv;
-use crate::storage::{Storage, StoreTx};
+use crate::storage::{Storage, StoreCursor, StoreTx};
 use crate::utils::{swap_option_result, TempCollector};
 use crate::Db;
 
@@ -188,15 +188,11 @@ impl<'s> StoreTx<'s> for TiKvTx {
         Box::new(BatchScanner::new(self.tx.clone(), lower, upper))
     }
 
-    fn range_skip_scan_tuple<'a>(
-        &'a self,
-        _lower: &[u8],
-        _upper: &[u8],
-        _valid_at: ValidityTs,
-    ) -> Box<dyn Iterator<Item = Result<Tuple>> + 'a> {
-        Box::new(iter::once(Err(miette!(
-            "TiKV backend does not support time travelling."
-        ))))
+    fn cursor<'a>(&'a self, _lower: &[u8], _upper: &[u8]) -> Result<Box<dyn StoreCursor + 'a>>
+    where
+        's: 'a,
+    {
+        bail!("TiKV backend does not support time travelling.")
     }
 
     fn range_scan<'a>(


### PR DESCRIPTION
With CozoDB being abandoned for almost 2 years now, I had started working on a fork for this specific functionality.

I wanted a layered storage model to be able to add a dimension to the concept of the time machine. Instead of just going forwards and backwards, I am building a system that I need to be able to fork, drop, merge, etc. Effectively to git-ify the graph and vector DB (without full support for doing so in the DDL besides what comes for free otherwise).

I built that out and pull requested it into my own Repo at https://github.com/shuruheel/mnestic/pull/1. But not before I first accidentally opened a [PR against the official repo](https://github.com/cozodb/cozo/pull/314). But in doing so I got the very helpful comment from @shuruheel about mnestic.

There's a lot of really great work that's happened in this fork. So I am opening this to see how you feel about this as a feature in this fork.

Ultimately it's driven by the same engine as the new rocksdb storage but it surfaces Column Families in a "layers" abstraction. And through the layers reads can fall through the current layer down into underlying layers (while writes only go to the "current" layer.

I also fundamentally changed the HNSW walk. The existing implementation leaned way too heavily on `ef` for everything, including filtering and tombstone skips. That's not the purpose of `ef` and is just a bad design for an API. While walking in a KNN search it's possible that a cousin node will have a closer record than the nearest Kth match among siblings. `ef` constrains how much it traverses back up the tree and continues the walk through nearby neighbor non-leafs, searching for closer matches. It sucks as a non-deterministic finger cross guard to make sure you collect enough that your filters don't eliminate all your `ef` matches so you end up with a false empty set for k. So now, the walk applies filters and the validity check during the walk, using `ef` to just terminate the outward search.

The effect of that change could have performance implications but only ever where `ef` is being tuned unnecessarily high to hack around the poor design or where it was returning incorrect results in exchange for performance.

So the change is given an otherwise identical query:
| ef | before | after |
|---|---|---|
| 3 | [] | [20, 22, 24] |
| 5 | [] | [20, 22, 24] |
| 50 | [20, 22, 24]  | [20, 22, 24] |